### PR TITLE
fix(addons): fix configs for remaining mcp installation issues

### DIFF
--- a/packages/ai-toolkit-nx-claude/src/generators/addons/addon-registry.ts
+++ b/packages/ai-toolkit-nx-claude/src/generators/addons/addon-registry.ts
@@ -193,8 +193,8 @@ const ADDON_REGISTRY: AddonMetadata[] = [
     packageName: 'figma',
     mcp: {
       serverName: 'figma',
-      command: 'sse',
-      args: ['http://127.0.0.1:3845/mcp'],
+      transport: 'sse',
+      url: 'http://127.0.0.1:3845/mcp',
     },
   },
   {
@@ -218,8 +218,8 @@ const ADDON_REGISTRY: AddonMetadata[] = [
     packageName: 'vercel',
     mcp: {
       serverName: 'vercel',
-      command: 'http',
-      args: ['https://mcp.vercel.com'],
+      transport: 'http',
+      url: 'https://mcp.vercel.com',
     },
   },
 ];


### PR DESCRIPTION
### TL;DR

Updated MCP configuration for Figma and Vercel addons to use the new transport/url pattern.

### What changed?

Modified the addon registry configuration for Figma and Vercel addons:
- Renamed `command` to `transport` in both addon configurations
- Renamed `args` array to `url` string property
- Preserved the actual transport types and URLs

### How to test?

1. Verify that the Figma addon connects properly using SSE transport to `http://127.0.0.1:3845/mcp`
2. Verify that the Vercel addon connects properly using HTTP transport to `https://mcp.vercel.com`

### Why make this change?

This change standardizes the MCP configuration pattern by using more descriptive property names (`transport` instead of `command`, `url` instead of an array of arguments). This improves code readability and makes the configuration more intuitive while maintaining the same functionality.