### PR TITLE
feat(ci): [DEV-92] implement shared GitHub Actions release notes generator and notifier

### DIFF
--- a/.github/REUSABLE_WORKFLOWS.md
+++ b/.github/REUSABLE_WORKFLOWS.md
@@ -1,0 +1,860 @@
+# Reusable Workflows Documentation
+
+This document provides comprehensive documentation for the reusable GitHub Actions workflows available in this repository. These workflows can be used by any repository in the organization to generate AI-powered changelogs and send notifications to multiple destinations.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [Workflows](#workflows)
+  - [Generate Changelog (`_generate-changelog.yml`)](#generate-changelog-_generate-changelogyml)
+  - [Notify Release (`_notify-release.yml`)](#notify-release-_notify-releaseyml)
+- [Usage Examples](#usage-examples)
+- [Best Practices](#best-practices)
+- [Troubleshooting](#troubleshooting)
+
+## Overview
+
+These reusable workflows provide:
+
+1. **AI-Powered Changelog Generation**: Generate human-readable changelogs from git commit ranges using Anthropic's Claude API
+2. **Multi-Format Output**: Support for Slack mrkdwn and standard markdown formats
+3. **Flexible Git References**: Support for any git reference type (SHA, tag, branch)
+4. **Multiple Notification Destinations**: Route notifications to Slack, Notion, or both
+5. **Customizable Prompts**: Bring your own prompts for domain-specific changelog formatting
+
+## Prerequisites
+
+### Required Secrets
+
+To use these workflows, you'll need to configure the following secrets in your repository:
+
+#### For Changelog Generation
+
+- **ANTHROPIC_API_KEY**: API key for Claude AI
+  - Required for: `_generate-changelog.yml`
+  - Get from: <https://console.anthropic.com/settings/keys>
+  - Permissions: API access with sufficient credits
+
+#### For Slack Notifications
+
+- **SLACK_WEBHOOK_URL**: Incoming webhook URL for your Slack channel
+  - Required for: `_notify-release.yml` (when `destinations` includes "slack")
+  - Get from: <https://api.slack.com/apps> → Your App → Incoming Webhooks
+  - Format: `https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX`
+
+#### For Notion Integration
+
+- **NOTION_API_KEY**: Notion integration API key
+
+  - Required for: `_notify-release.yml` (when `destinations` includes "notion")
+  - Get from: <https://www.notion.so/my-integrations>
+  - Format: `secret_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX`
+  - Permissions: Write access to target database
+
+- **RELEASE_NOTES_NOTION_DATABASE_ID**: Target Notion database ID
+  - Required for: `_notify-release.yml` (when `destinations` includes "notion")
+  - Extract from database URL: `notion.so/{workspace}/{database_id}?v=...`
+  - Format: 32-character hex string (xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx)
+  - Database Requirements:
+    - Must have a "Name" property (title)
+    - Should have "Commit Range", "Branch", "NPM Tag", and "Date" properties (rich text or date)
+
+### Repository Setup
+
+Add these secrets to your repository:
+
+1. Go to your repository → Settings → Secrets and variables → Actions
+2. Click "New repository secret"
+3. Add each required secret with its value
+
+---
+
+## Workflows
+
+### Generate Changelog (`_generate-changelog.yml`)
+
+Generates AI-powered changelogs from git commit ranges with support for multiple output formats.
+
+#### Reference
+
+```yaml
+uses: your-org/your-repo/.github/workflows/_generate-changelog.yml@main
+```
+
+#### Inputs
+
+| Input                | Type   | Required | Default      | Description                                                          |
+| -------------------- | ------ | -------- | ------------ | -------------------------------------------------------------------- |
+| `from_ref`           | string | ✅ Yes   | -            | Starting git reference (SHA, tag, or branch)                         |
+| `to_ref`             | string | ✅ Yes   | -            | Ending git reference (SHA, tag, or branch)                           |
+| `output_formats`     | string | ❌ No    | `"markdown"` | Comma-separated list: `"slack"`, `"markdown"`, or `"slack,markdown"` |
+| `custom_prompt_file` | string | ❌ No    | -            | Path to custom prompt file (relative to repo root)                   |
+| `custom_prompt_text` | string | ❌ No    | -            | Inline custom prompt text (overrides `custom_prompt_file`)           |
+| `max_tokens`         | number | ❌ No    | `2048`       | Maximum tokens for AI response (1024-4096)                           |
+
+#### Outputs
+
+| Output               | Type   | Description                                                                      |
+| -------------------- | ------ | -------------------------------------------------------------------------------- |
+| `changelog_slack`    | string | Slack mrkdwn formatted changelog (only if `"slack"` in `output_formats`)         |
+| `changelog_markdown` | string | Standard markdown formatted changelog (only if `"markdown"` in `output_formats`) |
+| `generation_method`  | string | Method used: `"ai"` (success) or `"fallback"` (commit list)                      |
+
+#### Secrets
+
+| Secret              | Required | Description                     |
+| ------------------- | -------- | ------------------------------- |
+| `ANTHROPIC_API_KEY` | ✅ Yes   | Anthropic API key for Claude AI |
+
+#### Features
+
+- **Flexible Git References**: Accepts any combination of SHA, tag, or branch references
+- **Multi-Format Generation**: Generate Slack and/or markdown formats in a single AI call
+- **Custom Prompts**: Provide your own prompts via file or inline text
+- **Automatic Fallback**: Falls back to commit list if AI generation fails
+- **Format-Specific Instructions**: Automatically appends format requirements to your custom prompt
+
+#### Example Usage
+
+<details>
+<summary>Basic Usage - Markdown Only</summary>
+
+```yaml
+jobs:
+  generate-changelog:
+    uses: your-org/your-repo/.github/workflows/_generate-changelog.yml@main
+    with:
+      from_ref: v1.0.0
+      to_ref: v1.1.0
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+</details>
+
+<details>
+<summary>Multi-Format with Custom Prompt</summary>
+
+```yaml
+jobs:
+  generate-changelog:
+    uses: your-org/your-repo/.github/workflows/_generate-changelog.yml@main
+    with:
+      from_ref: ${{ github.event.before }}
+      to_ref: ${{ github.sha }}
+      output_formats: 'slack,markdown'
+      custom_prompt_file: '.github/prompts/release-changelog.md'
+      max_tokens: 1024
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+</details>
+
+<details>
+<summary>SHA to SHA with Inline Prompt</summary>
+
+```yaml
+jobs:
+  generate-changelog:
+    uses: your-org/your-repo/.github/workflows/_generate-changelog.yml@main
+    with:
+      from_ref: abc123def
+      to_ref: def456abc
+      output_formats: 'markdown'
+      custom_prompt_text: |
+        Create a changelog focusing on:
+        - Breaking changes (highlight prominently)
+        - New features
+        - Bug fixes
+        Group by impact level.
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+</details>
+
+---
+
+### Notify Release (`_notify-release.yml`)
+
+Routes release notifications to multiple destinations (Slack, Notion, or both) with pre-generated changelogs.
+
+#### Reference
+
+```yaml
+uses: your-org/your-repo/.github/workflows/_notify-release.yml@main
+```
+
+#### Inputs
+
+| Input                | Type   | Required | Default | Description                                                              |
+| -------------------- | ------ | -------- | ------- | ------------------------------------------------------------------------ |
+| `changelog_slack`    | string | ❌ No    | -       | Pre-generated Slack-formatted changelog                                  |
+| `changelog_markdown` | string | ❌ No    | -       | Pre-generated markdown changelog                                         |
+| `destinations`       | string | ✅ Yes   | -       | Comma-separated destinations: `"slack"`, `"notion"`, or `"slack,notion"` |
+| `from_ref`           | string | ✅ Yes   | -       | Starting git reference (for display)                                     |
+| `to_ref`             | string | ✅ Yes   | -       | Ending git reference (for display)                                       |
+| `branch`             | string | ✅ Yes   | -       | Branch name that was released                                            |
+| `npm_tag`            | string | ❌ No    | -       | NPM tag used for publishing                                              |
+| `release_title`      | string | ❌ No    | -       | Custom title (default: generated from branch/refs)                       |
+
+#### Outputs
+
+This workflow does not have outputs (notifications are fire-and-forget).
+
+#### Secrets
+
+| Secret                             | Required                           | Description                |
+| ---------------------------------- | ---------------------------------- | -------------------------- |
+| `SLACK_WEBHOOK_URL`                | ✅ If `"slack"` in `destinations`  | Slack incoming webhook URL |
+| `NOTION_API_KEY`     | ✅ If `"notion"` in `destinations` | Notion integration API key |
+| `RELEASE_NOTES_NOTION_DATABASE_ID` | ✅ If `"notion"` in `destinations` | Target Notion database ID  |
+
+#### Features
+
+- **Destination Routing**: Send to Slack, Notion, or both based on configuration
+- **Automatic Format Handling**: Converts markdown to Slack format if needed
+- **Notion Database Integration**: Creates rich pages with metadata in Notion
+- **Graceful Failures**: Notifications continue even if one destination fails
+- **GitHub Actions Summary**: Provides detailed summary with links in workflow UI
+
+#### Example Usage
+
+<details>
+<summary>Slack Only Notification</summary>
+
+```yaml
+jobs:
+  notify:
+    uses: your-org/your-repo/.github/workflows/_notify-release.yml@main
+    with:
+      changelog_slack: ${{ needs.generate-changelog.outputs.changelog_slack }}
+      destinations: 'slack'
+      from_ref: v1.0.0
+      to_ref: v1.1.0
+      branch: main
+      npm_tag: latest
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+```
+
+</details>
+
+<details>
+<summary>Both Slack and Notion</summary>
+
+```yaml
+jobs:
+  notify:
+    uses: your-org/your-repo/.github/workflows/_notify-release.yml@main
+    with:
+      changelog_slack: ${{ needs.generate-changelog.outputs.changelog_slack }}
+      changelog_markdown: ${{ needs.generate-changelog.outputs.changelog_markdown }}
+      destinations: 'slack,notion'
+      from_ref: ${{ github.event.before }}
+      to_ref: ${{ github.sha }}
+      branch: ${{ github.ref_name }}
+      npm_tag: ${{ github.ref_name == 'main' && 'latest' || 'next' }}
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+      RELEASE_NOTES_NOTION_DATABASE_ID: ${{ secrets.RELEASE_NOTES_NOTION_DATABASE_ID }}
+```
+
+</details>
+
+<details>
+<summary>Notion Only with Custom Title</summary>
+
+```yaml
+jobs:
+  notify:
+    uses: your-org/your-repo/.github/workflows/_notify-release.yml@main
+    with:
+      changelog_markdown: ${{ needs.generate-changelog.outputs.changelog_markdown }}
+      destinations: 'notion'
+      from_ref: v2.0.0
+      to_ref: v2.1.0
+      branch: main
+      npm_tag: latest
+      release_title: 'Production Release v2.1.0 - Major Update'
+    secrets:
+      NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+      RELEASE_NOTES_NOTION_DATABASE_ID: ${{ secrets.RELEASE_NOTES_NOTION_DATABASE_ID }}
+```
+
+</details>
+
+---
+
+## Implementation Details
+
+### TypeScript Script Architecture
+
+The notification workflows leverage a TypeScript script (`.github/scripts/notion-publish.ts`) for Notion integration instead of bash scripts. This approach provides:
+
+- **Type Safety**: Full TypeScript type checking for API interactions
+- **Better Error Handling**: Structured error handling with detailed error messages
+- **Direct Execution**: Uses `tsx` for direct TypeScript execution without build steps
+- **Maintainability**: Easier to test, debug, and maintain than shell scripts
+
+### Community-First Development Principle
+
+**CRITICAL PRINCIPLE**: All scripts and tooling prioritize community-maintained libraries over custom implementations.
+
+**Why This Matters**:
+
+- Battle-tested reliability (millions of weekly downloads)
+- Active maintenance and security patches
+- Comprehensive documentation and community support
+- Reduced technical debt and maintenance burden
+
+**Example - Argument Parsing**:
+Instead of custom argument parsing logic, the script uses **minimist** (~62.5M weekly downloads):
+
+```typescript
+import minimist from 'minimist';
+
+const args = minimist(process.argv.slice(2), {
+  string: [
+    'api-key',
+    'database-id',
+    'title',
+    'content',
+    'from-ref',
+    'to-ref',
+    'branch',
+    'npm-tag',
+  ],
+  alias: {
+    'api-key': 'apiKey',
+    'database-id': 'databaseId',
+    'from-ref': 'fromRef',
+    'to-ref': 'toRef',
+    'npm-tag': 'npmTag',
+  },
+});
+```
+
+**Benefits**:
+
+- Handles edge cases (quoted arguments, spaces, special characters)
+- Supports aliases for kebab-case → camelCase conversion
+- Well-documented and widely used across the ecosystem
+- ~50 lines of custom code eliminated
+
+### Dependencies
+
+The Notion publishing script relies on these community-maintained libraries:
+
+#### Core Dependencies
+
+1. **@notionhq/client** (v2.2.15)
+
+   - Official Notion JavaScript SDK
+   - Provides type-safe API access
+   - Handles authentication and rate limiting
+   - [npm](https://www.npmjs.com/package/@notionhq/client)
+
+2. **@tryfabric/martian** (v1.2.4)
+
+   - Markdown to Notion blocks converter
+   - Supports rich formatting (headings, lists, code blocks)
+   - Handles complex markdown structures
+   - [npm](https://www.npmjs.com/package/@tryfabric/martian)
+
+3. **minimist** (v1.2.8)
+   - Lightweight CLI argument parser
+   - Supports flags, aliases, and type coercion
+   - Zero dependencies
+   - [npm](https://www.npmjs.com/package/minimist)
+
+#### Script Features
+
+The `notion-publish.ts` script provides:
+
+- **Flag-Based Arguments**: Clean CLI interface with kebab-case flags
+- **Structured Logging**: Color-coded output for info/error messages
+- **Error Context**: Detailed error messages with API response bodies
+- **Metadata Support**: Automatically adds commit range, branch, and npm tag properties
+- **Exit Codes**: Proper exit codes for CI/CD integration (0 = success, 1 = failure)
+
+#### TypeScript Configuration
+
+The scripts directory has its own TypeScript configuration (`.github/scripts/tsconfig.json`) with settings optimized for Node.js execution:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "outDir": "../../dist/.github/scripts"
+  }
+}
+```
+
+**Key Settings**:
+
+- **skipLibCheck**: Required for handling type incompatibilities between third-party libraries
+- **Node16 module system**: Ensures proper ESM/CommonJS interop
+- **Strict mode**: Enforces type safety throughout the script
+
+#### Type Handling for Third-Party Libraries
+
+The script handles a known type incompatibility between `@tryfabric/martian` and `@notionhq/client` using a **JSON serialization approach**:
+
+```typescript
+// Convert markdown to Notion blocks
+const blocks = markdownToBlocks(content);
+
+// Serialize and deserialize to strip TypeScript type metadata
+// This is necessary because @tryfabric/martian and @notionhq/client have
+// incompatible type definitions despite being structurally compatible at runtime
+const notionBlocks = JSON.parse(JSON.stringify(blocks));
+```
+
+**Why This Works**:
+
+- The libraries produce/consume structurally compatible data at runtime
+- TypeScript type definitions differ in newer properties (`is_toggleable`, `custom_emoji`)
+- JSON serialization preserves data structure while stripping type metadata
+- Avoids unsafe type assertions (`as any`) which bypass type safety
+- The data remains fully functional despite nominal type incompatibility
+
+**Type Safety Principle**: Always prefer solutions that maintain type safety (like JSON serialization) over type assertions or suppressing errors.
+
+#### Development Guidelines
+
+When modifying or extending these workflows:
+
+1. **Search First**: Always search for existing community libraries before writing custom code
+2. **Evaluate Adoption**: Prefer libraries with:
+   - High weekly downloads (> 1M)
+   - Active maintenance (recent updates)
+   - Good documentation
+   - Stable version history
+3. **Type Safety**: Use TypeScript for all new scripts
+   - Avoid `as any` type assertions
+   - Prefer structural solutions for type incompatibilities
+   - Document why type handling is necessary
+4. **Dependencies**: Keep dependencies minimal but don't reinvent the wheel
+
+---
+
+## Usage Examples
+
+### Complete Release Workflow
+
+This example demonstrates a complete release workflow using both reusable workflows:
+
+```yaml
+name: Release Workflow
+
+on:
+  push:
+    branches: [main, next]
+
+jobs:
+  # Step 1: Generate changelogs in both formats
+  generate-changelog:
+    uses: your-org/your-repo/.github/workflows/_generate-changelog.yml@main
+    with:
+      from_ref: ${{ github.event.before }}
+      to_ref: ${{ github.sha }}
+      output_formats: 'slack,markdown'
+      custom_prompt_file: '.github/prompts/release-changelog.md'
+      max_tokens: 2048
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+  # Step 2: Send notifications to both destinations
+  notify-release:
+    needs: generate-changelog
+    uses: your-org/your-repo/.github/workflows/_notify-release.yml@main
+    with:
+      changelog_slack: ${{ needs.generate-changelog.outputs.changelog_slack }}
+      changelog_markdown: ${{ needs.generate-changelog.outputs.changelog_markdown }}
+      destinations: 'slack,notion'
+      from_ref: ${{ github.event.before }}
+      to_ref: ${{ github.sha }}
+      branch: ${{ github.ref_name }}
+      npm_tag: ${{ github.ref_name == 'main' && 'latest' || 'next' }}
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+      RELEASE_NOTES_NOTION_DATABASE_ID: ${{ secrets.RELEASE_NOTES_NOTION_DATABASE_ID }}
+```
+
+### Tag-Based Release Workflow
+
+Generate changelog between two release tags:
+
+```yaml
+name: Tag Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  generate-changelog:
+    runs-on: ubuntu-latest
+    outputs:
+      previous_tag: ${{ steps.get-tags.outputs.previous_tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get previous tag
+        id: get-tags
+        run: |
+          CURRENT_TAG=${{ github.ref_name }}
+          PREVIOUS_TAG=$(git tag --sort=-version:refname | grep -A1 "^${CURRENT_TAG}$" | tail -n1)
+          echo "previous_tag=$PREVIOUS_TAG" >> $GITHUB_OUTPUT
+
+  changelog:
+    needs: generate-changelog
+    uses: your-org/your-repo/.github/workflows/_generate-changelog.yml@main
+    with:
+      from_ref: ${{ needs.generate-changelog.outputs.previous_tag }}
+      to_ref: ${{ github.ref_name }}
+      output_formats: 'markdown'
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+  notify:
+    needs: [generate-changelog, changelog]
+    uses: your-org/your-repo/.github/workflows/_notify-release.yml@main
+    with:
+      changelog_markdown: ${{ needs.changelog.outputs.changelog_markdown }}
+      destinations: 'slack'
+      from_ref: ${{ needs.generate-changelog.outputs.previous_tag }}
+      to_ref: ${{ github.ref_name }}
+      branch: main
+      release_title: 'Release ${{ github.ref_name }}'
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+```
+
+### Weekly Digest Workflow
+
+Generate a weekly digest of all changes:
+
+```yaml
+name: Weekly Digest
+
+on:
+  schedule:
+    - cron: '0 9 * * 1' # Every Monday at 9am UTC
+  workflow_dispatch:
+
+jobs:
+  generate-digest:
+    runs-on: ubuntu-latest
+    outputs:
+      week_ago_sha: ${{ steps.get-sha.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get SHA from one week ago
+        id: get-sha
+        run: |
+          WEEK_AGO_SHA=$(git rev-list -n 1 --before="1 week ago" HEAD)
+          echo "sha=$WEEK_AGO_SHA" >> $GITHUB_OUTPUT
+
+  changelog:
+    needs: generate-digest
+    uses: your-org/your-repo/.github/workflows/_generate-changelog.yml@main
+    with:
+      from_ref: ${{ needs.generate-digest.outputs.week_ago_sha }}
+      to_ref: HEAD
+      output_formats: 'slack'
+      custom_prompt_text: |
+        Create a weekly digest changelog:
+        - Highlight major features and improvements
+        - Summarize bug fixes
+        - Note any breaking changes
+        Keep it concise (max 10 items).
+      max_tokens: 1024
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+  notify:
+    needs: changelog
+    uses: your-org/your-repo/.github/workflows/_notify-release.yml@main
+    with:
+      changelog_slack: ${{ needs.changelog.outputs.changelog_slack }}
+      destinations: 'slack'
+      from_ref: '1 week ago'
+      to_ref: 'HEAD'
+      branch: main
+      release_title: 'Weekly Development Digest'
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+```
+
+---
+
+## Best Practices
+
+### 1. Custom Prompts
+
+Create repository-specific prompt files for consistent changelog formatting:
+
+```bash
+.github/
+  prompts/
+    release-changelog.md      # Production releases
+    weekly-digest.md          # Weekly summaries
+    hotfix-changelog.md       # Emergency fixes
+```
+
+**Example Prompt File** (`.github/prompts/release-changelog.md`):
+
+```markdown
+You are a changelog generator for a JavaScript/TypeScript monorepo.
+
+Based on the git changes, create a categorized changelog:
+
+## 🎉 Features
+
+- List new features
+
+## 🐛 Bug Fixes
+
+- List bug fixes
+
+## ⚡ Performance
+
+- List performance improvements
+
+## 🔨 Refactoring
+
+- List code refactoring
+
+## 📚 Documentation
+
+- List documentation updates
+
+Rules:
+
+- Keep items concise (one line each)
+- Focus on user-facing changes
+- Skip internal refactoring unless significant
+- Include package names for monorepo changes
+- Max 15 items total
+```
+
+### 2. Output Format Selection
+
+Choose the right format(s) for your needs:
+
+- **Slack only** (`"slack"`): Real-time notifications, team updates
+- **Markdown only** (`"markdown"`): Release notes, GitHub releases, Notion pages
+- **Both** (`"slack,markdown"`): When you need notifications AND documentation
+
+**Pro Tip**: Generate both formats in a single call for efficiency, even if you only need one immediately. The other can be saved for future use.
+
+### 3. Token Limits
+
+Adjust `max_tokens` based on changelog complexity:
+
+- **1024**: Short, concise changelogs (< 10 commits)
+- **2048**: Standard releases (10-50 commits) ← **Recommended default**
+- **4096**: Large releases or detailed changelogs (50+ commits)
+
+Higher token limits cost more and may take longer to generate.
+
+### 4. Notion Database Schema
+
+Set up your Notion database with these properties for best compatibility:
+
+**Required:**
+
+- **Name** (Title) - Page title
+
+**Recommended:**
+
+- **Commit Range** (Rich Text) - Git reference range
+- **Branch** (Rich Text) - Branch name
+- **NPM Tag** (Rich Text) - Package tag
+- **Date** (Date) - Release timestamp
+- **Status** (Select) - Release status (Optional: "Draft", "Published", "Archived")
+
+**Optional:**
+
+- **Version** (Rich Text) - Version number
+- **Author** (Person) - Release author
+
+### 5. Error Handling
+
+Both workflows use `continue-on-error: true` for non-critical steps:
+
+- **Changelog Generation**: Falls back to commit list if AI fails
+- **Slack Notifications**: Continues if webhook fails
+- **Notion Publishing**: Continues if API call fails
+
+Check workflow logs and GitHub Actions summary for detailed error information.
+
+### 6. Git Reference Patterns
+
+**Recommended patterns:**
+
+| Pattern        | Example                                            | Use Case                 |
+| -------------- | -------------------------------------------------- | ------------------------ |
+| Commit SHAs    | `abc123def` → `def456abc`                          | Specific commit ranges   |
+| Tags           | `v1.0.0` → `v1.1.0`                                | Release changelogs       |
+| Branch to HEAD | `main` → `HEAD`                                    | Current branch state     |
+| Event refs     | `${{ github.event.before }}` → `${{ github.sha }}` | Push-triggered workflows |
+
+**Avoid:**
+
+- Branch-to-branch comparisons (ambiguous)
+- Mixing local and remote references without clear intent
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+#### 1. "No changelog generated"
+
+**Symptom**: Empty or missing changelog output
+
+**Possible Causes:**
+
+- Insufficient ANTHROPIC_API_KEY credits
+- Invalid API key
+- Network timeout
+- Git reference doesn't exist
+
+**Solutions:**
+
+- Check API key validity at <https://console.anthropic.com>
+- Verify git references exist: `git rev-parse <ref>`
+- Check workflow logs for API errors
+- Verify `from_ref` and `to_ref` are correct
+
+#### 2. "Notion publishing failed"
+
+**Symptom**: Notion page not created, error in logs
+
+**Possible Causes:**
+
+- Invalid NOTION_API_KEY
+- Invalid RELEASE_NOTES_NOTION_DATABASE_ID
+- Integration doesn't have database access
+- Database schema mismatch
+
+**Solutions:**
+
+- Verify API key at <https://www.notion.so/my-integrations>
+- Confirm database ID from URL
+- Grant integration access to database (Share → Add Integration)
+- Ensure database has "Name" property (title type)
+
+#### 3. "Slack notification failed"
+
+**Symptom**: No Slack message, error in logs
+
+**Possible Causes:**
+
+- Invalid SLACK_WEBHOOK_URL
+- Webhook URL expired/revoked
+- Channel deleted or archived
+
+**Solutions:**
+
+- Regenerate webhook URL at <https://api.slack.com/apps>
+- Verify webhook URL format (should start with `https://hooks.slack.com`)
+- Check Slack app configuration
+- Test webhook with curl:
+
+  ```bash
+  curl -X POST -H 'Content-type: application/json' \
+    --data '{"text":"Test"}' \
+    YOUR_WEBHOOK_URL
+  ```
+
+#### 4. "Invalid git reference"
+
+**Symptom**: `fatal: bad revision` error
+
+**Possible Causes:**
+
+- Reference doesn't exist
+- Shallow clone (insufficient history)
+- Reference not fetched
+
+**Solutions:**
+
+- Use `fetch-depth: 0` in checkout action
+- Verify reference exists: `git rev-parse <ref>`
+- For tags, ensure they're fetched: `git fetch --tags`
+
+#### 5. "Format mismatch"
+
+**Symptom**: Wrong format received or parsed incorrectly
+
+**Possible Causes:**
+
+- Output format requested doesn't match consumption
+- Both formats requested but only one needed
+
+**Solutions:**
+
+- Request only needed formats for efficiency
+- Check output variable names match format requested:
+  - `changelog_slack` for Slack format
+  - `changelog_markdown` for markdown format
+- Verify destination expects correct format
+
+---
+
+## Support and Contributing
+
+For issues, questions, or contributions related to these workflows:
+
+1. **Issues**: Open an issue in this repository
+2. **Documentation**: This file is the source of truth
+3. **Updates**: Watch this repository for workflow updates
+4. **Breaking Changes**: Major version tags will be used for breaking changes
+
+### Versioning
+
+Reference workflows using tags for stability:
+
+```yaml
+# Recommended: Use specific version tag
+uses: your-org/your-repo/.github/workflows/_generate-changelog.yml@v1.0.0
+
+# Alternative: Use branch (gets latest changes, may break)
+uses: your-org/your-repo/.github/workflows/_generate-changelog.yml@main
+```
+
+### Changelog for This Documentation
+
+- **2025-01-XX**: Initial release with both reusable workflows
+- Changelog generation with multi-format support
+- Notification routing with Notion integration
+- Comprehensive documentation and examples
+
+---
+
+## License
+
+These workflows are part of the internal tooling and follow the same license as the parent repository.

--- a/.github/scripts/notion-publish.ts
+++ b/.github/scripts/notion-publish.ts
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+import { Client } from '@notionhq/client';
+import { markdownToBlocks } from '@tryfabric/martian';
+import minimist from 'minimist';
+
+// Parse CLI arguments with flags using minimist
+const args = minimist(process.argv.slice(2), {
+  string: [
+    'api-key',
+    'database-id',
+    'title',
+    'content',
+    'from-ref',
+    'to-ref',
+    'branch',
+    'npm-tag',
+  ],
+  alias: {
+    'api-key': 'apiKey',
+    'database-id': 'databaseId',
+    'from-ref': 'fromRef',
+    'to-ref': 'toRef',
+    'npm-tag': 'npmTag',
+  },
+});
+
+// Read from environment variables first, fall back to CLI arguments
+// This prevents secrets from appearing in process listings
+const apiKey = process.env.NOTION_API_KEY || args.apiKey;
+const databaseId =
+  process.env.RELEASE_NOTES_NOTION_DATABASE_ID || args.databaseId;
+const { title, content, fromRef, toRef, branch, npmTag } = args;
+
+// Color codes for output
+const RED = '\x1b[0;31m';
+const GREEN = '\x1b[0;32m';
+const YELLOW = '\x1b[1;33m';
+const NC = '\x1b[0m'; // No Color
+
+// Logging functions
+const logInfo = (message: string) => {
+  console.error(`${GREEN}[INFO]${NC} ${message}`);
+};
+
+const logError = (message: string) => {
+  console.error(`${RED}[ERROR]${NC} ${message}`);
+};
+
+// Validate required arguments
+if (!apiKey) {
+  logError(
+    'NOTION_API_KEY is required (via NOTION_API_KEY env var or --api-key flag)'
+  );
+  process.exit(1);
+}
+
+if (!databaseId) {
+  logError(
+    'RELEASE_NOTES_NOTION_DATABASE_ID is required (via RELEASE_NOTES_NOTION_DATABASE_ID env var or --database-id flag)'
+  );
+  process.exit(1);
+}
+
+if (!title) {
+  logError('TITLE is required');
+  process.exit(1);
+}
+
+if (!content) {
+  logError('CONTENT is required');
+  process.exit(1);
+}
+
+logInfo(`Preparing to publish to Notion database: ${databaseId}`);
+logInfo(`Page title: ${title}`);
+
+// Initialize Notion client
+const notion = new Client({ auth: apiKey });
+
+async function publishToNotion() {
+  try {
+    // Convert markdown content to Notion blocks using Martian
+    logInfo('Converting markdown to Notion blocks...');
+    const blocks = markdownToBlocks(content);
+
+    // Serialize and deserialize to strip TypeScript type metadata
+    // This is necessary because @tryfabric/martian and @notionhq/client have
+    // incompatible type definitions despite being structurally compatible at runtime
+    const notionBlocks = JSON.parse(JSON.stringify(blocks));
+
+    // Build properties object for the Notion page
+    const properties: any = {
+      Name: {
+        title: [{ text: { content: title } }],
+      },
+      Date: {
+        date: { start: new Date().toISOString() },
+      },
+    };
+
+    // Add optional properties if provided
+    if (fromRef && toRef) {
+      properties['Commit Range'] = {
+        rich_text: [{ text: { content: `${fromRef} → ${toRef}` } }],
+      };
+    } else if (fromRef) {
+      properties['Commit Range'] = {
+        rich_text: [{ text: { content: `From: ${fromRef}` } }],
+      };
+    } else if (toRef) {
+      properties['Commit Range'] = {
+        rich_text: [{ text: { content: `To: ${toRef}` } }],
+      };
+    }
+
+    if (branch) {
+      properties.Branch = {
+        rich_text: [{ text: { content: branch } }],
+      };
+    }
+
+    if (npmTag) {
+      properties['NPM Tag'] = {
+        rich_text: [{ text: { content: npmTag } }],
+      };
+    }
+
+    // Create Notion page
+    logInfo('Creating Notion page...');
+    const response = await notion.pages.create({
+      parent: { database_id: databaseId },
+      properties,
+      children: notionBlocks,
+    });
+
+    logInfo('✅ Successfully created Notion page');
+
+    // Check if response has url property (full page response vs partial)
+    const pageUrl = 'url' in response ? response.url : 'https://notion.so';
+    logInfo(`Page URL: ${pageUrl}`);
+
+    // Output the page URL to stdout (for GitHub Actions to capture)
+    console.log(pageUrl);
+    process.exit(0);
+  } catch (error) {
+    logError('Failed to create Notion page');
+
+    if (error instanceof Error) {
+      logError(error.message);
+
+      // Log additional details if available
+      if ('body' in error) {
+        logError(`Details: ${JSON.stringify(error.body, null, 2)}`);
+      }
+    } else {
+      logError(String(error));
+    }
+
+    process.exit(1);
+  }
+}
+
+// Run the main function
+publishToNotion();

--- a/.github/scripts/tsconfig.json
+++ b/.github/scripts/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "outDir": "../../dist/.github/scripts"
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -68,8 +68,12 @@ Workflows designed to be called by other workflows using `workflow_call`. These 
 
 - **notify-release.yml**:
   - Sends rich Slack notifications with formatted changelog
+  - Supports Notion database integration via TypeScript script
   - Different emoji and styling for production vs. next branch
   - Includes commit range, package list, and workflow run links
+  - Uses community-maintained libraries (minimist, @notionhq/client, @tryfabric/martian)
+
+**📚 For comprehensive documentation including implementation details, dependencies, and usage examples, see [REUSABLE_WORKFLOWS.md](../REUSABLE_WORKFLOWS.md)**
 
 ---
 

--- a/.github/workflows/_generate-changelog.yml
+++ b/.github/workflows/_generate-changelog.yml
@@ -3,38 +3,88 @@ name: Generate Changelog
 # Reusable workflow for generating AI-powered changelogs from git commit ranges.
 # This workflow can be called by other workflows to generate consistent, high-quality
 # changelogs using Anthropic's Claude API.
+#
+# Supports flexible git reference types (SHA, tag, branch) and multiple output formats
+# (Slack mrkdwn, standard markdown) generated in a single AI call for efficiency.
 
 on:
   workflow_call:
     inputs:
-      before_sha:
-        description: 'Starting commit SHA for the changelog range'
+      from_ref:
+        description: |
+          Starting git reference for changelog range.
+          Accepts: commit SHA, tag (v1.0.0), or branch name (main).
+          Example: "v1.0.0" or "abc123def" or "main"
         required: true
         type: string
-      after_sha:
-        description: 'Ending commit SHA for the changelog range'
+
+      to_ref:
+        description: |
+          Ending git reference for changelog range.
+          Accepts: commit SHA, tag (v1.1.0), or branch name (develop).
+          Example: "v1.1.0" or "def456abc" or "HEAD"
         required: true
         type: string
+
+      output_formats:
+        description: |
+          Comma-separated list of output formats to generate.
+          Options: "slack", "markdown", or "slack,markdown"
+          - "slack": Slack mrkdwn format with proper escaping
+          - "markdown": Standard GitHub-flavored markdown
+          Default: "markdown"
+        required: false
+        type: string
+        default: 'markdown'
+
       custom_prompt_file:
-        description: 'Path to custom prompt markdown file (relative to repo root, e.g., .github/prompts/my-prompt.md)'
+        description: |
+          Path to custom prompt markdown file (relative to repo root).
+          Example: ".github/prompts/changelog-prompt.md"
+          Mutually exclusive with custom_prompt_text.
+          If both provided, custom_prompt_text takes precedence.
         required: false
         type: string
+
       custom_prompt_text:
-        description: 'Inline custom prompt text (overrides custom_prompt_file if both provided)'
+        description: |
+          Inline custom prompt text for AI changelog generation.
+          Overrides custom_prompt_file if both provided.
+          Example: "Focus on breaking changes and new features. Group by category."
         required: false
         type: string
+
       max_tokens:
-        description: 'Maximum tokens for AI response'
+        description: |
+          Maximum tokens for AI response.
+          Recommended: 1024 for concise, 2048 for detailed, 4096 for comprehensive.
+          Default: 2048
         required: false
         type: number
-        default: 1024
+        default: 2048
+
     outputs:
-      changelog:
-        description: 'Generated changelog text'
-        value: ${{ jobs.generate.outputs.changelog }}
+      changelog_slack:
+        description: |
+          Slack mrkdwn formatted changelog.
+          Only populated if "slack" included in output_formats.
+          Properly escaped for Slack Block Kit API.
+        value: ${{ jobs.generate.outputs.changelog_slack }}
+
+      changelog_markdown:
+        description: |
+          Standard GitHub-flavored markdown formatted changelog.
+          Only populated if "markdown" included in output_formats.
+          Safe for GitHub releases, Notion, and general markdown renderers.
+        value: ${{ jobs.generate.outputs.changelog_markdown }}
+
       generation_method:
-        description: 'Method used to generate changelog (ai or fallback)'
+        description: |
+          Method used to generate changelog.
+          Values: "ai" (successful AI generation) or "fallback" (commit list fallback).
+          Use this to determine if AI generation succeeded.
         value: ${{ jobs.generate.outputs.method }}
+
     secrets:
       ANTHROPIC_API_KEY:
         description: 'Anthropic API key for AI changelog generation'
@@ -46,7 +96,8 @@ jobs:
     permissions:
       contents: read
     outputs:
-      changelog: ${{ steps.ai-changelog.outputs.changelog || steps.fallback-changelog.outputs.changelog }}
+      changelog_slack: ${{ steps.parse-response.outputs.changelog_slack || steps.fallback-changelog.outputs.changelog }}
+      changelog_markdown: ${{ steps.parse-response.outputs.changelog_markdown || steps.fallback-changelog.outputs.changelog }}
       method: ${{ steps.ai-changelog.outcome == 'success' && 'ai' || 'fallback' }}
 
     steps:
@@ -57,17 +108,34 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Normalize git references
+        id: normalize-refs
+        env:
+          INPUT_FROM_REF: ${{ inputs.from_ref }}
+          INPUT_TO_REF: ${{ inputs.to_ref }}
+        run: |
+          echo "Input references: $INPUT_FROM_REF → $INPUT_TO_REF"
+
+          # Normalize references to commit SHAs
+          FROM_SHA=$(git rev-parse "$INPUT_FROM_REF")
+          TO_SHA=$(git rev-parse "$INPUT_TO_REF")
+
+          echo "Resolved SHAs: $FROM_SHA → $TO_SHA"
+
+          echo "from_sha=$FROM_SHA" >> $GITHUB_OUTPUT
+          echo "to_sha=$TO_SHA" >> $GITHUB_OUTPUT
+
       - name: Get git diff and commit messages
         id: git-context
         run: |
-          BEFORE_SHA="${{ inputs.before_sha }}"
-          AFTER_SHA="${{ inputs.after_sha }}"
+          FROM_SHA="${{ steps.normalize-refs.outputs.from_sha }}"
+          TO_SHA="${{ steps.normalize-refs.outputs.to_sha }}"
 
-          echo "Comparing commits: $BEFORE_SHA...$AFTER_SHA"
+          echo "Comparing commits: $FROM_SHA...$TO_SHA"
 
           # Get the diff with file changes and commit messages
-          DIFF_OUTPUT=$(git diff --stat "$BEFORE_SHA...$AFTER_SHA")
-          COMMIT_MESSAGES=$(git log --pretty=format:"- %s (%h)" "$BEFORE_SHA..$AFTER_SHA")
+          DIFF_OUTPUT=$(git diff --stat "$FROM_SHA...$TO_SHA")
+          COMMIT_MESSAGES=$(git log --pretty=format:"- %s (%h)" "$FROM_SHA..$TO_SHA")
 
           # Combine into a single context for the AI
           FULL_CONTEXT="## Commits in this range:
@@ -109,28 +177,42 @@ jobs:
       - name: Generate AI-powered changelog
         id: ai-changelog
         continue-on-error: true
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CUSTOM_TEXT_PROVIDED: ${{ inputs.custom_prompt_text != '' }}
+          FILE_LOAD_SUCCESS: ${{ steps.load-prompt.outcome == 'success' }}
+          OUTPUT_FORMATS: ${{ inputs.output_formats }}
+          CUSTOM_PROMPT_TEXT: ${{ inputs.custom_prompt_text }}
+          CUSTOM_PROMPT_FILE: ${{ steps.load-prompt.outputs.prompt }}
+          GIT_CONTEXT: ${{ steps.git-context.outputs.context }}
+          MAX_TOKENS: ${{ inputs.max_tokens }}
         run: |
-          # Evaluate conditions in GitHub Actions context (safe for multi-line content)
-          CUSTOM_TEXT_PROVIDED="${{ inputs.custom_prompt_text != '' }}"
-          FILE_LOAD_SUCCESS="${{ steps.load-prompt.outcome == 'success' }}"
+          # Evaluate conditions from environment variables
 
-          # Use boolean flags to control flow (never test actual content)
+          # Determine which formats to generate
+          GENERATE_SLACK="false"
+          GENERATE_MARKDOWN="false"
+
+          if [[ "$OUTPUT_FORMATS" == *"slack"* ]]; then
+            GENERATE_SLACK="true"
+          fi
+          if [[ "$OUTPUT_FORMATS" == *"markdown"* ]]; then
+            GENERATE_MARKDOWN="true"
+          fi
+
+          echo "Generating formats: slack=$GENERATE_SLACK, markdown=$GENERATE_MARKDOWN"
+
+          # Build base prompt
           if [ "$CUSTOM_TEXT_PROVIDED" == "true" ]; then
-            # Use heredoc to safely assign inline custom prompt
-            PROMPT=$(cat <<'PROMPT_EOF'
-          ${{ inputs.custom_prompt_text }}
-          PROMPT_EOF
-          )
+            # Use inline custom prompt from environment variable
+            PROMPT="$CUSTOM_PROMPT_TEXT"
             echo "Using inline custom prompt"
           elif [ "$FILE_LOAD_SUCCESS" == "true" ]; then
-            # Use heredoc to safely assign file-based custom prompt
-            PROMPT=$(cat <<'PROMPT_EOF'
-          ${{ steps.load-prompt.outputs.prompt }}
-          PROMPT_EOF
-          )
+            # Use file-based custom prompt from environment variable
+            PROMPT="$CUSTOM_PROMPT_FILE"
             echo "Using custom prompt from file"
           else
-            # Default prompt (similar to notify-release.yml)
+            # Default prompt
             PROMPT=$(cat <<'PROMPT_EOF'
           You are a changelog generator. Based on the following git changes, create a concise, human-readable changelog summary.
 
@@ -139,34 +221,106 @@ jobs:
           - What bugs were fixed
           - What was changed or improved
 
-          Format requirements:
-          - Use bullet points (• or -) for each item
-          - Keep it to 3-10 items max
-          - Be concise and clear
-          - Do NOT include commit hashes unless specifically requested
-          - Group related changes together
+          Keep it to 3-10 items max.
+          Group related changes together.
           PROMPT_EOF
           )
             echo "Using default prompt"
           fi
 
-          # Append the git context to the prompt using heredoc
-          FULL_PROMPT=$(cat <<FULL_PROMPT_EOF
-          $PROMPT
+          # Build format-specific instructions
+          FORMAT_INSTRUCTIONS=""
 
-          ${{ steps.git-context.outputs.context }}
-          FULL_PROMPT_EOF
+          if [ "$GENERATE_SLACK" == "true" ] && [ "$GENERATE_MARKDOWN" == "true" ]; then
+            # Both formats requested
+            FORMAT_INSTRUCTIONS=$(cat <<'FORMAT_EOF'
+
+          ## Output Format Requirements
+
+          Generate the changelog in TWO formats with clear section markers:
+
+          ### Slack Format
+
+          Start this section with the marker: "## SLACK FORMAT"
+
+          Requirements for Slack format:
+          - Use Slack mrkdwn syntax
+          - Use • (bullet) for list items
+          - Use *bold* for emphasis
+          - Use _italic_ for secondary emphasis
+          - Use `code` for inline code
+          - Keep very concise (3-10 items max)
+          - Properly escape special characters for Slack
+          - Do NOT include commit hashes
+          - Format: • Item description
+
+          ### Markdown Format
+
+          Start this section with the marker: "## MARKDOWN FORMAT"
+
+          Requirements for Markdown format:
+          - Use standard GitHub-flavored markdown
+          - Use - or * for list items
+          - Use **bold** for emphasis
+          - Use *italic* for secondary emphasis
+          - Use `code` for inline code
+          - Include appropriate headers (###, ####) for grouping
+          - Can be more detailed than Slack version
+          - Format: - Item description
+          FORMAT_EOF
           )
+          elif [ "$GENERATE_SLACK" == "true" ]; then
+            # Slack only
+            FORMAT_INSTRUCTIONS=$(cat <<'FORMAT_EOF'
+
+          ## Output Format Requirements
+
+          Format the changelog for Slack using mrkdwn syntax:
+          - Use • (bullet) for list items
+          - Use *bold* for emphasis
+          - Use _italic_ for secondary emphasis
+          - Use `code` for inline code
+          - Keep very concise (3-10 items max)
+          - Properly escape special characters for Slack
+          - Do NOT include commit hashes unless specifically requested
+          - Format: • Item description
+          FORMAT_EOF
+          )
+          elif [ "$GENERATE_MARKDOWN" == "true" ]; then
+            # Markdown only
+            FORMAT_INSTRUCTIONS=$(cat <<'FORMAT_EOF'
+
+          ## Output Format Requirements
+
+          Format the changelog using standard markdown:
+          - Use - or * for list items
+          - Use **bold** for emphasis
+          - Use *italic* for secondary emphasis
+          - Use `code` for inline code
+          - Include appropriate headers (###, ####) for grouping if helpful
+          - Keep concise but can be more detailed than typical Slack messages
+          - Do NOT include commit hashes unless specifically requested
+          - Format: - Item description
+          FORMAT_EOF
+          )
+          fi
+
+          # Append the git context and format instructions to the prompt
+          FULL_PROMPT="$PROMPT
+
+          $FORMAT_INSTRUCTIONS
+
+          $GIT_CONTEXT"
 
           # Call Anthropic API
           RESPONSE=$(curl -s https://api.anthropic.com/v1/messages \
             -H "Content-Type: application/json" \
-            -H "x-api-key: ${{ secrets.ANTHROPIC_API_KEY }}" \
+            -H "x-api-key: $ANTHROPIC_API_KEY" \
             -H "anthropic-version: 2023-06-01" \
             -d @- <<EOF
           {
             "model": "claude-haiku-4-5",
-            "max_tokens": ${{ inputs.max_tokens }},
+            "max_tokens": $MAX_TOKENS,
             "messages": [{
               "role": "user",
               "content": $(echo "$FULL_PROMPT" | jq -Rs .)
@@ -186,30 +340,91 @@ jobs:
 
           echo "✅ AI changelog generated successfully"
 
-          # Save to output
+          # Save full response to output for parsing
           {
-            echo 'changelog<<EOF'
+            echo 'response<<EOF'
             echo "$CHANGELOG"
             echo 'EOF'
           } >> $GITHUB_OUTPUT
+
+          # Save format flags for parsing step
+          echo "generate_slack=$GENERATE_SLACK" >> $GITHUB_OUTPUT
+          echo "generate_markdown=$GENERATE_MARKDOWN" >> $GITHUB_OUTPUT
+
+      - name: Parse AI response into formats
+        if: steps.ai-changelog.outcome == 'success'
+        id: parse-response
+        env:
+          GENERATE_SLACK: ${{ steps.ai-changelog.outputs.generate_slack }}
+          GENERATE_MARKDOWN: ${{ steps.ai-changelog.outputs.generate_markdown }}
+          AI_RESPONSE: ${{ steps.ai-changelog.outputs.response }}
+        run: |
+          # Load the response from environment variable
+          RESPONSE="$AI_RESPONSE"
+
+          # Parse based on what was requested
+          if [ "$GENERATE_SLACK" == "true" ] && [ "$GENERATE_MARKDOWN" == "true" ]; then
+            # Both formats - need to split the response
+
+            # Extract Slack format (between "## SLACK FORMAT" and "## MARKDOWN FORMAT")
+            SLACK_CONTENT=$(echo "$RESPONSE" | sed -n '/## SLACK FORMAT/,/## MARKDOWN FORMAT/p' | sed '1d;$d' | sed '/^$/d')
+
+            # Extract Markdown format (after "## MARKDOWN FORMAT")
+            MARKDOWN_CONTENT=$(echo "$RESPONSE" | sed -n '/## MARKDOWN FORMAT/,$p' | sed '1d' | sed '/^$/d')
+
+            # Save both outputs
+            {
+              echo 'changelog_slack<<EOF'
+              echo "$SLACK_CONTENT"
+              echo 'EOF'
+            } >> $GITHUB_OUTPUT
+
+            {
+              echo 'changelog_markdown<<EOF'
+              echo "$MARKDOWN_CONTENT"
+              echo 'EOF'
+            } >> $GITHUB_OUTPUT
+
+            echo "✅ Parsed both Slack and Markdown formats"
+
+          elif [ "$GENERATE_SLACK" == "true" ]; then
+            # Slack only - entire response is Slack format
+            {
+              echo 'changelog_slack<<EOF'
+              echo "$RESPONSE"
+              echo 'EOF'
+            } >> $GITHUB_OUTPUT
+
+            echo "✅ Generated Slack format"
+
+          elif [ "$GENERATE_MARKDOWN" == "true" ]; then
+            # Markdown only - entire response is Markdown format
+            {
+              echo 'changelog_markdown<<EOF'
+              echo "$RESPONSE"
+              echo 'EOF'
+            } >> $GITHUB_OUTPUT
+
+            echo "✅ Generated Markdown format"
+          fi
 
       - name: Generate fallback changelog from commits
         if: steps.ai-changelog.outcome == 'failure'
         id: fallback-changelog
         run: |
-          BEFORE_SHA="${{ inputs.before_sha }}"
-          AFTER_SHA="${{ inputs.after_sha }}"
+          FROM_SHA="${{ steps.normalize-refs.outputs.from_sha }}"
+          TO_SHA="${{ steps.normalize-refs.outputs.to_sha }}"
 
-          echo "⚠️ AI generation failed, using fallback changelog"
+          echo "⚠️ AI generation failed, using fallback changelog (markdown format)"
 
           # Get commits between the two SHAs
-          COMMITS=$(git log --pretty=format:"• %s (%h)" "$BEFORE_SHA..$AFTER_SHA" | head -n 20)
+          COMMITS=$(git log --pretty=format:"- %s (%h)" "$FROM_SHA..$TO_SHA" | head -n 20)
 
           if [ -z "$COMMITS" ]; then
-            COMMITS="• No commits found in this range"
+            COMMITS="- No commits found in this range"
           fi
 
-          # Save to output
+          # Save to output (markdown format only for fallback)
           {
             echo 'changelog<<EOF'
             echo "$COMMITS"
@@ -218,31 +433,71 @@ jobs:
 
       - name: Summary
         if: always()
+        env:
+          AI_OUTCOME: ${{ steps.ai-changelog.outcome }}
+          SLACK_CHANGELOG_OUTPUT: ${{ steps.parse-response.outputs.changelog_slack }}
+          MARKDOWN_CHANGELOG_OUTPUT: ${{ steps.parse-response.outputs.changelog_markdown }}
+          FALLBACK_CHANGELOG_OUTPUT: ${{ steps.fallback-changelog.outputs.changelog }}
+          INPUT_CUSTOM_PROMPT_TEXT: ${{ inputs.custom_prompt_text }}
+          INPUT_CUSTOM_PROMPT_FILE: ${{ inputs.custom_prompt_file }}
+          INPUT_FROM_REF: ${{ inputs.from_ref }}
+          INPUT_TO_REF: ${{ inputs.to_ref }}
+          NORMALIZED_FROM_SHA: ${{ steps.normalize-refs.outputs.from_sha }}
+          NORMALIZED_TO_SHA: ${{ steps.normalize-refs.outputs.to_sha }}
+          INPUT_OUTPUT_FORMATS: ${{ inputs.output_formats }}
         run: |
-          # Safely capture the changelog using heredoc
-          CHANGELOG=$(cat <<'CHANGELOG_EOF'
-          ${{ steps.ai-changelog.outputs.changelog || steps.fallback-changelog.outputs.changelog }}
-          CHANGELOG_EOF
-          )
+          # Safely capture the changelog from environment variables
+          if [ "$AI_OUTCOME" == "success" ]; then
+            SLACK_CHANGELOG="$SLACK_CHANGELOG_OUTPUT"
+            MARKDOWN_CHANGELOG="$MARKDOWN_CHANGELOG_OUTPUT"
+          else
+            MARKDOWN_CHANGELOG="$FALLBACK_CHANGELOG_OUTPUT"
+          fi
 
           # Determine prompt source
-          if [ -n "${{ inputs.custom_prompt_text }}" ]; then
+          if [ -n "$INPUT_CUSTOM_PROMPT_TEXT" ]; then
             PROMPT_SOURCE="Inline custom prompt"
-          elif [ -n "${{ inputs.custom_prompt_file }}" ]; then
-            PROMPT_SOURCE="\`${{ inputs.custom_prompt_file }}\`"
+          elif [ -n "$INPUT_CUSTOM_PROMPT_FILE" ]; then
+            PROMPT_SOURCE="\`$INPUT_CUSTOM_PROMPT_FILE\`"
           else
             PROMPT_SOURCE="Default prompt"
+          fi
+
+          # Determine generation method
+          if [ "$AI_OUTCOME" == "success" ]; then
+            GENERATION_METHOD="AI-powered ✨"
+          else
+            GENERATION_METHOD="Fallback (commit list) ⚠️"
           fi
 
           # Write the entire summary using heredoc to safely handle all content
           cat <<SUMMARY_EOF >> $GITHUB_STEP_SUMMARY
           ## 📝 Changelog Generation Summary
 
-          - **Commit Range**: \`${{ inputs.before_sha }}\` → \`${{ inputs.after_sha }}\`
-          - **Generation Method**: ${{ steps.ai-changelog.outcome == 'success' && 'AI-powered ✨' || 'Fallback (commit list) ⚠️' }}
+          - **Git References**: \`$INPUT_FROM_REF\` → \`$INPUT_TO_REF\`
+          - **Resolved SHAs**: \`$NORMALIZED_FROM_SHA\` → \`$NORMALIZED_TO_SHA\`
+          - **Output Formats**: \`$INPUT_OUTPUT_FORMATS\`
+          - **Generation Method**: $GENERATION_METHOD
           - **Prompt Source**: $PROMPT_SOURCE
 
-          ### Generated Changelog:
-
-          $CHANGELOG
           SUMMARY_EOF
+
+          # Add Slack format if generated
+          if [ -n "$SLACK_CHANGELOG" ]; then
+            cat <<SLACK_SECTION >> $GITHUB_STEP_SUMMARY
+          ### Slack Format:
+
+          $SLACK_CHANGELOG
+
+          SLACK_SECTION
+          fi
+
+          # Add Markdown format if generated
+          if [ -n "$MARKDOWN_CHANGELOG" ]; then
+            cat <<MARKDOWN_SECTION >> $GITHUB_STEP_SUMMARY
+          ### Markdown Format:
+
+          $MARKDOWN_CHANGELOG
+
+          MARKDOWN_SECTION
+          fi

--- a/.github/workflows/_notify-release.yml
+++ b/.github/workflows/_notify-release.yml
@@ -1,46 +1,120 @@
 name: Notify Release
 
-# Reusable workflow for sending Slack notifications about package releases.
+# Reusable workflow for sending release notifications to multiple destinations.
 # This workflow expects a pre-generated changelog and focuses solely on notification delivery.
 #
 # ARCHITECTURE:
-# This workflow is intentionally simple and focused on a single responsibility: sending
-# notifications. Changelog generation should be handled by the calling workflow using
-# the generate-changelog.yml reusable workflow.
+# This workflow is intentionally simple and focused on a single responsibility: routing
+# notifications to configured destinations. Changelog generation should be handled by the
+# calling workflow using the _generate-changelog.yml reusable workflow.
+#
+# Supports routing to Slack, Notion, or both destinations based on configuration.
 
 on:
   workflow_call:
     inputs:
+      changelog_slack:
+        description: |
+          Pre-generated Slack-formatted changelog from _generate-changelog.yml.
+          Required if "slack" in destinations and want formatted output.
+          If not provided but changelog_markdown is, will be auto-converted.
+        required: false
+        type: string
+
+      changelog_markdown:
+        description: |
+          Pre-generated markdown changelog from _generate-changelog.yml.
+          Required if "notion" in destinations.
+          Can be used for Slack if changelog_slack not provided.
+        required: false
+        type: string
+
+      destinations:
+        description: |
+          Comma-separated list of notification destinations.
+          Options: "slack", "notion", or "slack,notion"
+          - "slack": Send to Slack via webhook (requires SLACK_WEBHOOK_URL secret)
+          - "notion": Create page in Notion database (requires NOTION_API_KEY, RELEASE_NOTES_NOTION_DATABASE_ID)
+          At least one changelog input must be provided for each destination.
+        required: true
+        type: string
+
+      from_ref:
+        description: |
+          Starting git reference for display in notifications.
+          Example: "v1.0.0" or "abc123d"
+        required: true
+        type: string
+
+      to_ref:
+        description: |
+          Ending git reference for display in notifications.
+          Example: "v1.1.0" or "def456a"
+        required: true
+        type: string
+
       branch:
-        description: "Branch name that was released"
+        description: |
+          Branch name that was released.
+          Example: "main", "next", "develop"
         required: true
         type: string
+
       npm_tag:
-        description: "NPM tag used for publishing (next or latest)"
-        required: true
+        description: |
+          NPM tag used for publishing.
+          Example: "latest", "next", "beta"
+          Used for display purposes in notifications.
+        required: false
         type: string
-      before_sha:
-        description: "Commit SHA before the push"
-        required: true
+
+      release_title:
+        description: |
+          Custom title for the release notification.
+          Used as Notion page title and Slack header.
+          Example: "Production Release v1.1.0"
+          Default: Generated from branch and ref range.
+        required: false
         type: string
-      after_sha:
-        description: "Commit SHA after the push"
-        required: true
-        type: string
-      changelog:
-        description: "Pre-generated changelog text (from generate-changelog workflow)"
-        required: true
-        type: string
+
     secrets:
       SLACK_WEBHOOK_URL:
-        description: "Slack webhook URL for notifications"
-        required: true
+        description: |
+          Slack incoming webhook URL for notifications.
+          Required if "slack" included in destinations input.
+          Format: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
+        required: false
+
+      # NOTE: Notion integration is currently disabled but configuration is kept for future use
+      NOTION_API_KEY:
+        description: |
+          Notion integration API key with write access to target database.
+          Required if "notion" included in destinations input.
+          Format: secret_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+          Obtain from: https://www.notion.so/my-integrations
+        required: false
+
+      RELEASE_NOTES_NOTION_DATABASE_ID:
+        description: |
+          Notion database ID where changelog pages will be created.
+          Required if "notion" included in destinations input.
+          Format: 32-character hex string (xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx)
+          Extract from database URL: notion.so/{workspace}/{database_id}?v=...
+        required: false
 
 jobs:
-  notify:
+  prepare:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+    outputs:
+      packages: ${{ steps.package-list.outputs.packages }}
+      emoji: ${{ steps.notification.outputs.emoji }}
+      title: ${{ steps.notification.outputs.title }}
+      description: ${{ steps.notification.outputs.description }}
+      final_title: ${{ steps.notification.outputs.final_title }}
+      changelog_for_slack: ${{ steps.prepare-changelogs.outputs.changelog_for_slack }}
+      changelog_for_notion: ${{ steps.prepare-changelogs.outputs.changelog_for_notion }}
 
     steps:
       - uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
@@ -50,7 +124,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get package list for Slack notification
+      - name: Get package list for notifications
         id: package-list
         run: |
           # Get the list of packages that were published
@@ -59,8 +133,14 @@ jobs:
 
       - name: Determine notification details
         id: notification
+        env:
+          INPUT_BRANCH: ${{ inputs.branch }}
+          INPUT_RELEASE_TITLE: ${{ inputs.release_title }}
+          INPUT_FROM_REF: ${{ inputs.from_ref }}
+          INPUT_TO_REF: ${{ inputs.to_ref }}
         run: |
-          if [[ "${{ inputs.branch }}" == "next" ]]; then
+          # Set emoji, title, and description based on branch
+          if [[ "$INPUT_BRANCH" == "next" ]]; then
             echo "emoji=📦" >> $GITHUB_OUTPUT
             echo "title=Next Branch Packages Published" >> $GITHUB_OUTPUT
             echo "description=Packages from the \`next\` branch have been published to npm with the \`next\` tag." >> $GITHUB_OUTPUT
@@ -70,15 +150,90 @@ jobs:
             echo "description=Packages from the \`main\` branch have been published to npm with the \`latest\` tag." >> $GITHUB_OUTPUT
           fi
 
-      - name: Prepare changelog for Slack
-        id: slack-changelog
-        run: |
-          # Convert real newlines to \n for Slack's mrkdwn format
-          # Slack Block Kit requires explicit \n strings, not actual newline characters
-          CHANGELOG=$(echo "${{ inputs.changelog }}" | awk '{printf "%s\\n", $0}' | sed 's/\\n$//')
+          # Determine final title for notifications
+          if [[ -n "$INPUT_RELEASE_TITLE" ]]; then
+            FINAL_TITLE="$INPUT_RELEASE_TITLE"
+          else
+            FINAL_TITLE="Release $INPUT_BRANCH - $INPUT_FROM_REF → $INPUT_TO_REF"
+          fi
 
-          # Save to output
-          echo "changelog=$CHANGELOG" >> $GITHUB_OUTPUT
+          echo "final_title=$FINAL_TITLE" >> $GITHUB_OUTPUT
+
+      - name: Prepare changelogs for destinations
+        id: prepare-changelogs
+        env:
+          INPUT_DESTINATIONS: ${{ inputs.destinations }}
+          INPUT_CHANGELOG_SLACK: ${{ inputs.changelog_slack }}
+          INPUT_CHANGELOG_MARKDOWN: ${{ inputs.changelog_markdown }}
+        run: |
+          # Determine what we need
+          NEED_SLACK=false
+          NEED_NOTION=false
+
+          if [[ "$INPUT_DESTINATIONS" == *"slack"* ]]; then
+            NEED_SLACK=true
+          fi
+          if [[ "$INPUT_DESTINATIONS" == *"notion"* ]]; then
+            NEED_NOTION=true
+          fi
+
+          echo "Preparing changelogs for destinations: $INPUT_DESTINATIONS"
+          echo "Need Slack: $NEED_SLACK, Need Notion: $NEED_NOTION"
+
+          # Prepare Slack changelog
+          if [ "$NEED_SLACK" == "true" ]; then
+            if [[ -n "$INPUT_CHANGELOG_SLACK" ]]; then
+              # Use provided Slack format
+              SLACK_CHANGELOG="$INPUT_CHANGELOG_SLACK"
+              echo "Using provided Slack changelog"
+            elif [[ -n "$INPUT_CHANGELOG_MARKDOWN" ]]; then
+              # Convert markdown to Slack format (basic conversion)
+              # Replace markdown bullets with Slack bullets
+              SLACK_CHANGELOG=$(echo "$INPUT_CHANGELOG_MARKDOWN" | sed 's/^[*-] /• /g')
+              echo "Converted markdown to Slack format"
+            else
+              echo "Error: Slack destination requested but no changelog provided"
+              exit 1
+            fi
+
+            # Convert real newlines to \\n for Slack's mrkdwn format
+            # Slack Block Kit requires explicit \\n strings, not actual newline characters
+            SLACK_CHANGELOG_ESCAPED=$(echo "$SLACK_CHANGELOG" | awk '{printf "%s\\\\n", $0}' | sed 's/\\\\n$//')
+
+            echo "changelog_for_slack=$SLACK_CHANGELOG_ESCAPED" >> $GITHUB_OUTPUT
+          fi
+
+          # Prepare Notion changelog
+          if [ "$NEED_NOTION" == "true" ]; then
+            if [[ -n "$INPUT_CHANGELOG_MARKDOWN" ]]; then
+              # Use provided markdown format
+              NOTION_CHANGELOG="$INPUT_CHANGELOG_MARKDOWN"
+              echo "Using markdown changelog for Notion"
+            elif [[ -n "$INPUT_CHANGELOG_SLACK" ]]; then
+              # Use Slack format as fallback (Notion can handle basic markdown-like text)
+              NOTION_CHANGELOG="$INPUT_CHANGELOG_SLACK"
+              echo "Using Slack changelog for Notion (fallback)"
+            else
+              echo "Error: Notion destination requested but no changelog provided"
+              exit 1
+            fi
+
+            {
+              echo 'changelog_for_notion<<EOF'
+              echo "$NOTION_CHANGELOG"
+              echo 'EOF'
+            } >> $GITHUB_OUTPUT
+          fi
+
+  notify-slack:
+    needs: prepare
+    if: contains(inputs.destinations, 'slack')
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    steps:
+      - uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
 
       - name: Send Slack notification
         continue-on-error: true
@@ -87,12 +242,12 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-            text: "${{ steps.notification.outputs.emoji }} *${{ steps.notification.outputs.title }}*"
+            text: "${{ needs.prepare.outputs.emoji }} *${{ needs.prepare.outputs.title }}*"
             blocks:
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: "${{ steps.notification.outputs.emoji }} *${{ steps.notification.outputs.title }}*\n\n${{ steps.notification.outputs.description }}"
+                  text: "${{ needs.prepare.outputs.emoji }} *${{ needs.prepare.outputs.title }}*\n\n${{ needs.prepare.outputs.description }}"
               - type: "section"
                 fields:
                   - type: "mrkdwn"
@@ -100,13 +255,13 @@ jobs:
                   - type: "mrkdwn"
                     text: "*npm Tag:*\n`${{ inputs.npm_tag }}`"
                   - type: "mrkdwn"
-                    text: "*Commits:*\n`${{ inputs.before_sha }}` → `${{ inputs.after_sha }}`"
+                    text: "*Commits:*\n`${{ inputs.from_ref }}` → `${{ inputs.to_ref }}`"
                   - type: "mrkdwn"
-                    text: "*Packages:*\n${{ steps.package-list.outputs.packages }}"
+                    text: "*Packages:*\n${{ needs.prepare.outputs.packages }}"
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: "*What's Changed:*\n${{ steps.slack-changelog.outputs.changelog }}"
+                  text: "*What's Changed:*\n${{ needs.prepare.outputs.changelog_for_slack }}"
               - type: "actions"
                 elements:
                   - type: "button"
@@ -115,3 +270,77 @@ jobs:
                       text: "View Workflow Run"
                     url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                     style: "primary"
+
+  notify-notion:
+    needs: prepare
+    if: contains(inputs.destinations, 'notion')
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    steps:
+      - uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
+
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish to Notion
+        id: notion-publish
+        continue-on-error: true
+        env:
+          NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+          RELEASE_NOTES_NOTION_DATABASE_ID: ${{ secrets.RELEASE_NOTES_NOTION_DATABASE_ID }}
+          INPUT_TITLE: ${{ needs.prepare.outputs.final_title }}
+          INPUT_CONTENT: ${{ needs.prepare.outputs.changelog_for_notion }}
+          INPUT_FROM_REF: ${{ inputs.from_ref }}
+          INPUT_TO_REF: ${{ inputs.to_ref }}
+          INPUT_BRANCH: ${{ inputs.branch }}
+          INPUT_NPM_TAG: ${{ inputs.npm_tag }}
+        run: |
+          # Call the TypeScript Notion publishing script with flags
+          PAGE_URL=$(npx tsx .github/scripts/notion-publish.ts \
+            --title "$INPUT_TITLE" \
+            --content "$INPUT_CONTENT" \
+            --from-ref "$INPUT_FROM_REF" \
+            --to-ref "$INPUT_TO_REF" \
+            --branch "$INPUT_BRANCH" \
+            --npm-tag "$INPUT_NPM_TAG")
+
+          echo "✅ Notion page created: $PAGE_URL"
+          echo "page_url=$PAGE_URL" >> $GITHUB_OUTPUT
+
+      - name: Add Notion URL to summary
+        if: steps.notion-publish.outcome == 'success'
+        run: |
+          cat <<SUMMARY_EOF >> $GITHUB_STEP_SUMMARY
+          ## 📄 Notion Page Created
+
+          **Page URL**: ${{ steps.notion-publish.outputs.page_url }}
+
+          [View in Notion](${{ steps.notion-publish.outputs.page_url }})
+          SUMMARY_EOF
+
+      - name: Notion publishing failed
+        if: steps.notion-publish.outcome == 'failure'
+        run: |
+          echo "⚠️ Notion publishing failed (check logs above)"
+          cat <<SUMMARY_EOF >> $GITHUB_STEP_SUMMARY
+          ## ⚠️ Notion Publishing Failed
+
+          The Notion page could not be created. Check the workflow logs for details.
+
+          Common issues:
+          - Invalid NOTION_API_KEY secret
+          - Invalid RELEASE_NOTES_NOTION_DATABASE_ID secret
+          - Notion integration doesn't have access to the database
+          - Database properties don't match expected schema
+          SUMMARY_EOF

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -44,13 +44,13 @@ on:
   workflow_dispatch:
     inputs:
       dryRun:
-        description: "Perform a dry run without publishing"
+        description: 'Perform a dry run without publishing'
         required: false
-        default: "false"
+        default: 'false'
         type: choice
         options:
-          - "true"
-          - "false"
+          - 'true'
+          - 'false'
 
 # Ensure only one publish workflow runs at a time per branch
 # If a new run is triggered while one is in progress, it will be queued
@@ -89,9 +89,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: "22.21.1"
-          registry-url: "https://registry.npmjs.org"
-          scope: "@uniswap"
+          node-version: '22.21.1'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@uniswap'
 
       - name: Install npm
         run: npm install -g npm@11.6.2
@@ -273,8 +273,51 @@ jobs:
       - name: Create GitHub releases
         if: github.event.inputs.dryRun != 'true' && github.event_name == 'push' && steps.affected.outputs.has_affected == 'true'
         run: |
-          # Nx Release will create GitHub releases based on changelog configuration
-          echo "GitHub releases will be created by Nx Release based on the changelog configuration"
+          # Get the tags that were just pushed (created by Nx release version)
+          # These are the tags created since the previous commit
+          AFFECTED_PROJECTS="${{ steps.affected.outputs.projects }}"
+
+          # Convert comma-separated list to array
+          IFS=',' read -ra PACKAGES <<< "$AFFECTED_PROJECTS"
+
+          for package in "${PACKAGES[@]}"; do
+            if [ -n "$package" ]; then
+              # Extract the package name without scope for tag checking
+              PACKAGE_NAME=$(echo "$package" | sed 's/@[^/]*\///')
+
+              # Get the latest tag for this package
+              # Nx creates tags in the format: package-name@version
+              LATEST_TAG=$(git tag -l "${PACKAGE_NAME}@*" --sort=-v:refname | head -n 1)
+
+              if [ -z "$LATEST_TAG" ]; then
+                # Try with full package name including scope
+                LATEST_TAG=$(git tag -l "${package}@*" --sort=-v:refname | head -n 1)
+              fi
+
+              if [ -n "$LATEST_TAG" ]; then
+                # Extract version from tag
+                VERSION="${LATEST_TAG##*@}"
+
+                # Check if release already exists
+                if gh release view "$LATEST_TAG" &>/dev/null; then
+                  echo "✓ Release $LATEST_TAG already exists, skipping"
+                else
+                  echo "Creating GitHub release for $LATEST_TAG"
+
+                  # Create the release with a basic changelog
+                  # The AI-generated changelog will be added to Slack/Notion notifications
+                  gh release create "$LATEST_TAG" \
+                    --title "$package $VERSION" \
+                    --notes "Release $VERSION of $package. See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details." \
+                    --verify-tag
+
+                  echo "✅ Created release for $LATEST_TAG"
+                fi
+              else
+                echo "⚠️ No tag found for $package"
+              fi
+            fi
+          done
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
 
@@ -284,9 +327,10 @@ jobs:
     if: github.event.inputs.dryRun != 'true' && github.event_name == 'push' && needs.publish.outputs.has_affected == 'true'
     uses: ./.github/workflows/_generate-changelog.yml
     with:
-      before_sha: ${{ github.event.before }}
-      after_sha: ${{ github.sha }}
-      custom_prompt_file: ".github/prompts/release-changelog.md"
+      from_ref: ${{ github.event.before }}
+      to_ref: ${{ github.sha }}
+      output_formats: 'slack,markdown'
+      custom_prompt_file: '.github/prompts/release-changelog.md'
       max_tokens: 1024
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -297,11 +341,13 @@ jobs:
     if: github.event.inputs.dryRun != 'true' && github.event_name == 'push' && needs.publish.outputs.has_affected == 'true'
     uses: ./.github/workflows/_notify-release.yml
     with:
+      changelog_slack: ${{ needs.generate-changelog.outputs.changelog_slack }}
+      changelog_markdown: ${{ needs.generate-changelog.outputs.changelog_markdown }}
+      destinations: 'slack'
+      from_ref: ${{ github.event.before }}
+      to_ref: ${{ github.sha }}
       branch: ${{ github.ref_name }}
       npm_tag: ${{ github.ref_name == 'next' && 'next' || 'latest' }}
-      before_sha: ${{ github.event.before }}
-      after_sha: ${{ github.sha }}
-      changelog: ${{ needs.generate-changelog.outputs.changelog }}
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 

--- a/.github/workflows/release-update-production.yml
+++ b/.github/workflows/release-update-production.yml
@@ -211,8 +211,9 @@ jobs:
     if: needs.create-pr.outputs.pr_created == 'true'
     uses: ./.github/workflows/_generate-changelog.yml
     with:
-      before_sha: ${{ needs.create-pr.outputs.before_sha }}
-      after_sha: ${{ needs.create-pr.outputs.after_sha }}
+      from_ref: ${{ needs.create-pr.outputs.before_sha }}
+      to_ref: ${{ needs.create-pr.outputs.after_sha }}
+      output_formats: 'markdown'
       custom_prompt_file: '.github/prompts/production-release-changelog.md'
       max_tokens: 2048
     secrets:
@@ -247,7 +248,7 @@ jobs:
           # Get the AI-generated changelog
           # Use heredoc to safely capture content with special characters (backticks, etc.)
           CHANGELOG=$(cat <<'CHANGELOG_EOF'
-          ${{ needs.generate-changelog.outputs.changelog }}
+          ${{ needs.generate-changelog.outputs.changelog_markdown }}
           CHANGELOG_EOF
           )
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,12 @@
         "apps/*"
       ],
       "dependencies": {
+        "@notionhq/client": "^2.2.15",
+        "@tryfabric/martian": "^1.2.4",
         "express": "^5.1.0",
         "express-rate-limit": "^8.0.1",
-        "helmet": "^8.1.0"
+        "helmet": "^8.1.0",
+        "minimist": "^1.2.8"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",
@@ -38,6 +41,7 @@
         "@swc/jest": "~0.2.38",
         "@types/express": "^5.0.4",
         "@types/jest": "^30.0.0",
+        "@types/minimist": "^1.2.5",
         "@types/node": "20.19.9",
         "@types/supertest": "^6.0.3",
         "@typescript-eslint/eslint-plugin": "^8.42.0",
@@ -3826,6 +3830,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@notionhq/client": {
+      "version": "2.2.15",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-2.2.15.tgz",
+      "integrity": "sha512-XhdSY/4B1D34tSco/GION+23GMjaS9S2zszcqYkMHo8RcWInymF6L1x+Gk7EmHdrSxNFva2WM8orhC4BwQCwgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node-fetch": "^2.5.10",
+        "node-fetch": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@nx/devkit": {
       "version": "22.0.2",
       "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-22.0.2.tgz",
@@ -5253,6 +5270,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tryfabric/martian": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@tryfabric/martian/-/martian-1.2.4.tgz",
+      "integrity": "sha512-g7SP7beaxrjxLnW//vskra07a1jsJowqp07KMouxh4gCwaF+ItHbRZN8O+1dhJivBi3VdasT71BPyk+8wzEreQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@notionhq/client": "^1.0.4",
+        "remark-gfm": "^1.0.0",
+        "remark-math": "^4.0.0",
+        "remark-parse": "^9.0.0",
+        "unified": "^9.2.1"
+      },
+      "engines": {
+        "node": ">=15"
+      }
+    },
+    "node_modules/@tryfabric/martian/node_modules/@notionhq/client": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-1.0.4.tgz",
+      "integrity": "sha512-m7zZ5l3RUktayf1lRBV1XMb8HSKsmWTv/LZPqP7UGC1NMzOlc+bbTOPNQ4CP/c1P4cP61VWLb/zBq7a3c0nMaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node-fetch": "^2.5.10",
+        "node-fetch": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -5534,6 +5580,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mdast": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
+      "integrity": "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
     "node_modules/@types/methods": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
@@ -5548,6 +5603,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
@@ -5556,6 +5618,16 @@
       "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/node-forge": {
@@ -5689,6 +5761,12 @@
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -8465,6 +8543,16 @@
         "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
       }
     },
+    "node_modules/bail": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
+      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -8957,6 +9045,16 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/ccount": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.1.0.tgz",
+      "integrity": "sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -8981,6 +9079,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chokidar": {
@@ -10832,7 +10960,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -11441,7 +11568,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/extsprintf": {
@@ -13311,6 +13437,30 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-alphabetical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -13402,6 +13552,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -13464,6 +13637,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-deflate": {
@@ -13580,6 +13763,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-inside-container": {
@@ -14890,6 +15083,24 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/katex": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.12.0.tgz",
+      "integrity": "sha512-y+8btoc/CK70XqcHqjxiGWBOeIL8upbS0peTPXTvgrh21n1RiWWcIpSWM+4uXq+IAgNh9YYQWdc7LVDPDAEEAg==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.19.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -15417,6 +15628,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/longest-streak": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
+      "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lowdb": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-1.0.0.tgz",
@@ -15507,6 +15728,19 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+      "license": "MIT",
+      "dependencies": {
+        "repeat-string": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -15514,6 +15748,153 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-1.1.1.tgz",
+      "integrity": "sha512-9cKl33Y21lyckGzpSmEQnIDjEfeeWelN5s1kUW1LwdB0Fkuq2u+4GdqcGEygYxJE8GVqCl0741bYXHgamfWAZA==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit-parents": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
+      "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-string": "^2.0.0",
+        "micromark": "~2.11.0",
+        "parse-entities": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-0.1.2.tgz",
+      "integrity": "sha512-NNkhDx/qYcuOWB7xHUGWZYVXvjPFFd6afg6/e2g+SV4r9q5XUcCbV4Wfa3DLYIiD+xAEZc6K4MGaE/m0KDcPwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-gfm-autolink-literal": "^0.1.0",
+        "mdast-util-gfm-strikethrough": "^0.2.0",
+        "mdast-util-gfm-table": "^0.1.0",
+        "mdast-util-gfm-task-list-item": "^0.1.0",
+        "mdast-util-to-markdown": "^0.6.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-0.1.3.tgz",
+      "integrity": "sha512-GjmLjWrXg1wqMIO9+ZsRik/s7PLwTaeCHVB7vRxUwLntZc8mzmTsLVr6HW1yLokcnhfURsn5zmSVdi3/xWWu1A==",
+      "license": "MIT",
+      "dependencies": {
+        "ccount": "^1.0.0",
+        "mdast-util-find-and-replace": "^1.1.0",
+        "micromark": "^2.11.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-0.2.3.tgz",
+      "integrity": "sha512-5OQLXpt6qdbttcDG/UxYY7Yjj3e8P7X16LzvpX8pIQPYJ/C2Z1qFGMmcw+1PZMUM3Z8wt8NRfYTvCni93mgsgA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-to-markdown": "^0.6.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-0.1.6.tgz",
+      "integrity": "sha512-j4yDxQ66AJSBwGkbpFEp9uG/LS1tZV3P33fN1gkyRB2LoRL+RR3f76m0HPHaby6F4Z5xr9Fv1URmATlRRUIpRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "markdown-table": "^2.0.0",
+        "mdast-util-to-markdown": "~0.6.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-0.1.6.tgz",
+      "integrity": "sha512-/d51FFIfPsSmCIRNp7E6pozM9z1GYPIkSy1urQ8s/o4TC22BZ7DqfHFWiqBD23bc7J3vV1Fc9O4QIHBlfuit8A==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-to-markdown": "~0.6.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-0.1.2.tgz",
+      "integrity": "sha512-fogAitds+wH+QRas78Yr1TwmQGN4cW/G2WRw5ePuNoJbBSPJCxIOCE8MTzHgWHVSpgkRaPQTgfzXRE1CrwWSlg==",
+      "license": "MIT",
+      "dependencies": {
+        "longest-streak": "^2.0.0",
+        "mdast-util-to-markdown": "^0.6.0",
+        "repeat-string": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
+      "integrity": "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "longest-streak": "^2.0.0",
+        "mdast-util-to-string": "^2.0.0",
+        "parse-entities": "^2.0.0",
+        "repeat-string": "^1.0.0",
+        "zwitch": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+      "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdn-data": {
@@ -15582,6 +15963,120 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+      "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.0.0",
+        "parse-entities": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-0.3.3.tgz",
+      "integrity": "sha512-oVN4zv5/tAIA+l3GbMi7lWeYpJ14oQyJ3uEim20ktYFAcfX1x3LNlFGGlmrZHt7u9YlKExmyJdDGaTt6cMSR/A==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark": "~2.11.0",
+        "micromark-extension-gfm-autolink-literal": "~0.5.0",
+        "micromark-extension-gfm-strikethrough": "~0.6.5",
+        "micromark-extension-gfm-table": "~0.4.0",
+        "micromark-extension-gfm-tagfilter": "~0.3.0",
+        "micromark-extension-gfm-task-list-item": "~0.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-0.5.7.tgz",
+      "integrity": "sha512-ePiDGH0/lhcngCe8FtH4ARFoxKTUelMp4L7Gg2pujYD5CSMb9PbblnyL+AAMud/SNMyusbS2XDSiPIRcQoNFAw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark": "~2.11.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-0.6.5.tgz",
+      "integrity": "sha512-PpOKlgokpQRwUesRwWEp+fHjGGkZEejj83k9gU5iXCbDG+XBA92BqnRKYJdfqfkrRcZRgGuPuXb7DaK/DmxOhw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark": "~2.11.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-0.4.3.tgz",
+      "integrity": "sha512-hVGvESPq0fk6ALWtomcwmgLvH8ZSVpcPjzi0AjPclB9FsVRgMtGZkUcpE0zgjOCFAznKepF4z3hX8z6e3HODdA==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark": "~2.11.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-0.3.0.tgz",
+      "integrity": "sha512-9GU0xBatryXifL//FJH+tAZ6i240xQuFrSL7mYi8f4oZSbc+NvXjkrHemeYP0+L4ZUT+Ptz3b95zhUZnMtoi/Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-0.3.3.tgz",
+      "integrity": "sha512-0zvM5iSLKrc/NQl84pZSjGo66aTGd57C1idmlWmE87lkMcXrTxg1uXa/nXomxJytoje9trP0NDLvw4bZ/Z/XCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark": "~2.11.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-0.1.2.tgz",
+      "integrity": "sha512-ZJXsT2eVPM8VTmcw0CPSDeyonOn9SziGK3Z+nkf9Vb6xMPeU+4JMEnO6vzDL10562Favw8Vste74f54rxJ/i6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "katex": "^0.12.0",
+        "micromark": "~2.11.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromatch": {
@@ -15854,7 +16349,6 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -16513,6 +17007,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-entities": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/parse-json": {
@@ -17986,6 +18498,56 @@
       },
       "bin": {
         "regjsparser": "bin/parser"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-1.0.0.tgz",
+      "integrity": "sha512-KfexHJCiqvrdBZVbQ6RopMZGwaXz6wFJEfByIuEwGf0arvITHjiKKZ1dpXujjH9KZdm1//XJQwgfnJ3lmXaDPA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-gfm": "^0.1.0",
+        "micromark-extension-gfm": "^0.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-4.0.0.tgz",
+      "integrity": "sha512-lH7SoQenXtQrvL0bm+mjZbvOk//YWNuyR+MxV18Qyv8rgFmMEGNuB0TSCQDkoDaiJ40FCnG8lxErc/zhcedYbw==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-math": "^0.1.0",
+        "micromark-extension-math": "^0.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
+      "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^0.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/require-directory": {
@@ -20357,7 +20919,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tree-dump": {
@@ -20384,6 +20945,16 @@
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/trough": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
+      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-api-utils": {
@@ -20906,6 +21477,70 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/unified": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
+      "integrity": "sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bail": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^2.0.0",
+        "trough": "^1.0.0",
+        "vfile": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unified/node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+      "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
+      "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/universalify": {
@@ -21968,6 +22603,36 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "node_modules/vfile": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
+      "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0",
+        "vfile-message": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
+      "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -22027,7 +22692,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
@@ -22805,7 +23469,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -23240,6 +23903,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
+      "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "packages/agents/agnostic": {

--- a/package.json
+++ b/package.json
@@ -20,9 +20,12 @@
   },
   "private": true,
   "dependencies": {
+    "@notionhq/client": "^2.2.15",
+    "@tryfabric/martian": "^1.2.4",
     "express": "^5.1.0",
     "express-rate-limit": "^8.0.1",
-    "helmet": "^8.1.0"
+    "helmet": "^8.1.0",
+    "minimist": "^1.2.8"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",
@@ -43,6 +46,7 @@
     "@swc/jest": "~0.2.38",
     "@types/express": "^5.0.4",
     "@types/jest": "^30.0.0",
+    "@types/minimist": "^1.2.5",
     "@types/node": "20.19.9",
     "@types/supertest": "^6.0.3",
     "@typescript-eslint/eslint-plugin": "^8.42.0",


### PR DESCRIPTION
## Description

Addresses DEV-92

- Added guidelines for script separation in GitHub Actions, emphasizing the need for complex scripts to be placed in the `.github/scripts/` directory.
- Introduced a new reusable workflow for generating AI-powered changelogs, supporting multiple output formats (Slack and markdown).
- Created a Notion publishing script to facilitate integration with Notion databases.
- Updated existing workflows to utilize new input parameters and improve changelog generation and notification processes.
- Enhanced documentation for reusable workflows, including prerequisites and usage examples.