### PR TITLE
fix(addons): use proper slack mcp addon config, and update claude docs to use form…

### DIFF
--- a/docs/readmes/CONTRIBUTING.md
+++ b/docs/readmes/CONTRIBUTING.md
@@ -189,8 +189,8 @@ Our codebase enforces quality through automated checks:
 Before committing:
 
 ```bash
-# Format all uncommitted files
-npx nx format:write --uncommitted
+# Format all files
+npm run format
 
 # Lint affected projects
 npx nx affected --target=lint --base=HEAD~1

--- a/docs/readmes/DEVELOPMENT.md
+++ b/docs/readmes/DEVELOPMENT.md
@@ -406,7 +406,7 @@ npm install /path/to/package-name-1.0.0.tgz
 
 ```bash
 # Format code
-npx nx format:write --uncommitted
+npm run format
 
 # Lint with fixes
 npx nx affected --target=lint --fix

--- a/docs/readmes/WORKFLOW.md
+++ b/docs/readmes/WORKFLOW.md
@@ -67,7 +67,7 @@ git checkout -b fix/bug-description
 # ... edit files ...
 
 # Run quality checks frequently
-npx nx format:write --uncommitted  # Format code
+npm run format  # Format code
 npx nx affected --target=lint --base=next  # Lint
 npx nx affected --target=test --base=next  # Test
 

--- a/packages/ai-toolkit-nx-claude/src/generators/addons/addon-registry.ts
+++ b/packages/ai-toolkit-nx-claude/src/generators/addons/addon-registry.ts
@@ -136,9 +136,9 @@ const ADDON_REGISTRY: AddonMetadata[] = [
     type: 'mcp-server',
     packageName: 'slack-mcp',
     mcp: {
-      serverName: 'zencoder-slack',
-      command: 'slack-mcp',
-      args: ['--transport', 'stdio'],
+      serverName: 'slack',
+      command: 'npx',
+      args: ['-y', '@zencoderai/slack-mcp-server', '--transport', 'stdio'],
       env: {
         SLACK_BOT_TOKEN: 'PROMPT_TO_INSERT_SLACK_BOT_TOKEN',
         SLACK_TEAM_ID: 'TKZBCKUJJ',


### PR DESCRIPTION
…at command that works

The current slack addon that gets installed doesn't work after setting a valid env var. Now it does

Also, Claude was giving me errors when trying to format, and it's something to do with nx complexities. using simply 'npm run lint' does not have those problems, so I updated the relevant Claude files to use that command"