### PR TITLE
move npmrc auth entirely to CI for npm publishing

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -50,11 +50,21 @@ jobs:
           node-version: '22.13.1'
           registry-url: 'https://registry.npmjs.org'
           scope: '@uniswap'
+          always-auth: true
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
         with:
           bun-version: 1.2.21
+
+      - name: Configure npm authentication
+        run: |
+          echo "@uniswap:registry=https://registry.npmjs.org" >> .npmrc
+          echo "registry=https://registry.npmjs.org/" >> .npmrc
+          echo "always-auth=true" >> .npmrc
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
+        env:
+          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
 
       - name: Install dependencies
         run: bun install

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,0 @@
-@uniswap:registry=https://registry.npmjs.org
-registry=https://registry.npmjs.org/
-always-auth=true
-//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}


### PR DESCRIPTION
Prior to this commit, the ai-toolkit's package-specific .npmrc file would override the global ~/.npmrc file and cause authentication errors in software that relied on the global npmrc auth (such as ai-toolkit itself, as well as spec-workflow-mcp). Now, we delete the package-specific .npmrc file so there is no conflict. The package-specific .npmrc file is created ephemerally in every publish CI run, and that is th eonly place its needed