### PR TITLE
fix(ai-toolkit-nx-claude): fix custom installation flow for global init execution

### DIFF
--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -25,7 +25,6 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
-
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
@@ -52,23 +51,23 @@ jobs:
       - name: Build changed packages
         run: |
           echo "Building changed packages..."
-          npx nx affected --target=build
+          npx nx affected --target=build --verbose
           echo "✅ Build(s) completed successfully"
 
       - name: Run linting
         run: |
           echo "Running linters..."
-          npx nx affected --target=lint
+          npx nx affected --target=lint --verbose
           echo "✅ Linting passed"
 
       - name: Check formatting
         run: |
           echo "Checking code formatting..."
-          npx nx affected --target=format
+          npx nx affected --target=format --verbose
           echo "✅ Formatting check passed"
 
       - name: Run tests
         run: |
           echo "Running tests..."
-          npx nx affected --target=test --parallel=3 --coverage
+          npx nx affected --target=test --parallel=3 --coverage --verbose
           echo "✅ Tests passed"

--- a/packages/ai-toolkit-nx-claude/src/generators/addons/generator.ts
+++ b/packages/ai-toolkit-nx-claude/src/generators/addons/generator.ts
@@ -8,13 +8,13 @@ import {
 } from '../../utils/cli-parser';
 import {
   getAddonById,
+  getAvailableAddons,
   isAddonInstalled,
   validateAddonRequirements,
 } from './addon-registry';
 import {
   installMcpServer,
-  verifyMcpInstallation,
-  updateMcpServer,
+  // updateMcpServer,
   // removeMcpServer,
 } from './claude-mcp-installer';
 import { setupSpecWorkflow } from './spec-workflow-setup';
@@ -28,9 +28,6 @@ export default async function generator(
 ): Promise<void> {
   console.log('\n🎯 Claude Code Addons Installer');
   console.log('================================\n');
-
-  // Track whether project setup was performed
-  let projectSetupCompleted = false;
 
   // Check if Nx dry-run flag was provided
   const dryRunFlagProvided = isNxDryRunProvided() ?? schema.dry;
@@ -57,153 +54,196 @@ export default async function generator(
     console.log('🔍 Dry-run mode activated\n');
   }
 
-  // Always prompt for options (even in dry-run mode) to customize the output
-  const options = (await promptForMissingOptions(
-    schema,
-    require('./schema.json')
-  )) as AddonsGeneratorSchema & { dryRun?: boolean };
+  // Check if parent generator wants to skip prompting
+  let options: AddonsGeneratorSchema & { dryRun?: boolean };
 
-  // Set the dryRun flag based on our earlier determination
-  options.dryRun = isDryRun;
+  if (schema.installMode === 'default') {
+    // Skip prompting - use provided options
+    options = {
+      selectionMode: schema.selectionMode || 'all',
+      force: schema.force || false,
+      skipVerification: schema.skipVerification || false,
+      dashboardMode: schema.dashboardMode || 'always',
+      port: schema.port || 0,
+      dry: schema.dry || false,
+      installMode: 'default',
+      dryRun: isDryRun,
+    };
+  } else {
+    // Normal prompting flow
+    const availableAddons = getAvailableAddons();
+    options = (await promptForMissingOptions(schema, require('./schema.json'), {
+      availableAddons: availableAddons.map((a) => a.id),
+      addonDescriptions: availableAddons.reduce((acc, a) => {
+        acc[a.id] = `${a.name}: ${a.description}`;
+        return acc;
+      }, {} as Record<string, string>),
+    })) as AddonsGeneratorSchema & { dryRun?: boolean };
+
+    // Set the dryRun flag based on our earlier determination
+    options.dryRun = isDryRun;
+  }
 
   // Handle "install all" mode
-  if (options.installMode === 'all') {
+  if (options.selectionMode === 'all') {
     await installAllAddons(tree, options);
     return;
   }
 
-  // Get the selected addon (specific mode)
-  const addon = getAddonById(options.addon || 'spec-workflow-mcp');
-  if (!addon) {
-    throw new Error(`Unknown addon: ${options.addon}`);
+  // Handle "specific" mode - install selected addons
+  await installSelectedAddons(tree, options);
+
+  await formatFiles(tree);
+}
+
+/**
+ * Install selected MCP server addons
+ */
+async function installSelectedAddons(
+  tree: Tree,
+  options: AddonsGeneratorSchema & { dryRun?: boolean }
+): Promise<void> {
+  // Get selected addons
+  const selectedAddonIds = options.addons || [];
+
+  if (selectedAddonIds.length === 0) {
+    console.log('\n⚠️  No addons selected for installation');
+    return;
   }
 
-  console.log(`\n📦 Installing: ${addon.name}`);
-  console.log(`   ${addon.description}\n`);
+  const selectedAddons = selectedAddonIds
+    .map((id) => getAddonById(id))
+    .filter((addon) => addon !== undefined);
 
-  // Check if already installed
-  if (!options.force && !options.dryRun) {
-    const installed = await isAddonInstalled(addon.id);
-    if (installed) {
-      console.log('✅ Addon is already installed');
+  if (selectedAddons.length === 0) {
+    throw new Error('No valid addons found in selection');
+  }
 
-      // Ask if user wants to update configuration
-      const { confirm } = await require('enquirer').prompt({
-        type: 'confirm',
-        name: 'confirm',
-        message: 'Would you like to update the configuration?',
-        initial: false,
-      });
+  console.log('\n📦 Installing Selected MCP Servers');
+  console.log('===================================\n');
+  console.log(`Installing ${selectedAddons.length} MCP server(s)\n`);
 
-      if (confirm) {
-        await updateConfiguration(addon.id, options);
+  const results: Array<{ addon: any; success: boolean; error?: string }> = [];
+
+  // Install each selected addon
+  for (let i = 0; i < selectedAddons.length; i++) {
+    const addon = selectedAddons[i];
+    console.log(
+      `\n[${i + 1}/${selectedAddons.length}] Installing: ${addon.name}`
+    );
+    console.log(`   ${addon.description}`);
+
+    try {
+      // Check if already installed
+      if (!options.force && !options.dryRun) {
+        const installed = await isAddonInstalled(addon.id);
+        if (installed) {
+          console.log('   ✅ Already installed, skipping');
+          results.push({ addon, success: true });
+          continue;
+        }
       }
-      return;
-    }
-  } else if (options.dryRun) {
-    // In dry-run mode, just note if it would check for existing installation
-    const installed = await isAddonInstalled(addon.id);
-    if (installed && !options.force) {
-      console.log(
-        'ℹ️  [DRY-RUN] Addon is already installed, would prompt for update'
-      );
-    }
-  }
 
-  // Validate requirements
-  console.log('\n🔍 Checking requirements...');
-  const validation = await validateAddonRequirements(addon.id);
-  if (!validation.valid) {
-    console.error('\n❌ Requirements not met:');
-    validation.errors.forEach((error) => console.error(`   • ${error}`));
+      // Validate requirements
+      const validation = await validateAddonRequirements(addon.id);
+      if (!validation.valid && !options.force) {
+        console.log('   ⚠️  Requirements not met:');
+        validation.errors.forEach((error) => console.log(`      • ${error}`));
+        console.log('   ⏭️  Skipping (use --force to override)');
+        results.push({
+          addon,
+          success: false,
+          error: 'Requirements not met',
+        });
+        continue;
+      }
 
-    if (!options.force) {
-      throw new Error(
-        'Installation requirements not met. Use --force to override.'
-      );
-    }
-    console.log('\n⚠️  Continuing with --force flag...');
-  }
+      // Install the MCP server
+      await installMcpAddon(addon, options);
 
-  // Install the addon based on type
-  if (addon.type === 'mcp-server') {
-    await installMcpAddon(addon, options);
-
-    // If the addon has project setup configuration, prompt for setup
-    if (addon.projectSetup) {
-      // Ask user if they want to set up project configuration
-      const { setupProject } = await require('enquirer').prompt({
-        type: 'confirm',
-        name: 'setupProject',
-        message:
-          '📁 Would you like to set up spec-workflow configuration for a particular project?',
-        initial: true,
-      });
-
-      if (setupProject) {
-        // Prompt for project path
-        const { projectPath } = await require('enquirer').prompt({
-          type: 'input',
-          name: 'projectPath',
+      // If this is spec-workflow and it's the only/last addon, prompt for project setup
+      if (
+        addon.id === 'spec-workflow-mcp' &&
+        addon.projectSetup &&
+        i === selectedAddons.length - 1
+      ) {
+        // Ask user if they want to set up project configuration
+        const { setupProject } = await require('enquirer').prompt({
+          type: 'confirm',
+          name: 'setupProject',
           message:
-            '📁 Enter the project path where spec-workflow config should be added:',
-          initial: process.cwd(),
-          result: (value: string) => value || process.cwd(),
+            '📁 Would you like to set up spec-workflow configuration for a particular project?',
+          initial: true,
         });
 
-        options.projectPath = projectPath;
+        if (setupProject) {
+          // Prompt for project path
+          const { projectPath } = await require('enquirer').prompt({
+            type: 'input',
+            name: 'projectPath',
+            message:
+              '📁 Enter the project path where spec-workflow config should be added:',
+            initial: process.cwd(),
+            result: (value: string) => value || process.cwd(),
+          });
 
-        if (options.dryRun) {
+          options.projectPath = projectPath;
+
+          if (options.dryRun) {
+            console.log(
+              `\n📁 [DRY-RUN] Would set up project configuration at: ${projectPath}`
+            );
+          }
+
+          await installProjectSetup(addon, options);
+        } else if (options.dryRun) {
           console.log(
-            `\n📁 [DRY-RUN] Would set up project configuration at: ${projectPath}`
+            '\n📁 [DRY-RUN] Skipping project configuration (user chose not to set up)'
           );
         }
-
-        await installProjectSetup(addon, options);
-        projectSetupCompleted = true;
-      } else if (options.dryRun) {
-        console.log(
-          '\n📁 [DRY-RUN] Skipping project configuration (user chose not to set up)'
-        );
       }
+
+      results.push({ addon, success: true });
+    } catch (error) {
+      console.error(
+        `   ❌ Failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      results.push({
+        addon,
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
-  } else {
-    throw new Error(`Addon type '${addon.type}' is not yet supported`);
   }
 
-  // Verify installation (skip in dry-run mode)
-  if (!options.skipVerification && !options.dryRun) {
-    console.log('\n🔍 Verifying installation...');
-    const serverName = addon.mcp.serverName;
-    const verification = await verifyMcpInstallation(serverName);
+  // Show summary
+  console.log('\n\n📊 Installation Summary');
+  console.log('======================\n');
 
-    if (verification.installed) {
-      console.log('✅ Installation verified successfully');
+  const successful = results.filter((r) => r.success);
+  const failed = results.filter((r) => !r.success);
 
-      // Show usage instructions
-      showUsageInstructions(addon, options, projectSetupCompleted);
-    } else {
-      console.log('⚠️  Could not verify installation');
-      console.log('   The addon may still work correctly.');
-      // Show usage instructions anyway
-      showUsageInstructions(addon, options, projectSetupCompleted);
-    }
-  } else if (options.dryRun) {
-    console.log('\n🔍 [DRY-RUN] Skipping installation verification');
-    // Still show usage instructions in dry-run mode
-    showUsageInstructions(addon, options, projectSetupCompleted);
+  console.log(`✅ Successfully installed: ${successful.length}`);
+  successful.forEach((r) => console.log(`   • ${r.addon.name}`));
+
+  if (failed.length > 0) {
+    console.log(`\n❌ Failed to install: ${failed.length}`);
+    failed.forEach((r) =>
+      console.log(`   • ${r.addon.name} - ${r.error || 'Unknown error'}`)
+    );
   }
 
   if (options.dryRun) {
     console.log('\n✨ Dry-run complete! No changes were made.\n');
+    // Show general MCP authentication instructions (even in dry-run)
+    showGeneralMcpInstructions(selectedAddons);
   } else {
     console.log('\n✨ Installation complete!\n');
+    // Show general MCP authentication instructions
+    showGeneralMcpInstructions(successful.map((r) => r.addon));
   }
-
-  // Show general MCP authentication instructions (always, even in dry-run)
-  showGeneralMcpInstructions([addon]);
-
-  await formatFiles(tree);
 }
 
 /**
@@ -362,149 +402,6 @@ async function installProjectSetup(
   }
 
   console.log(`✅ ${result.message}`);
-}
-
-/**
- * Update configuration for an existing addon
- */
-async function updateConfiguration(
-  addonId: string,
-  options: AddonsGeneratorSchema
-): Promise<void> {
-  console.log('\n🔧 Updating configuration...');
-
-  const addon = getAddonById(addonId);
-  if (!addon) {
-    console.error(`❌ Unknown addon: ${addonId}`);
-    return;
-  }
-
-  const serverName = addon.mcp.serverName;
-
-  // Build updates based on addon type
-  const argUpdates: { remove?: string[]; add?: string[] } = {
-    remove: [],
-    add: [],
-  };
-
-  // Handle spec-workflow specific updates
-  if (addon.id === 'spec-workflow-mcp') {
-    // Update dashboard mode
-    if (options.dashboardMode) {
-      // Remove existing dashboard flags
-      argUpdates.remove!.push('--AutoStartDashboard');
-
-      // Add new dashboard flag
-      if (options.dashboardMode === 'always') {
-        argUpdates.add!.push('--AutoStartDashboard');
-      }
-    }
-
-    // Update port
-    if (options.port !== undefined) {
-      // Remove existing port flag
-      argUpdates.remove!.push('--Port=');
-
-      // Add new port flag if not 0
-      if (options.port > 0) {
-        argUpdates.add!.push(`--Port=${options.port}`);
-      }
-    }
-  }
-
-  const result = await updateMcpServer(serverName, argUpdates);
-
-  if (result.success) {
-    console.log(`✅ ${result.message}`);
-  } else {
-    console.error(`❌ ${result.message}`);
-  }
-}
-
-/**
- * Show usage instructions after installation
- */
-function showUsageInstructions(
-  addon: any,
-  options: AddonsGeneratorSchema & { dryRun?: boolean },
-  projectSetupCompleted = false
-): void {
-  console.log('\n📚 Usage Instructions:');
-  console.log('====================\n');
-
-  if (addon.id === 'spec-workflow-mcp') {
-    console.log(
-      '1. Start a new instance of Claude Code to load the new MCP server'
-    );
-    console.log('2. Open your project in Claude Code');
-
-    if (options.dashboardMode === 'always') {
-      console.log(
-        '3. The spec-workflow dashboard will start automatically once you ask claude code "use the spec-workflow mcp to <do some task>"'
-      );
-      console.log(
-        `   Dashboard URL: http://localhost:${options.port || 50014}`
-      );
-    } else {
-      console.log(
-        '3. Start the dashboard manually with: npx @uniswap/spec-workflow-mcp@latest --dashboard'
-      );
-    }
-
-    console.log('\n📋 Available MCP Tools:');
-    console.log('  • spec-workflow-guide - Get workflow documentation');
-    console.log('  • create-spec-doc - Create spec documents');
-    console.log('  • spec-status - Check specification status');
-    console.log('  • manage-tasks - Manage implementation tasks');
-    console.log('  • request-approval - Request human approval for documents');
-    console.log('  • orchestrate-with-agents - Use AI agent orchestration');
-    console.log('  • And more...');
-
-    // If project setup was also configured and completed
-    if (addon.projectSetup && projectSetupCompleted) {
-      console.log('\n📁 Project Configuration:');
-      console.log(
-        '  ✅ Spec-workflow configuration has been added to your project'
-      );
-      console.log('  • .spec-workflow/ - Configuration directory');
-      console.log(
-        '  • .spec-workflow/orchestration.yaml - Agent orchestration config'
-      );
-
-      console.log('\n🤖 Agent Orchestration:');
-      console.log('  Automatic agent orchestration is ENABLED by default');
-      console.log('  Edit .spec-workflow/orchestration.yaml to customize');
-    }
-
-    console.log('\n🚀 Quick Start - start a new instance of Claude Code and:');
-    console.log('  1. Ask Claude: "Show me the spec workflow guide"');
-    console.log('  2. Ask Claude: "Help me create a new spec for [feature]"');
-    console.log('  3. Visit the dashboard to monitor progress');
-    console.log('  4. Start creating specs for your features!');
-  }
-
-  // Show authentication instructions for specific MCPs
-  showAuthInstructions(addon);
-}
-
-/**
- * Show authentication instructions for MCPs that require setup
- */
-function showAuthInstructions(addon: any): void {
-  if (addon.id === 'slack-mcp') {
-    console.log('\n🔐 Slack MCP Authentication:');
-    console.log(
-      '  📖 Documentation: https://www.notion.so/uniswaplabs/Using-a-Slack-MCP-with-Claude-Claude-Code-249c52b2548b8052b901dc05d90e57fc'
-    );
-    console.log(
-      '  This guide contains detailed instructions on how to obtain your Slack bot token.'
-    );
-  } else if (addon.id === 'github-mcp') {
-    console.log('\n🔐 GitHub MCP Authentication:');
-    console.log('  You can obtain your GitHub Personal Access Token using:');
-    console.log('  $ gh auth token');
-    console.log('  (Requires GitHub CLI to be installed and authenticated)');
-  }
 }
 
 /**

--- a/packages/ai-toolkit-nx-claude/src/generators/addons/schema.d.ts
+++ b/packages/ai-toolkit-nx-claude/src/generators/addons/schema.d.ts
@@ -1,8 +1,8 @@
 export interface AddonsGeneratorSchema {
-  /** Installation mode */
-  installMode?: 'all' | 'specific';
-  /** The addon to install */
-  addon?:
+  /** Selection mode for which addons to install */
+  selectionMode?: 'all' | 'specific';
+  /** The addons to install */
+  addons?: Array<
     | 'spec-workflow-mcp'
     | 'graphite-mcp'
     | 'nx-mcp'
@@ -14,7 +14,8 @@ export interface AddonsGeneratorSchema {
     | 'figma-mcp'
     | 'chrome-devtools-mcp'
     | 'vercel-mcp'
-    | 'supabase-mcp';
+    | 'supabase-mcp'
+  >;
   /** Dashboard startup mode */
   dashboardMode?: 'always' | 'manual';
   /** Dashboard port (default: auto) */
@@ -27,4 +28,6 @@ export interface AddonsGeneratorSchema {
   projectPath?: string;
   /** Dry run mode */
   dry?: boolean;
+  /** Installation mode from parent generator (default or custom) */
+  installMode?: 'default' | 'custom';
 }

--- a/packages/ai-toolkit-nx-claude/src/generators/addons/schema.json
+++ b/packages/ai-toolkit-nx-claude/src/generators/addons/schema.json
@@ -5,9 +5,9 @@
   "type": "object",
   "description": "Install and configure Claude Code addons including MCP servers.",
   "properties": {
-    "installMode": {
+    "selectionMode": {
       "type": "string",
-      "description": "Installation mode",
+      "description": "Selection mode for which addons to install",
       "enum": ["all", "specific"],
       "default": "all",
       "x-prompt": {
@@ -20,29 +20,34 @@
           },
           {
             "value": "specific",
-            "label": "A specific MCP server"
+            "label": "Select specific MCP servers"
           }
         ]
       }
     },
-    "addon": {
-      "type": "string",
-      "description": "The addon to install",
-      "enum": [
-        "spec-workflow-mcp",
-        "graphite-mcp",
-        "nx-mcp",
-        "slack-mcp",
-        "universe-mcp",
-        "linear-mcp",
-        "notion-mcp",
-        "github-mcp",
-        "figma-mcp",
-        "chrome-devtools-mcp",
-        "vercel-mcp",
-        "supabase-mcp"
-      ],
-      "prompt-when": "installMode === 'specific'"
+    "addons": {
+      "type": "array",
+      "description": "The addons to install",
+      "items": {
+        "type": "string",
+        "enum": [
+          "spec-workflow-mcp",
+          "graphite-mcp",
+          "nx-mcp",
+          "slack-mcp",
+          "universe-mcp",
+          "linear-mcp",
+          "notion-mcp",
+          "github-mcp",
+          "figma-mcp",
+          "chrome-devtools-mcp",
+          "vercel-mcp",
+          "supabase-mcp"
+        ]
+      },
+      "prompt-when": "selectionMode === 'specific'",
+      "prompt-type": "multiselect",
+      "prompt-message": "🔌 Select MCP servers to install"
     },
     "dashboardMode": {
       "type": "string",
@@ -81,6 +86,12 @@
       "type": "boolean",
       "description": "Dry run mode",
       "default": false
+    },
+    "installMode": {
+      "type": "string",
+      "description": "Installation mode from parent generator (default or custom)",
+      "enum": ["default", "custom"],
+      "hidden": true
     }
   },
   "required": []

--- a/packages/ai-toolkit-nx-claude/src/generators/hooks/schema.json
+++ b/packages/ai-toolkit-nx-claude/src/generators/hooks/schema.json
@@ -8,7 +8,6 @@
       "type": "boolean",
       "description": "Backup existing hooks configuration before installation",
       "default": true,
-      "always-prompt": true,
       "prompt-message": "💾 Backup existing hooks configuration (if any)?",
       "prompt-type": "confirm"
     },
@@ -16,7 +15,6 @@
       "type": "boolean",
       "description": "Preview installation without making changes",
       "default": false,
-      "always-prompt": true,
       "prompt-message": "👁️ Run in dry-run mode (preview only)?",
       "prompt-type": "confirm"
     },
@@ -24,7 +22,6 @@
       "type": "boolean",
       "description": "Show detailed output during installation",
       "default": false,
-      "always-prompt": true,
       "prompt-message": "📝 Show verbose output during installation?",
       "prompt-type": "confirm"
     },

--- a/packages/ai-toolkit-nx-claude/src/generators/init/schema.d.ts
+++ b/packages/ai-toolkit-nx-claude/src/generators/init/schema.d.ts
@@ -3,10 +3,13 @@ export interface InitGeneratorSchema {
   installationType?: 'global' | 'local';
   confirmLocalPath?: boolean;
   installCommands?: boolean;
+  commandSelectionMode?: 'all' | 'specific';
   installAgents?: boolean;
+  agentSelectionMode?: 'all' | 'specific';
   installHooks?: boolean;
   hooksMode?: 'sound' | 'speech' | 'both';
   installAddons?: boolean;
+  addonSelectionMode?: 'all' | 'specific';
   commands?: string[];
   agents?: string[];
   dry?: boolean;

--- a/packages/ai-toolkit-nx-claude/src/generators/init/schema.json
+++ b/packages/ai-toolkit-nx-claude/src/generators/init/schema.json
@@ -55,6 +55,24 @@
       "prompt-message": "📝 Install slash commands?",
       "prompt-type": "confirm"
     },
+    "commandSelectionMode": {
+      "type": "string",
+      "description": "Whether to install all commands or select specific ones",
+      "enum": ["all", "specific"],
+      "prompt-when": "installMode === 'custom' && installCommands === true",
+      "prompt-message": "📝 Select commands to install:",
+      "prompt-type": "list",
+      "prompt-items": [
+        {
+          "value": "all",
+          "label": "All commands"
+        },
+        {
+          "value": "specific",
+          "label": "Select specific commands"
+        }
+      ]
+    },
     "installAgents": {
       "type": "boolean",
       "description": "Whether to install agents",
@@ -63,13 +81,31 @@
       "prompt-message": "🤖 Install AI agents?",
       "prompt-type": "confirm"
     },
+    "agentSelectionMode": {
+      "type": "string",
+      "description": "Whether to install all agents or select specific ones",
+      "enum": ["all", "specific"],
+      "prompt-when": "installMode === 'custom' && installAgents === true",
+      "prompt-message": "🤖 Select agents to install:",
+      "prompt-type": "list",
+      "prompt-items": [
+        {
+          "value": "all",
+          "label": "All agents"
+        },
+        {
+          "value": "specific",
+          "label": "Select specific agents"
+        }
+      ]
+    },
     "commands": {
       "type": "array",
       "description": "Specific commands to install",
       "items": {
         "type": "string"
       },
-      "prompt-when": "installMode === 'custom' && installCommands === true"
+      "prompt-when": "installMode === 'custom' && installCommands === true && commandSelectionMode === 'specific'"
     },
     "agents": {
       "type": "array",
@@ -77,7 +113,7 @@
       "items": {
         "type": "string"
       },
-      "prompt-when": "installMode === 'custom' && installAgents === true"
+      "prompt-when": "installMode === 'custom' && installAgents === true && agentSelectionMode === 'specific'"
     },
     "installHooks": {
       "type": "boolean",
@@ -98,7 +134,27 @@
       "type": "boolean",
       "description": "Install addons like spec-mcp-workflow",
       "default": false,
-      "x-skip-prompt": true
+      "prompt-when": "installMode === 'custom'",
+      "prompt-message": "🔌 Install addons/mcps?",
+      "prompt-type": "confirm"
+    },
+    "addonSelectionMode": {
+      "type": "string",
+      "description": "Whether to install all addons or select a specific one",
+      "enum": ["all", "specific"],
+      "prompt-when": "installMode === 'custom' && installAddons === true",
+      "prompt-message": "🔌 Select addons to install:",
+      "prompt-type": "list",
+      "prompt-items": [
+        {
+          "value": "all",
+          "label": "All addons"
+        },
+        {
+          "value": "specific",
+          "label": "Select specific addons"
+        }
+      ]
     },
     "dry": {
       "type": "boolean",

--- a/packages/ai-toolkit-nx-claude/src/utils/prompt-utils.ts
+++ b/packages/ai-toolkit-nx-claude/src/utils/prompt-utils.ts
@@ -33,8 +33,10 @@ export async function promptForMissingOptions<T extends Record<string, any>>(
   context: {
     availableCommands?: string[];
     availableAgents?: string[];
+    availableAddons?: string[];
     commandDescriptions?: Record<string, string>;
     agentDescriptions?: Record<string, string>;
+    addonDescriptions?: Record<string, string>;
     // Explicit global/local format
     globalExistingCommands?: Set<string>;
     globalExistingAgents?: Set<string>;
@@ -171,6 +173,11 @@ export async function promptForMissingOptions<T extends Record<string, any>>(
         result.installAddons = true;
         result.dry = false;
 
+        // Set selection modes to 'all' for default mode
+        result.commandSelectionMode = 'all';
+        result.agentSelectionMode = 'all';
+        result.addonSelectionMode = 'all';
+
         // Set default command and agent selections
         if (context.defaultCommands) {
           result.commands = context.defaultCommands;
@@ -189,6 +196,9 @@ export async function promptForMissingOptions<T extends Record<string, any>>(
           explicitlyProvidedOptions.set('hooksMode', 'sound');
           explicitlyProvidedOptions.set('installAddons', true);
           explicitlyProvidedOptions.set('dry', false);
+          explicitlyProvidedOptions.set('commandSelectionMode', 'all');
+          explicitlyProvidedOptions.set('agentSelectionMode', 'all');
+          explicitlyProvidedOptions.set('addonSelectionMode', 'all');
           if (context.defaultCommands) {
             explicitlyProvidedOptions.set('commands', context.defaultCommands);
           }
@@ -220,8 +230,10 @@ async function promptForProperty(
   context: {
     availableCommands?: string[];
     availableAgents?: string[];
+    availableAddons?: string[];
     commandDescriptions?: Record<string, string>;
     agentDescriptions?: Record<string, string>;
+    addonDescriptions?: Record<string, string>;
     // Explicit global/local format
     globalExistingCommands?: Set<string>;
     globalExistingAgents?: Set<string>;
@@ -351,6 +363,18 @@ async function promptForProperty(
       );
     }
 
+    if (key === 'addons' && context.availableAddons) {
+      return await promptMultiSelectWithAll(
+        promptMessage,
+        context.availableAddons,
+        'addons',
+        context.addonDescriptions,
+        undefined, // No existing set for addons
+        undefined, // No other location set for addons
+        undefined // No installation type for addons
+      );
+    }
+
     // Generic array input (shouldn't happen in practice)
     return [];
   }
@@ -382,7 +406,7 @@ async function promptForProperty(
 async function promptMultiSelectWithAll(
   message: string,
   choices: string[],
-  type: 'commands' | 'agents',
+  type: 'commands' | 'agents' | 'addons',
   descriptions?: Record<string, string>,
   existingItems?: Set<string>,
   otherLocationItems?: Set<string>,


### PR DESCRIPTION
### TL;DR

Fixes DEV-113

Refactored the addons generator to support multi-selection of MCP servers and improved the installation workflow.

### What changed?

- Changed the addons generator to support installing multiple MCP servers at once
- Replaced `installMode` with `selectionMode` for clarity
- Added new selection modes for commands, agents, and addons in the init generator
- Updated schema definitions to support multi-select for addons
- Improved installation summary with success/failure reporting
- Removed the update functionality for MCP servers (commented out `updateMcpServer`)
- Enhanced the init generator to handle addon installation more consistently
- Added support for parent generators to skip prompting with `installMode: 'default'`

### How to test?

1. Run the generator with `nx g @anthropic-ai/ai-toolkit-nx-claude:addons`
2. Verify you can select multiple MCP servers to install
3. Test the installation summary with both successful and failed installations
4. Run the init generator with `nx g @anthropic-ai/ai-toolkit-nx-claude:init`
5. Verify the new selection modes for commands, agents, and addons work correctly
6. Test both default and custom installation modes
7. Run `npx nx build ai-toolkit-nx-claude`
8. In a different directory (not this repo's Nx workspace), run `node path/to/built/cli-generator.cjs`
9. Test and ensure it works as expected

### Why make this change?

This change improves the user experience by allowing installation of multiple MCP servers in a single operation, rather than requiring separate installations for each server. It also provides clearer selection options and better feedback during installation. The refactoring makes the code more maintainable and provides a more consistent interface between the init generator and the addons generator.