### PR TITLE
feat(addons): Use standard http figma mcp addon

### DIFF
--- a/packages/ai-toolkit-nx-claude/src/generators/addons/addon-registry.ts
+++ b/packages/ai-toolkit-nx-claude/src/generators/addons/addon-registry.ts
@@ -188,13 +188,13 @@ const ADDON_REGISTRY: AddonMetadata[] = [
   {
     id: 'figma-mcp',
     name: 'Figma MCP',
-    description: 'MCP server for Figma design file access (SSE)',
+    description: 'MCP server for Figma design file access',
     type: 'mcp-server',
     packageName: 'figma',
     mcp: {
       serverName: 'figma',
-      transport: 'sse',
-      url: 'http://127.0.0.1:3845/mcp',
+      transport: 'http',
+      url: 'https://mcp.figma.com/mcp',
     },
   },
   {


### PR DESCRIPTION
Prior to this commit, we were using a figma mcp that required the figma desktop app to be running locally in order for the mcp to work. Now all that's required is installing the addon and authenticating with it