### PR TITLE
fix(ci): remove NPM authentication references from configuration files

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -87,7 +87,6 @@ jobs:
           npx nx release publish --dry-run --tag=${{ steps.npm-tag.outputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
 
       - name: Version affected packages
         if: github.event.inputs.dryRun != 'true' && github.event_name == 'push'
@@ -152,8 +151,6 @@ jobs:
             echo "Found existing tags - publishing without --first-release flag"
             npx nx release publish --tag=${{ steps.npm-tag.outputs.tag }} --registry=https://registry.npmjs.org
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
 
       - name: Push version commits and tags
         if: github.event.inputs.dryRun != 'true' && github.event_name == 'push'

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,2 @@
 @uniswap:registry=https://registry.npmjs.org
 registry=https://registry.npmjs.org/
-always-auth=true
-//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}

--- a/docs/readmes/DEVELOPMENT.md
+++ b/docs/readmes/DEVELOPMENT.md
@@ -238,7 +238,6 @@ graph LR
 ```bash
 # Required for reading from npmjs
 GITHUB_TOKEN        # GitHub authentication
-NODE_AUTH_TOKEN     # NPM authentication for private NPMJS registry
 
 # Optional for configuration
 NX_CLOUD_AUTH_TOKEN # Nx Cloud distributed caching


### PR DESCRIPTION
### Summary of Changes
- Deleted `always-auth` and `_authToken` entries from `.npmrc`.
- Removed `NODE_AUTH_TOKEN` references from the GitHub Actions workflow and documentation.

### Why This Change?
These modifications streamline the configuration by eliminating unnecessary authentication steps, enhancing clarity and security in the publishing process.