### PR TITLE
feat(generators): implement installMode pattern to enhance prompting behavior

### DIFF
--- a/packages/ai-toolkit-nx-claude/src/cli-generator.ts
+++ b/packages/ai-toolkit-nx-claude/src/cli-generator.ts
@@ -5,8 +5,8 @@
  *
  * External Usage (npx @uniswap/ai-toolkit-nx-claude@latest):
  * - No arguments -> runs init generator (prompts for installMode)
- * - default-install -> runs init with --install-mode=default
- * - custom-install -> runs init with --install-mode=custom
+ * - default -> runs init with --install-mode=default
+ * - custom -> runs init with --install-mode=custom
  *
  * Internal Usage (from within ai-toolkit repo):
  * - No arguments -> shows interactive menu of all generators
@@ -41,8 +41,8 @@ function isInAiToolkitRepo(): boolean {
 
 // Available generators (only show user-facing ones in interactive mode)
 const GENERATORS = {
-  'default-install': 'Recommended setup with pre-selected components',
-  'custom-install': 'Choose exactly what to install',
+  default: 'Recommended setup with pre-selected components',
+  custom: 'Choose exactly what to install',
 };
 
 // All generators including internal ones (for validation)
@@ -120,8 +120,8 @@ async function main() {
     console.log('\nUsage:');
     console.log('  npx @uniswap/ai-toolkit-nx-claude@latest [generator]');
     console.log('\nExamples:');
-    console.log('  npx @uniswap/ai-toolkit-nx-claude@latest default-install');
-    console.log('  npx @uniswap/ai-toolkit-nx-claude@latest custom-install');
+    console.log('  npx @uniswap/ai-toolkit-nx-claude@latest default');
+    console.log('  npx @uniswap/ai-toolkit-nx-claude@latest custom');
     process.exit(0);
   }
 
@@ -171,13 +171,13 @@ async function main() {
     process.exit(1);
   }
 
-  // Route default-install and custom-install to init generator with appropriate mode
-  if (generatorName === 'default-install') {
+  // Route default and custom to init generator with appropriate mode
+  if (generatorName === 'default') {
     await handleNxExecution('init', [
       ...processedArgs,
       '--install-mode=default',
     ]);
-  } else if (generatorName === 'custom-install') {
+  } else if (generatorName === 'custom') {
     await handleNxExecution('init', [
       ...processedArgs,
       '--install-mode=custom',

--- a/packages/ai-toolkit-nx-claude/src/generators/hooks/CLAUDE.md
+++ b/packages/ai-toolkit-nx-claude/src/generators/hooks/CLAUDE.md
@@ -145,8 +145,37 @@ interface HooksGeneratorSchema {
   'dry-run'?: boolean; // Preview without changes
   force?: boolean; // Skip dependency checks
   verbose?: boolean; // Detailed output
+  installMode?: 'default' | 'custom'; // Installation mode from parent generator (hidden)
 }
 ```
+
+### installMode Parameter
+
+The `installMode` parameter is a **hidden** parameter designed for programmatic use only. It's passed from parent generators (like `init`) to control the prompting behavior:
+
+- **`'default'`**: Skips all interactive prompts and uses default values for all options. This provides a streamlined, non-interactive installation experience.
+- **`'custom'`**: (or undefined): Enables full interactive prompting, allowing users to configure all options through CLI prompts.
+
+**Usage Pattern**:
+
+```typescript
+// Called programmatically from init generator in default mode
+await hooksGenerator(tree, {
+  installMode: 'default', // Skips all prompts
+  force: false,
+  dry: false,
+  backup: true,
+  verbose: false,
+});
+
+// Called programmatically from init generator in custom mode (or standalone)
+await hooksGenerator(tree, {
+  // installMode omitted or 'custom' - enables prompts
+  force: false,
+});
+```
+
+**Implementation**: When `installMode === 'default'`, the generator bypasses the entire `promptForMissingOptions()` flow and constructs the normalized options directly using default values.
 
 ### Input Handling
 
@@ -237,6 +266,29 @@ Manual testing checklist:
 7. Custom repository usage
 
 ## Development Notes
+
+### Programmatic Usage Pattern
+
+This generator implements the **installMode pattern** for sub-generators:
+
+**Purpose**: Prevent duplicate prompting when generators are called programmatically from parent generators.
+
+**Implementation**:
+
+1. Add `installMode?: 'default' | 'custom'` to schema with `hidden: true`
+2. Add `installMode?: 'default' | 'custom'` to TypeScript interface
+3. In generator.ts, check `if (options.installMode === 'default')` before prompting
+4. When 'default', construct normalized options with defaults instead of prompting
+5. When undefined or 'custom', proceed with normal prompting flow
+
+**Why This Works**:
+
+- Hidden schema properties don't show up in CLI help or prompts
+- Parent generators can pass the mode to control child behavior
+- Avoids issues with `getExplicitlyProvidedOptions()` reading `process.argv`
+- Each generator maintains backward compatibility (works standalone or programmatically)
+
+**Pattern Applied**: This pattern is used across all sub-generators that are called from the `init` generator (hooks, addons, etc.).
 
 ### Adding New Features
 

--- a/packages/ai-toolkit-nx-claude/src/generators/hooks/schema.d.ts
+++ b/packages/ai-toolkit-nx-claude/src/generators/hooks/schema.d.ts
@@ -26,4 +26,12 @@ export interface HooksGeneratorSchema {
    * @default false
    */
   verbose?: boolean;
+
+  /**
+   * Installation mode from parent generator (default or custom).
+   * When set to 'default', skips all prompts and uses defaults.
+   * This is passed programmatically from the init generator.
+   * @hidden
+   */
+  installMode?: 'default' | 'custom';
 }

--- a/packages/ai-toolkit-nx-claude/src/generators/hooks/schema.json
+++ b/packages/ai-toolkit-nx-claude/src/generators/hooks/schema.json
@@ -32,6 +32,12 @@
       "type": "boolean",
       "description": "Skip confirmation prompts and overwrite existing configuration",
       "default": false
+    },
+    "installMode": {
+      "type": "string",
+      "description": "Installation mode from parent generator (default or custom). When set to 'default', skips all prompts and uses defaults.",
+      "enum": ["default", "custom"],
+      "hidden": true
     }
   },
   "required": []

--- a/packages/ai-toolkit-nx-claude/src/generators/init/generator.ts
+++ b/packages/ai-toolkit-nx-claude/src/generators/init/generator.ts
@@ -536,6 +536,7 @@ export async function initGenerator(tree: Tree, options: InitGeneratorSchema) {
           dry: false,
           backup: true,
           verbose: false,
+          installMode: normalizedOptions.installMode,
         });
         logger.info('✅ Notification hooks installed successfully');
       } catch (error: any) {
@@ -588,7 +589,8 @@ export async function initGenerator(tree: Tree, options: InitGeneratorSchema) {
                 port: 0, // Use default port
               }
             : {
-                // Custom mode - let addons generator prompt user
+                // Custom mode - let addons generator prompt user for specific addon
+                installMode: 'specific' as const,
                 force: normalizedOptions.force || false,
               }
         );


### PR DESCRIPTION
- Introduced the installMode parameter to prevent duplicate prompts when child generators are called programmatically from parent generators.
- Updated schema.json and TypeScript interfaces to include the hidden installMode property.
- Modified generator logic to skip prompts and use default values when installMode is set to 'default'.
- Enhanced documentation to clarify the usage and benefits of the installMode pattern across generators.