### PR TITLE
add top-level start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,8 @@ bun install # or npm install if you're not using bun
 ### Option A: Install Everything (Recommended)
 
 ```bash
-# One-shot installer - installs Claude Code at ~/.claude and sets up all agents + commands
-bun run install-all
-
-# Install Claude code hooks, which are custom scripts that hook into Claude Code's lifecycle (such as emitting sound notifications when Claude Code needs your input)
+# Run the CLI to show you everything you can install. Start with the 'init' and then 'hooks' to get started
+bun run start
 ```
 
 ### Option B: Selective Installation

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "install-all": "nx generate @uniswap/ai-toolkit-nx-claude:init && nx generate @uniswap/ai-toolkit-nx-claude:hooks",
+    "start": "nx run @uniswap/ai-toolkit-nx-claude:nx-claude:exec",
     "build": "nx run-many --target=build --all",
     "lint": "nx run-many --target=lint --all",
     "format": "nx format:write",

--- a/packages/ai-toolkit-nx-claude/package.json
+++ b/packages/ai-toolkit-nx-claude/package.json
@@ -137,7 +137,7 @@
       "nx-claude:exec": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "node packages/ai-toolkit-nx-claude/dist/cli-generator.js"
+          "command": "node packages/ai-toolkit-nx-claude/dist/cli-generator.cjs"
         },
         "dependsOn": [
           "build"


### PR DESCRIPTION
'bun run start' or 'npm start' will now execute the same code path as someone running

npx --@uniswap:registry=https://npm.pkg.github.com @uniswap/ai-toolkit-nx-claude@latest