### PR TITLE
chore: add ignoreCommand to vercel.json for slack-oauth-backend to optimize deployment process

### DIFF
--- a/apps/slack-oauth-backend/vercel.json
+++ b/apps/slack-oauth-backend/vercel.json
@@ -3,6 +3,7 @@
   "outputDirectory": "dist",
   "installCommand": "bun install",
   "framework": null,
+  "ignoreCommand": "bunx nx show projects --affected --base=$VERCEL_GIT_PREVIOUS_SHA --head=$VERCEL_GIT_COMMIT_SHA | grep -q '^slack-oauth-backend$'",
   "functions": {
     "api/index.js": {
       "maxDuration": 10


### PR DESCRIPTION
### TL;DR

Added an ignore command to the Vercel configuration for the Slack OAuth backend to skip deployments when the project is not affected.

### What changed?

Added an `ignoreCommand` to the `vercel.json` file that uses the Nx affected projects detection to determine if the `slack-oauth-backend` project was modified between the previous and current commit. If the project wasn't affected, the deployment will be skipped.

### How to test?

1. Make a change to a different project in the monorepo
2. Verify that the Slack OAuth backend doesn't deploy on Vercel
3. Make a change to the Slack OAuth backend
4. Verify that the deployment proceeds as expected

### Why make this change?

This optimization prevents unnecessary deployments of the Slack OAuth backend when changes are made to unrelated parts of the codebase. This will save deployment resources and time by only triggering deployments when the project is actually affected by changes.