### PR TITLE
fix(workflows): [DEV-92] update changelog generation scripts for Slack formatting

### DIFF
--- a/.github/workflows/_generate-changelog.yml
+++ b/.github/workflows/_generate-changelog.yml
@@ -367,10 +367,10 @@ jobs:
             # Both formats - need to split the response
 
             # Extract Slack format (between "## SLACK FORMAT" and "## MARKDOWN FORMAT")
-            SLACK_CONTENT=$(echo "$RESPONSE" | sed -n '/## SLACK FORMAT/,/## MARKDOWN FORMAT/p' | sed '1d;$d' | sed '/^$/d')
+            SLACK_CONTENT=$(echo "$RESPONSE" | sed -n '/## SLACK FORMAT/,/## MARKDOWN FORMAT/p' | sed '1d;$d')
 
             # Extract Markdown format (after "## MARKDOWN FORMAT")
-            MARKDOWN_CONTENT=$(echo "$RESPONSE" | sed -n '/## MARKDOWN FORMAT/,$p' | sed '1d' | sed '/^$/d')
+            MARKDOWN_CONTENT=$(echo "$RESPONSE" | sed -n '/## MARKDOWN FORMAT/,$p' | sed '1d')
 
             # Save both outputs
             {

--- a/.github/workflows/_notify-release.yml
+++ b/.github/workflows/_notify-release.yml
@@ -196,9 +196,9 @@ jobs:
               exit 1
             fi
 
-            # Convert real newlines to \\n for Slack's mrkdwn format
-            # Slack Block Kit requires explicit \\n strings, not actual newline characters
-            SLACK_CHANGELOG_ESCAPED=$(echo "$SLACK_CHANGELOG" | awk '{printf "%s\\\\n", $0}' | sed 's/\\\\n$//')
+            # Convert real newlines to \n for Slack's mrkdwn format
+            # Slack Block Kit requires explicit \n strings, not actual newline characters
+            SLACK_CHANGELOG_ESCAPED=$(echo "$SLACK_CHANGELOG" | awk '{printf "%s\\n", $0}' | sed 's/\\n$//')
 
             echo "changelog_for_slack=$SLACK_CHANGELOG_ESCAPED" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
Fixes DEV-92

- Removed unnecessary empty line removal in Slack content extraction.
- Corrected newline escape sequence in Slack changelog formatting to ensure proper display in Slack's Block Kit.