### PR TITLE
refactor: update package scope from @ai-toolkit to @uniswap across co…

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,10 +5,10 @@
       "type": "nx",
       "project": "",
       "command": "run",
-      "positional": "@ai-toolkit/ai-toolkit-nx-claude:build",
+      "positional": "@uniswap/ai-toolkit-nx-claude:build",
       "flags": [],
       "problemMatcher": [],
-      "label": "nx: nx run @ai-toolkit/ai-toolkit-nx-claude:build"
+      "label": "nx: nx run @uniswap/ai-toolkit-nx-claude:build"
     },
     {
       "type": "nx",

--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ bun run install-all
 
 ```bash
 # Install just the notification hooks
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:hooks
+bunx nx generate @uniswap/ai-toolkit-nx-claude:hooks
 
 # Or preview what would be installed (dry-run mode)
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:init --dry-run
+bunx nx generate @uniswap/ai-toolkit-nx-claude:init --dry-run
 ```
 
 ### Verify Installation

--- a/package.json
+++ b/package.json
@@ -3,14 +3,14 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "install-all": "nx generate @ai-toolkit/ai-toolkit-nx-claude:init && nx generate @ai-toolkit/ai-toolkit-nx-claude:hooks",
+    "install-all": "nx generate @uniswap/ai-toolkit-nx-claude:init && nx generate @uniswap/ai-toolkit-nx-claude:hooks",
     "build": "nx run-many --target=build --all",
     "lint": "nx run-many --target=lint --all",
     "format": "nx format:write",
     "format:check": "nx format:check",
     "prepare": "lefthook install",
     "lefthook": "lefthook run pre-commit",
-    "claude:init": "nx generate @ai-toolkit/ai-toolkit-nx-claude:init"
+    "claude:init": "nx generate @uniswap/ai-toolkit-nx-claude:init"
   },
   "private": true,
   "dependencies": {

--- a/packages/ai-toolkit-nx-claude/CLAUDE.md
+++ b/packages/ai-toolkit-nx-claude/CLAUDE.md
@@ -1,8 +1,8 @@
-# CLAUDE.md - @ai-toolkit/ai-toolkit-nx-claude Package
+# CLAUDE.md - @uniswap/ai-toolkit-nx-claude Package
 
 ## Overview
 
-The `@ai-toolkit/ai-toolkit-nx-claude` package (published as `@uniswap/ai-toolkit-nx-claude` to GitHub Packages) provides Nx generators for setting up and managing Claude Code configurations, commands, agents, and notification hooks. This package is the primary tooling interface for the AI Toolkit, offering both one-shot installers and incremental configuration management.
+The `@uniswap/ai-toolkit-nx-claude` package (published as `@uniswap/ai-toolkit-nx-claude` to GitHub Packages) provides Nx generators for setting up and managing Claude Code configurations, commands, agents, and notification hooks. This package is the primary tooling interface for the AI Toolkit, offering both one-shot installers and incremental configuration management.
 
 ### Standalone Package Usage
 
@@ -44,7 +44,7 @@ packages/ai-toolkit-nx-claude/
 **Usage**:
 
 ```bash
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:init
+bunx nx generate @uniswap/ai-toolkit-nx-claude:init
 ```
 
 **Key Features**:
@@ -69,7 +69,7 @@ bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:init
 **Usage**:
 
 ```bash
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:hooks
+bunx nx generate @uniswap/ai-toolkit-nx-claude:hooks
 ```
 
 **Key Features**:
@@ -89,7 +89,7 @@ bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:hooks
 **Usage**:
 
 ```bash
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:setup-registry-proxy
+bunx nx generate @uniswap/ai-toolkit-nx-claude:setup-registry-proxy
 ```
 
 **Key Features**:
@@ -110,7 +110,7 @@ bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:setup-registry-proxy
 **Usage**:
 
 ```bash
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:add-command
+bunx nx generate @uniswap/ai-toolkit-nx-claude:add-command
 ```
 
 **Status**: Placeholder implementation - needs completion
@@ -122,7 +122,7 @@ bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:add-command
 **Usage**:
 
 ```bash
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:add-agent
+bunx nx generate @uniswap/ai-toolkit-nx-claude:add-agent
 ```
 
 **Status**: Placeholder implementation - needs completion
@@ -339,8 +339,8 @@ bunx nx build ai-toolkit-nx-claude
 bunx nx test ai-toolkit-nx-claude
 
 # Test generators locally
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:init --dry
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:hooks --dry
+bunx nx generate @uniswap/ai-toolkit-nx-claude:init --dry
+bunx nx generate @uniswap/ai-toolkit-nx-claude:hooks --dry
 ```
 
 ### Nx Workspace Integration

--- a/packages/ai-toolkit-nx-claude/src/generators/add-agent/generator.ts
+++ b/packages/ai-toolkit-nx-claude/src/generators/add-agent/generator.ts
@@ -139,7 +139,7 @@ This package contains agent configurations specific to ${targetPackage}.
 Install this package to access ${targetPackage}-specific agents in Claude Code:
 
 \`\`\`bash
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:init
+bunx nx generate @uniswap/ai-toolkit-nx-claude:init
 \`\`\`
 
 Then select the agents from this package during the installation process.
@@ -155,7 +155,7 @@ Then select the agents from this package during the installation process.
 To add new agents to this package:
 
 \`\`\`bash
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:add-agent
+bunx nx generate @uniswap/ai-toolkit-nx-claude:add-agent
 \`\`\`
 
 After adding or modifying agents, regenerate the index:

--- a/packages/ai-toolkit-nx-claude/src/generators/add-command/generator.ts
+++ b/packages/ai-toolkit-nx-claude/src/generators/add-command/generator.ts
@@ -141,7 +141,7 @@ This package contains command configurations specific to ${targetPackage}.
 Install this package to access ${targetPackage}-specific commands in Claude Code:
 
 \`\`\`bash
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:init
+bunx nx generate @uniswap/ai-toolkit-nx-claude:init
 \`\`\`
 
 Then select the commands from this package during the installation process.
@@ -157,7 +157,7 @@ Then select the commands from this package during the installation process.
 To add new commands to this package:
 
 \`\`\`bash
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:add-command
+bunx nx generate @uniswap/ai-toolkit-nx-claude:add-command
 \`\`\`
 
 After adding or modifying commands, regenerate the index:

--- a/packages/ai-toolkit-nx-claude/src/generators/hooks/CLAUDE.md
+++ b/packages/ai-toolkit-nx-claude/src/generators/hooks/CLAUDE.md
@@ -254,7 +254,7 @@ To extend the generator:
 Use verbose mode to debug issues:
 
 ```bash
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:hooks --verbose
+bunx nx generate @uniswap/ai-toolkit-nx-claude:hooks --verbose
 ```
 
 This preserves the cloned repository and shows detailed output.
@@ -294,7 +294,7 @@ bunx nx build nx-claude
 bunx nx test nx-claude
 
 # Test locally
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:hooks --dry-run
+bunx nx generate @uniswap/ai-toolkit-nx-claude:hooks --dry-run
 ```
 
 ## Future Enhancements

--- a/packages/ai-toolkit-nx-claude/src/generators/hooks/README.md
+++ b/packages/ai-toolkit-nx-claude/src/generators/hooks/README.md
@@ -26,10 +26,10 @@ The generator will check for these dependencies and warn if missing:
 
 ```bash
 # From any directory (installs globally to ~/.claude/hooks/)
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:hooks
+bunx nx generate @uniswap/ai-toolkit-nx-claude:hooks
 
 # Or with npm
-npm run nx generate @ai-toolkit/ai-toolkit-nx-claude:hooks
+npm run nx generate @uniswap/ai-toolkit-nx-claude:hooks
 ```
 
 ### Interactive Mode (Default)
@@ -44,22 +44,22 @@ When run without options, the generator will interactively prompt for:
 
 ```bash
 # Install with all defaults (using Nx's built-in flag)
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:hooks --no-interactive
+bunx nx generate @uniswap/ai-toolkit-nx-claude:hooks --no-interactive
 
 # Dry run to preview changes
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:hooks --dry
+bunx nx generate @uniswap/ai-toolkit-nx-claude:hooks --dry
 
 # Also works with --dry-run alias for Nx compatibility
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:hooks --dry-run
+bunx nx generate @uniswap/ai-toolkit-nx-claude:hooks --dry-run
 
 # Skip backup during installation
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:hooks --backup=false --no-interactive
+bunx nx generate @uniswap/ai-toolkit-nx-claude:hooks --backup=false --no-interactive
 
 # Force installation (skip dependency checks)
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:hooks --force
+bunx nx generate @uniswap/ai-toolkit-nx-claude:hooks --force
 
 # Verbose output for debugging
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:hooks --verbose
+bunx nx generate @uniswap/ai-toolkit-nx-claude:hooks --verbose
 ```
 
 ## Generator Options
@@ -112,7 +112,7 @@ After installation, you can test the hooks:
 
 ```bash
 # Run with verbose flag to get testing option
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:hooks --verbose
+bunx nx generate @uniswap/ai-toolkit-nx-claude:hooks --verbose
 
 # When prompted, choose to test the hooks
 # You should hear a notification sound

--- a/packages/ai-toolkit-nx-claude/src/generators/init/CLAUDE.md
+++ b/packages/ai-toolkit-nx-claude/src/generators/init/CLAUDE.md
@@ -85,7 +85,7 @@ The generator pulls content from:
 When run without options, the generator will interactively prompt for all configuration choices:
 
 ```bash
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:init
+bunx nx generate @uniswap/ai-toolkit-nx-claude:init
 ```
 
 The interactive flow will:
@@ -103,20 +103,20 @@ The interactive flow will:
 ### Non-Interactive Global Installation
 
 ```bash
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:init --no-interactive --installation-type=global --commands=review-pr,gen-tests,plan-feature --agents=test-writer,doc-writer,planner
+bunx nx generate @uniswap/ai-toolkit-nx-claude:init --no-interactive --installation-type=global --commands=review-pr,gen-tests,plan-feature --agents=test-writer,doc-writer,planner
 ```
 
 ### Non-Interactive Local Installation
 
 ```bash
 # Must be run from project root
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:init --no-interactive --installation-type=local --confirm-local-path=true --commands=review-pr,gen-tests,plan-feature --agents=test-writer,doc-writer,planner
+bunx nx generate @uniswap/ai-toolkit-nx-claude:init --no-interactive --installation-type=local --confirm-local-path=true --commands=review-pr,gen-tests,plan-feature --agents=test-writer,doc-writer,planner
 ```
 
 ### Dry Run to Preview
 
 ```bash
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:init --dry
+bunx nx generate @uniswap/ai-toolkit-nx-claude:init --dry
 ```
 
 In dry-run mode, if Claude CLI is not installed, the generator will show:
@@ -128,7 +128,7 @@ In dry-run mode, if Claude CLI is not installed, the generator will show:
 ### Selective Installation
 
 ```bash
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:init --installation-type=global --commands=review-pr,gen-tests --agents=test-writer,doc-writer
+bunx nx generate @uniswap/ai-toolkit-nx-claude:init --installation-type=global --commands=review-pr,gen-tests --agents=test-writer,doc-writer
 ```
 
 ## File Structure Created
@@ -260,13 +260,13 @@ To add new commands or agents:
 bunx nx build nx-claude
 
 # Test global installation with dry-run
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:init --dry --installation-type=global
+bunx nx generate @uniswap/ai-toolkit-nx-claude:init --dry --installation-type=global
 
 # Test local installation (must be at project root)
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:init --installation-type=local --confirm-local-path=true
+bunx nx generate @uniswap/ai-toolkit-nx-claude:init --installation-type=local --confirm-local-path=true
 
 # Test interactive mode
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:init
+bunx nx generate @uniswap/ai-toolkit-nx-claude:init
 
 # Verify global installation
 ls -la ~/.claude/

--- a/packages/ai-toolkit-nx-claude/src/generators/setup-registry-proxy/README.md
+++ b/packages/ai-toolkit-nx-claude/src/generators/setup-registry-proxy/README.md
@@ -23,10 +23,10 @@ This proxy solves the problem by intercepting npm/npx/yarn/bun commands and addi
 
 ```bash
 # Run the generator
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:setup-registry-proxy
+bunx nx generate @uniswap/ai-toolkit-nx-claude:setup-registry-proxy
 
 # Or with options
-bunx nx generate @ai-toolkit/ai-toolkit-nx-claude:setup-registry-proxy --force --test
+bunx nx generate @uniswap/ai-toolkit-nx-claude:setup-registry-proxy --force --test
 ```
 
 ## Options


### PR DESCRIPTION
…debase

This commit corrects package scope references throughout the monorepo so that users call the correct commands. Prior to this commit, the instructions for which bunx nx command were wrong

Example:
bunx nx @ai-toolkit/ai-toolkit-nx-claude:build -> bunx nx @uniswap/ai-toolkit-nx-claude:build

🤖 Generated with [Claude Code](https://claude.ai/code)