### PR TITLE
chore: update AI model references to sonnet-4.5

### DIFF
--- a/packages/agents/agnostic/README.md
+++ b/packages/agents/agnostic/README.md
@@ -9,24 +9,28 @@ This package contains 30+ specialized agents that work together to handle comple
 ## Key Agents
 
 ### Documentation & Context Management
+
 - **claude-docs-initializer**: Initialize comprehensive CLAUDE.md documentation across repositories
 - **claude-docs-manager**: Update CLAUDE.md files based on code changes
 - **context-loader**: Advanced context management and cross-agent sharing
 - **doc-writer**: Generate API docs, READMEs, and architecture documentation
 
 ### Development & Quality
+
 - **code-generator**: Create production-ready code with tests
 - **debug-assistant**: Root cause analysis and fix validation
 - **refactorer**: Architectural refactoring with safe strategies
 - **test-writer**: Comprehensive test generation with edge cases
 
 ### Analysis & Review
+
 - **code-explainer**: Deep code analysis and pattern recognition
 - **security-analyzer**: Vulnerability assessment and threat modeling
 - **performance-analyzer**: Bottleneck identification and optimization
 - **style-enforcer**: Multi-language style enforcement
 
 ### Orchestration & Meta-Learning
+
 - **agent-orchestrator**: Coordinate multiple agents for complex tasks
 - **agent-optimizer**: Continuously improve agent performance
 - **pattern-learner**: Extract and apply reusable patterns
@@ -43,8 +47,9 @@ Agents are invoked by commands, not directly by users. They inherit tool permiss
 ## Development
 
 To add a new agent:
+
 1. Run `bun start` and choose `add-agent`, then follow the steps to create a template prompt file for your new agent
-2. Choose the sonnet model if you expect a large amount of source code output from the tool, and choose opus (the more powerful & expensive model) if your agent will have complex reasoning tasks
+2. As of October 2025, we recmmend to choose sonnet 4.5, as it's the best and cheapest Anthropic model available
 3. Look at the other markdown agent files for inspiration and fill in the TODOs in the generated template file
 
 ## License

--- a/packages/agents/agnostic/src/commit-message-generator.md
+++ b/packages/agents/agnostic/src/commit-message-generator.md
@@ -1,7 +1,7 @@
 ---
 name: commit-message-generator
 description: Generate well-structured git commit messages that clearly communicate the WHAT and WHY of code changes. Your messages should help future developers (including the author) understand the purpose and context of the commit.
-model: sonnet-4
+model: sonnet-4.5
 ---
 
 # commit-message-generator Agent

--- a/packages/agents/agnostic/src/pr-creator.md
+++ b/packages/agents/agnostic/src/pr-creator.md
@@ -1,7 +1,7 @@
 ---
 name: pr-creator
 description: Creates or updates Graphite PRs with auto-generated conventional commit messages and comprehensive PR descriptions based on diffs
-model: sonnet-4
+model: sonnet-4.5
 ---
 
 You are a Graphite PR management specialist who creates and updates pull requests with well-crafted conventional commit messages and informative PR descriptions.

--- a/packages/ai-toolkit-nx-claude/src/generators/add-agent/schema.d.ts
+++ b/packages/ai-toolkit-nx-claude/src/generators/add-agent/schema.d.ts
@@ -5,5 +5,5 @@ export interface AddAgentGeneratorSchema {
   newPackageDescription?: string;
   name: string;
   description?: string;
-  model?: 'sonnet-4' | 'opus-4.1';
+  model?: 'sonnet-4.5' | 'opus-4.1';
 }

--- a/packages/ai-toolkit-nx-claude/src/generators/add-agent/schema.json
+++ b/packages/ai-toolkit-nx-claude/src/generators/add-agent/schema.json
@@ -48,7 +48,7 @@
     "model": {
       "type": "string",
       "description": "The AI model to use for this agent",
-      "enum": ["sonnet-4", "opus-4.1"],
+      "enum": ["sonnet-4.5", "opus-4.1"],
       "x-prompt": {
         "message": "🧠 Which AI model should this agent use?",
         "type": "list"


### PR DESCRIPTION
- Updated README.md to recommend sonnet-4.5 as the preferred model for new agents.
- Changed model references in commit-message-generator.md and pr-creator.md to sonnet-4.5.
- Modified schema.d.ts and schema.json to include sonnet-4.5 as an option for agent models.