### PR TITLE
chore(workflow): refactor Slack notification process and streamline changelog generation

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -1,0 +1,213 @@
+name: Notify Release
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: 'Branch name that was released'
+        required: true
+        type: string
+      npm_tag:
+        description: 'NPM tag used for publishing (next or latest)'
+        required: true
+        type: string
+      before_sha:
+        description: 'Commit SHA before the push'
+        required: true
+        type: string
+      after_sha:
+        description: 'Commit SHA after the push'
+        required: true
+        type: string
+    secrets:
+      ANTHROPIC_API_KEY:
+        description: 'Anthropic API key for AI changelog generation'
+        required: true
+      SLACK_WEBHOOK_URL:
+        description: 'Slack webhook URL for notifications'
+        required: true
+
+jobs:
+  notify:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    steps:
+      - uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
+
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          fetch-depth: 0
+
+      - name: Get package list for Slack notification
+        id: package-list
+        run: |
+          # Get the list of packages that were published
+          PACKAGES=$(jq -r '.release.projects[]' nx.json | tr '\n' ', ' | sed 's/,$//')
+          echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
+
+      - name: Get git diff for changelog
+        id: git-diff
+        run: |
+          # Get the commit range for this push
+          BEFORE_SHA="${{ inputs.before_sha }}"
+          AFTER_SHA="${{ inputs.after_sha }}"
+
+          echo "Comparing commits: $BEFORE_SHA...$AFTER_SHA"
+
+          # Get the diff with file changes and commit messages
+          DIFF_OUTPUT=$(git diff --stat "$BEFORE_SHA...$AFTER_SHA")
+          COMMIT_MESSAGES=$(git log --pretty=format:"- %s (%h)" "$BEFORE_SHA..$AFTER_SHA")
+
+          # Combine into a single output for the AI
+          FULL_CONTEXT="## Commits in this push:
+          $COMMIT_MESSAGES
+
+          ## Files changed:
+          $DIFF_OUTPUT"
+
+          # Save to output using heredoc
+          {
+            echo 'context<<EOF'
+            echo "$FULL_CONTEXT"
+            echo 'EOF'
+          } >> $GITHUB_OUTPUT
+
+          echo "before_sha=$BEFORE_SHA" >> $GITHUB_OUTPUT
+          echo "after_sha=$AFTER_SHA" >> $GITHUB_OUTPUT
+
+      - name: Generate AI-powered changelog
+        id: ai-changelog
+        continue-on-error: true
+        run: |
+          # Prepare the prompt for Claude
+          PROMPT="You are a changelog generator. Based on the following git changes, create a concise, human-readable changelog summary for Slack.
+
+          Focus on:
+          - What features were added
+          - What bugs were fixed
+          - What was changed or improved
+
+          Format requirements (Slack mrkdwn syntax):
+          - Use bullet points (• or -) for each item, separated by newlines
+          - Use *asterisks* for bold (NOT **double asterisks**)
+          - Use _underscores_ for italic if needed
+          - Keep it to 3-7 items max
+          - Be concise and clear
+          - Do NOT use # headers
+          - Do NOT include commit hashes
+          - Do NOT include a 'Changelog' or 'What's Changed' header
+          - Just return the bullet points directly
+
+          Example format:
+          • *Added* new feature for user authentication
+          • *Fixed* critical bug in payment processing
+          • *Improved* performance of data loading
+
+          ${{ steps.git-diff.outputs.context }}"
+
+          # Call Anthropic API
+          RESPONSE=$(curl -s https://api.anthropic.com/v1/messages \
+            -H "Content-Type: application/json" \
+            -H "x-api-key: ${{ secrets.ANTHROPIC_API_KEY }}" \
+            -H "anthropic-version: 2023-06-01" \
+            -d @- <<EOF
+          {
+            "model": "claude-haiku-4-5",
+            "max_tokens": 1024,
+            "messages": [{
+              "role": "user",
+              "content": $(echo "$PROMPT" | jq -Rs .)
+            }]
+          }
+          EOF
+          )
+
+          # Extract the changelog from the response
+          CHANGELOG=$(echo "$RESPONSE" | jq -r '.content[0].text // empty')
+
+          if [ -z "$CHANGELOG" ]; then
+            echo "Error: Failed to generate changelog from API response"
+            echo "Response: $RESPONSE"
+            exit 1
+          fi
+
+          # Save to output
+          {
+            echo 'changelog<<EOF'
+            echo "$CHANGELOG"
+            echo 'EOF'
+          } >> $GITHUB_OUTPUT
+
+      - name: Generate fallback changelog from commits
+        if: steps.ai-changelog.outcome == 'failure'
+        id: fallback-changelog
+        run: |
+          # Generate a simple commit list as fallback
+          BEFORE_SHA="${{ steps.git-diff.outputs.before_sha }}"
+          AFTER_SHA="${{ steps.git-diff.outputs.after_sha }}"
+
+          # Get commits between the two SHAs
+          COMMITS=$(git log --pretty=format:"• %s (%h)" "$BEFORE_SHA..$AFTER_SHA" | head -n 20)
+
+          if [ -z "$COMMITS" ]; then
+            COMMITS="• No commits found in this push"
+          fi
+
+          # Save to output
+          {
+            echo 'changelog<<EOF'
+            echo "$COMMITS"
+            echo 'EOF'
+          } >> $GITHUB_OUTPUT
+
+      - name: Determine notification details
+        id: notification
+        run: |
+          if [[ "${{ inputs.branch }}" == "next" ]]; then
+            echo "emoji=📦" >> $GITHUB_OUTPUT
+            echo "title=Next Branch Packages Published" >> $GITHUB_OUTPUT
+            echo "description=Packages from the \`next\` branch have been published to npm with the \`next\` tag." >> $GITHUB_OUTPUT
+          else
+            echo "emoji=🚀" >> $GITHUB_OUTPUT
+            echo "title=Production Packages Published" >> $GITHUB_OUTPUT
+            echo "description=Packages from the \`main\` branch have been published to npm with the \`latest\` tag." >> $GITHUB_OUTPUT
+          fi
+
+      - name: Send Slack notification
+        continue-on-error: true
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "${{ steps.notification.outputs.emoji }} *${{ steps.notification.outputs.title }}*"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "${{ steps.notification.outputs.emoji }} *${{ steps.notification.outputs.title }}*\n\n${{ steps.notification.outputs.description }}"
+              - type: "section"
+                fields:
+                  - type: "mrkdwn"
+                    text: "*Branch:*\n`${{ inputs.branch }}`"
+                  - type: "mrkdwn"
+                    text: "*npm Tag:*\n`${{ inputs.npm_tag }}`"
+                  - type: "mrkdwn"
+                    text: "*Commits:*\n`${{ steps.git-diff.outputs.before_sha }}` → `${{ steps.git-diff.outputs.after_sha }}`"
+                  - type: "mrkdwn"
+                    text: "*Packages:*\n${{ steps.package-list.outputs.packages }}"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "*What's Changed:*\n${{ steps.ai-changelog.outputs.changelog || steps.fallback-changelog.outputs.changelog || 'No changes detected' }}"
+              - type: "actions"
+                elements:
+                  - type: "button"
+                    text:
+                      type: "plain_text"
+                      text: "View Workflow Run"
+                    url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    style: "primary"

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -163,167 +163,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
 
-      - name: Get package list for Slack notification
-        if: github.event.inputs.dryRun != 'true' && github.event_name == 'push' && github.ref_name == 'next'
-        id: package-list
-        run: |
-          # Get the list of packages that were published
-          PACKAGES=$(jq -r '.release.projects[]' nx.json | tr '\n' ', ' | sed 's/,$//')
-          echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
-
-      - name: Get git diff for changelog
-        if: github.event.inputs.dryRun != 'true' && github.event_name == 'push' && github.ref_name == 'next'
-        id: git-diff
-        run: |
-          # Get the commit range for this push
-          BEFORE_SHA="${{ github.event.before }}"
-          AFTER_SHA="${{ github.sha }}"
-
-          echo "Comparing commits: $BEFORE_SHA...$AFTER_SHA"
-
-          # Get the diff with file changes and commit messages
-          DIFF_OUTPUT=$(git diff --stat "$BEFORE_SHA...$AFTER_SHA")
-          COMMIT_MESSAGES=$(git log --pretty=format:"- %s (%h)" "$BEFORE_SHA..$AFTER_SHA")
-
-          # Combine into a single output for the AI
-          FULL_CONTEXT="## Commits in this push:
-          $COMMIT_MESSAGES
-
-          ## Files changed:
-          $DIFF_OUTPUT"
-
-          # Save to output using heredoc
-          {
-            echo 'context<<EOF'
-            echo "$FULL_CONTEXT"
-            echo 'EOF'
-          } >> $GITHUB_OUTPUT
-
-          echo "before_sha=$BEFORE_SHA" >> $GITHUB_OUTPUT
-          echo "after_sha=$AFTER_SHA" >> $GITHUB_OUTPUT
-
-      - name: Generate AI-powered changelog
-        if: github.event.inputs.dryRun != 'true' && github.event_name == 'push' && github.ref_name == 'next'
-        id: ai-changelog
-        continue-on-error: true
-        run: |
-          # Prepare the prompt for Claude
-          PROMPT="You are a changelog generator. Based on the following git changes, create a concise, human-readable changelog summary for Slack.
-
-          Focus on:
-          - What features were added
-          - What bugs were fixed
-          - What was changed or improved
-
-          Format requirements (Slack mrkdwn syntax):
-          - Use bullet points (• or -) for each item, separated by newlines
-          - Use *asterisks* for bold (NOT **double asterisks**)
-          - Use _underscores_ for italic if needed
-          - Keep it to 3-7 items max
-          - Be concise and clear
-          - Do NOT use # headers
-          - Do NOT include commit hashes
-          - Do NOT include a 'Changelog' or 'What's Changed' header
-          - Just return the bullet points directly
-
-          Example format:
-          • *Added* new feature for user authentication
-          • *Fixed* critical bug in payment processing
-          • *Improved* performance of data loading
-
-          ${{ steps.git-diff.outputs.context }}"
-
-          # Call Anthropic API
-          RESPONSE=$(curl -s https://api.anthropic.com/v1/messages \
-            -H "Content-Type: application/json" \
-            -H "x-api-key: ${{ secrets.ANTHROPIC_API_KEY }}" \
-            -H "anthropic-version: 2023-06-01" \
-            -d @- <<EOF
-          {
-            "model": "claude-haiku-4-5",
-            "max_tokens": 1024,
-            "messages": [{
-              "role": "user",
-              "content": $(echo "$PROMPT" | jq -Rs .)
-            }]
-          }
-          EOF
-          )
-
-          # Extract the changelog from the response
-          CHANGELOG=$(echo "$RESPONSE" | jq -r '.content[0].text // empty')
-
-          if [ -z "$CHANGELOG" ]; then
-            echo "Error: Failed to generate changelog from API response"
-            echo "Response: $RESPONSE"
-            exit 1
-          fi
-
-          # Save to output
-          {
-            echo 'changelog<<EOF'
-            echo "$CHANGELOG"
-            echo 'EOF'
-          } >> $GITHUB_OUTPUT
-
-      - name: Generate fallback changelog from commits
-        if: github.event.inputs.dryRun != 'true' && github.event_name == 'push' && github.ref_name == 'next' && steps.ai-changelog.outcome == 'failure'
-        id: fallback-changelog
-        run: |
-          # Generate a simple commit list as fallback
-          BEFORE_SHA="${{ steps.git-diff.outputs.before_sha }}"
-          AFTER_SHA="${{ steps.git-diff.outputs.after_sha }}"
-
-          # Get commits between the two SHAs
-          COMMITS=$(git log --pretty=format:"• %s (%h)" "$BEFORE_SHA..$AFTER_SHA" | head -n 20)
-
-          if [ -z "$COMMITS" ]; then
-            COMMITS="• No commits found in this push"
-          fi
-
-          # Save to output
-          {
-            echo 'changelog<<EOF'
-            echo "$COMMITS"
-            echo 'EOF'
-          } >> $GITHUB_OUTPUT
-
-      - name: Send Slack notification for next branch publish
-        if: github.event.inputs.dryRun != 'true' && github.event_name == 'push' && github.ref_name == 'next'
-        continue-on-error: true
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            text: "📦 *Next Branch Packages Published*"
-            blocks:
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: "📦 *Next Branch Packages Published*\n\nPackages from the `next` branch have been published to npm with the `next` tag."
-              - type: "section"
-                fields:
-                  - type: "mrkdwn"
-                    text: "*Branch:*\n`next`"
-                  - type: "mrkdwn"
-                    text: "*npm Tag:*\n`next`"
-                  - type: "mrkdwn"
-                    text: "*Commits:*\n`${{ steps.git-diff.outputs.before_sha }}` → `${{ steps.git-diff.outputs.after_sha }}`"
-                  - type: "mrkdwn"
-                    text: "*Packages:*\n${{ steps.package-list.outputs.packages }}"
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: "*What's Changed:*\n${{ steps.ai-changelog.outputs.changelog || steps.fallback-changelog.outputs.changelog || 'No changes detected' }}"
-              - type: "actions"
-                elements:
-                  - type: "button"
-                    text:
-                      type: "plain_text"
-                      text: "View Workflow Run"
-                    url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    style: "primary"
+  notify-release:
+    name: Notify release via Slack
+    needs: publish
+    if: github.event.inputs.dryRun != 'true' && github.event_name == 'push'
+    uses: ./.github/workflows/notify-release.yml
+    with:
+      branch: ${{ github.ref_name }}
+      npm_tag: ${{ github.ref_name == 'next' && 'next' || 'latest' }}
+      before_sha: ${{ github.event.before }}
+      after_sha: ${{ github.sha }}
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   sync-next:
     name: Sync next branch with main


### PR DESCRIPTION
### TL;DR

Extract Slack notification logic into a reusable workflow for both main and next branch releases.

### What changed?

- Created a new reusable workflow file `.github/workflows/notify-release.yml` that handles release notifications
- Modified `publish-packages.yml` to call the new workflow for both main and next branch releases
- The notification workflow:
  - Accepts branch name, npm tag, and commit SHAs as inputs
  - Uses Anthropic's Claude API to generate an AI-powered changelog
  - Formats and sends Slack notifications with release details
  - Includes fallback changelog generation if AI generation fails
  - Customizes notification appearance based on branch (main vs next)

### How to test?

1. Trigger a release on either the main or next branch
2. Verify that the notification workflow is called with the correct parameters
3. Check that the Slack notification is sent with appropriate formatting and content
4. Test the fallback changelog generation by temporarily disabling the AI-powered generation

### Why make this change?

This refactoring improves code maintainability by centralizing notification logic in a reusable workflow. It also extends notification functionality to both main and next branch releases, ensuring consistent communication about all package releases. The workflow provides detailed release information including branch, npm tag, affected packages, and an AI-generated changelog of changes.