### PR TITLE
add production environment to publish github action

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -19,7 +19,10 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-24.04
+    environment:
+      name: production
     permissions:
+      id-token: write
       contents: write
       packages: write
       pull-requests: write


### PR DESCRIPTION
we need this so that #team-security can add the necessary env tokens to allow publishing to npm