### PR TITLE
chore(workflow): add concurrency control to publish workflow

### DIFF
--- a/.github/workflows/release-update-production.yml
+++ b/.github/workflows/release-update-production.yml
@@ -36,10 +36,24 @@ on:
   workflow_dispatch:
 
 jobs:
-  create-pr:
+  validate-branch:
     runs-on: ubuntu-24.04
-    # Only allow this workflow to run from the next branch
-    if: github.ref == 'refs/heads/next'
+    steps:
+      - uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
+
+      - name: Validate workflow is running from next branch
+        run: |
+          if [ "${{ github.ref }}" != "refs/heads/next" ]; then
+            echo "❌ ERROR: This workflow can only be run from the 'next' branch"
+            echo "Current branch: ${{ github.ref }}"
+            echo "Expected branch: refs/heads/next"
+            exit 1
+          fi
+          echo "✅ Branch validation passed - running from 'next' branch"
+
+  create-pr:
+    needs: validate-branch
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
chore(workflow): add concurrency control to publish workflow

- Implemented concurrency settings to ensure only one publish workflow runs at a time per branch.
- Queued runs will execute sequentially if a new run is triggered while one is in progress.

chore(workflow): add branch validation step to release workflow

- Introduced a new job to validate that the workflow is triggered from the 'next' branch.
- Added a step to ensure the workflow only runs if the current branch matches 'refs/heads/next', providing clear error messaging for invalid triggers.