### PR TITLE
ci: prevent workflow loops by skipping commits from service account

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -26,6 +26,8 @@ jobs:
       packages: write
       pull-requests: write
       issues: write
+    # Skip the workflow if the commit was made by the service account to prevent loops
+    if: github.actor != 'hello-happy-puppy'
 
     steps:
       - name: Load Secrets


### PR DESCRIPTION
- Added a condition to skip the GitHub Actions workflow if the commit is made by the service account 'hello-happy-puppy' to avoid infinite loops during package publishing.