### PR TITLE
chore: update PR title format in release workflow to remove tag that skips ci

### DIFF
--- a/.github/workflows/release-update-production.yml
+++ b/.github/workflows/release-update-production.yml
@@ -32,7 +32,7 @@ on:
   schedule:
     # Runs every Monday at 5pm UTC (1pm EDT during daylight saving time)
     # Note: During EST (Nov-Mar), this will run at 12pm EST
-    - cron: "0 17 * * 1"
+    - cron: '0 17 * * 1'
   workflow_dispatch:
 
 jobs:
@@ -119,7 +119,7 @@ jobs:
 
             # Generate PR title with date
             DATE=$(date +'%Y-%m-%d')
-            PR_TITLE="chore: [skip ci] promote next to production ($DATE)"
+            PR_TITLE="chore: promote next to production ($DATE)"
 
             # Capture git log output first to avoid bash parsing issues with special characters
             COMMIT_LIST=$(git log origin/main..HEAD --oneline)
@@ -199,7 +199,7 @@ jobs:
     with:
       before_sha: ${{ needs.create-pr.outputs.before_sha }}
       after_sha: ${{ needs.create-pr.outputs.after_sha }}
-      custom_prompt_file: ".github/prompts/production-release-changelog.md"
+      custom_prompt_file: '.github/prompts/production-release-changelog.md'
       max_tokens: 2048
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
### TL;DR

Remove `[skip ci]` from production promotion PR title to ensure CI runs on these PRs.

### What changed?

- Removed the `[skip ci]` directive from the PR title in the production promotion workflow
- Fixed inconsistent quote styles in the workflow file (changed double quotes to single quotes in several places)

### How to test?

1. Trigger the `release-update-production` workflow manually
2. Verify that the created PR has a title without the `[skip ci]` directive
3. Confirm that CI workflows run properly on the created PR

### Why make this change?

The `[skip ci]` directive was preventing CI workflows from running on production promotion PRs. This change ensures that all necessary CI checks will run on these PRs, providing better validation before merging changes to production.