### PR TITLE
feat(mcp): add Claude MCP helper package for managing Model Context Protocol servers

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -100,6 +100,7 @@
   "release": {
     "projects": [
       "@uniswap/ai-toolkit-nx-claude",
+      "@uniswap/ai-toolkit-claude-mcp-helper",
       "@ai-toolkit/utils",
       "@ai-toolkit/agents-agnostic",
       "@ai-toolkit/commands-agnostic",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6074,6 +6074,10 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@uniswap/ai-toolkit-claude-mcp-helper": {
+      "resolved": "packages/mcp-config",
+      "link": true
+    },
     "node_modules/@uniswap/ai-toolkit-nx-claude": {
       "resolved": "packages/ai-toolkit-nx-claude",
       "link": true
@@ -23948,6 +23952,56 @@
     "packages/commands/typescript": {
       "name": "@ai-toolkit/commands-typescript",
       "version": "0.1.13-next.7"
+    },
+    "packages/mcp-config": {
+      "name": "@uniswap/ai-toolkit-claude-mcp-helper",
+      "version": "1.0.0",
+      "dependencies": {
+        "enquirer": "^2.4.1"
+      },
+      "bin": {
+        "mcp-config": "dist/mcp-config.cjs"
+      },
+      "devDependencies": {
+        "@types/node": "^24.10.0",
+        "memfs": "^4.14.0"
+      }
+    },
+    "packages/mcp-config/node_modules/@types/node": {
+      "version": "24.10.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.0.tgz",
+      "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/mcp-config/node_modules/memfs": {
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.50.0.tgz",
+      "integrity": "sha512-N0LUYQMUA1yS5tJKmMtU9yprPm6ZIg24yr/OVv/7t6q0kKDIho4cBbXRi1XKttUmNYDYgF/q45qrKE/UhGO0CA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/json-pack": "^1.11.0",
+        "@jsonjoy.com/util": "^1.9.0",
+        "glob-to-regex.js": "^1.0.1",
+        "thingies": "^2.5.0",
+        "tree-dump": "^1.0.3",
+        "tslib": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      }
+    },
+    "packages/mcp-config/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/utils": {
       "name": "@ai-toolkit/utils",

--- a/packages/mcp-config/.spec.swcrc
+++ b/packages/mcp-config/.spec.swcrc
@@ -1,0 +1,22 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    },
+    "keepClassNames": true,
+    "externalHelpers": true,
+    "loose": true
+  },
+  "module": {
+    "type": "es6"
+  },
+  "sourceMaps": true,
+  "exclude": []
+}

--- a/packages/mcp-config/CLAUDE.md
+++ b/packages/mcp-config/CLAUDE.md
@@ -1,0 +1,644 @@
+# CLAUDE.md - MCP Config Package
+
+## Overview
+
+The `@uniswap/ai-toolkit-claude-mcp-helper` package (source directory: `packages/mcp-config`) is a standalone CLI tool for managing MCP (Model Context Protocol) servers in Claude Code workspaces. It provides an intuitive interface for enabling/disabling MCP servers across global and project-specific configurations.
+
+## Package Purpose
+
+This tool solves the problem of managing MCP server availability in Claude Code by:
+
+- Reading from multiple sources: global (`~/.claude.json`), project-specific (`~/.claude.json` projects), and project-local (`./.mcp.json`)
+- Managing enabled/disabled state through local settings (`./.claude/settings.local.json`)
+- Presenting a unified view of all available servers with their enabled/disabled status
+- Allowing easy multi-select interface to toggle server availability
+- Maintaining proper configuration priority (local overrides global)
+
+## Architecture
+
+### Configuration System
+
+The tool implements a **multi-source configuration system** that discovers MCP servers from three locations and manages their enabled/disabled state:
+
+#### MCP Server Sources (Discovery)
+
+1. **Global Config** (`~/.claude.json`):
+
+   - Contains user-wide MCP server definitions in `mcpServers` object
+   - Accessible across all projects
+   - Example: `{ "mcpServers": { "github": { "command": "npx", "args": [...] } } }`
+
+2. **Project-Specific Config** (`~/.claude.json` → `projects[cwd].mcpServers`):
+
+   - Project-specific MCP server definitions within the global config
+   - Scoped to specific working directories
+   - Example: `{ "projects": { "/path/to/project": { "mcpServers": { "custom-tool": {...} } } } }`
+
+3. **Project-Local Config** (`./.mcp.json`):
+   - Project-committed MCP server definitions
+   - Allows teams to share MCP server configurations via version control
+   - Example: `{ "mcpServers": { "team-tool": { "command": "npx", "args": [...] } } }`
+
+#### Enabled/Disabled State Management
+
+**Local Settings** (`./.claude/settings.local.json`):
+
+- Project-specific settings that control which discovered servers are enabled/disabled
+- Contains `deniedMcpServers` array listing disabled servers
+- Format: Array of objects with `serverName` property
+- **Takes precedence** over all other configurations
+
+```json
+{
+  "deniedMcpServers": [
+    { "serverName": "chrome-devtools" },
+    { "serverName": "claude-historian" }
+  ]
+}
+```
+
+**Priority Rule**: If a server appears in local `deniedMcpServers`, it's disabled regardless of where it was discovered. Otherwise, it's enabled by default.
+
+### Key Data Structure
+
+The `deniedMcpServers` array uses an **object format** (not string array):
+
+```json
+{
+  "deniedMcpServers": [
+    { "serverName": "chrome-devtools" },
+    { "serverName": "claude-historian" }
+  ]
+}
+```
+
+This format is critical for proper integration with Claude Code's configuration system.
+
+## Module Structure
+
+```
+packages/mcp-config/
+├── src/
+│   ├── index.ts              # CLI entry point and command router
+│   ├── commands/
+│   │   ├── list.ts           # List servers with status
+│   │   ├── enable.ts         # Enable one or more servers
+│   │   ├── disable.ts        # Disable one or more servers
+│   │   ├── status.ts         # Detailed status view
+│   │   └── interactive.ts    # Multi-select interactive mode
+│   ├── config/
+│   │   ├── types.ts          # TypeScript interfaces
+│   │   ├── reader.ts         # Configuration reading logic
+│   │   └── writer.ts         # Configuration writing logic
+│   └── utils/
+│       └── display.ts        # Console output formatting
+├── package.json
+├── tsconfig.json
+├── tsconfig.lib.json
+├── README.md
+└── CLAUDE.md                 # This file
+```
+
+## Core Components
+
+### 1. Type System (types.ts)
+
+Defines the complete type structure for configuration management:
+
+```typescript
+// Critical: Object format for denied servers
+interface DeniedMcpServer {
+  serverName: string;
+}
+
+// Local project configuration
+interface SettingsLocal {
+  permissions?: {
+    allow?: string[];
+    deny?: string[];
+    ask?: string[];
+  };
+  deniedMcpServers?: DeniedMcpServer[];
+}
+
+// Global configuration structure
+interface ClaudeConfig {
+  mcpServers?: Record<string, McpServerConfig>;
+  projects?: Record<string, ProjectConfig>;
+}
+
+// Project-local MCP configuration (.mcp.json)
+interface McpConfig {
+  mcpServers?: Record<string, McpServerConfig>;
+}
+
+// Server status tracking
+interface ServerStatus {
+  name: string;
+  enabled: boolean;
+  source: 'local' | 'global' | 'none';
+}
+```
+
+### 2. Configuration Reader (reader.ts)
+
+Implements the multi-source configuration discovery and status determination:
+
+**Key Functions**:
+
+- `readGlobalConfig()`: Reads `~/.claude.json`
+- `readLocalConfig()`: Reads `./.claude/settings.local.json`
+- `readMcpJsonConfig()`: Reads `./.mcp.json` (NEW)
+- `getAvailableServers()`: Returns all server names from all three sources (UPDATED)
+- `getServerStatus(name)`: Determines if server is enabled and why
+- `getAllServerStatuses()`: Returns status for all servers
+- `hasMcpServers()`: Checks if any MCP servers are configured
+
+**Server Discovery Logic**:
+
+```typescript
+export function getAvailableServers(): string[] {
+  const servers = new Set<string>();
+  const cwd = process.cwd();
+
+  // 1. Global MCP servers from ~/.claude.json
+  const globalConfig = readGlobalConfig();
+  if (globalConfig.mcpServers) {
+    Object.keys(globalConfig.mcpServers).forEach((name) => servers.add(name));
+  }
+
+  // 2. Project-specific from ~/.claude.json projects[cwd].mcpServers
+  if (globalConfig.projects?.[cwd]?.mcpServers) {
+    Object.keys(globalConfig.projects[cwd].mcpServers!).forEach((name) =>
+      servers.add(name)
+    );
+  }
+
+  // 3. Project-local from ./.mcp.json
+  const mcpConfig = readMcpJsonConfig();
+  if (mcpConfig.mcpServers) {
+    Object.keys(mcpConfig.mcpServers).forEach((name) => servers.add(name));
+  }
+
+  return Array.from(servers).sort();
+}
+```
+
+**Priority Logic**:
+
+```typescript
+export function getServerStatus(serverName: string): ServerStatus {
+  // 1. Check local config first (highest priority)
+  if (isServerDeniedLocally(serverName)) {
+    return { name: serverName, enabled: false, source: 'local' };
+  }
+
+  // 2. Check global config for current project
+  if (isServerDisabledGlobally(serverName)) {
+    return { name: serverName, enabled: false, source: 'global' };
+  }
+
+  // 3. Default: enabled
+  return { name: serverName, enabled: true, source: 'none' };
+}
+```
+
+### 3. Configuration Writer (writer.ts)
+
+Handles writing changes to local configuration:
+
+**Key Function**:
+
+```typescript
+export function updateLocalConfig(deniedServers: string[]): void {
+  const configPath = path.join(process.cwd(), '.claude', 'settings.local.json');
+
+  // Load existing config or create new
+  let config: SettingsLocal = {};
+  if (existsSync(configPath)) {
+    config = JSON.parse(readFileSync(configPath, 'utf-8'));
+  }
+
+  // CRITICAL: Convert to object format
+  config.deniedMcpServers = deniedServers.map(
+    (serverName): DeniedMcpServer => ({ serverName })
+  );
+
+  // Write with formatting
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+}
+```
+
+**Important**: Always converts server names to object format when writing.
+
+### 4. Commands
+
+#### list.ts - List Command
+
+Displays all servers with their status:
+
+```
+✓ Enabled Servers:
+  ✓ github
+  ✓ linear
+  ✓ notion
+
+✗ Disabled Servers:
+  ✗ chrome-devtools (local)
+  ✗ claude-historian (global)
+
+3 enabled, 2 disabled
+```
+
+#### enable.ts - Enable Command
+
+Removes servers from `deniedMcpServers`:
+
+```bash
+mcp-config enable chrome-devtools linear
+```
+
+#### disable.ts - Disable Command
+
+Adds servers to `deniedMcpServers`:
+
+```bash
+mcp-config disable chrome-devtools claude-historian
+```
+
+#### status.ts - Status Command
+
+Shows detailed configuration information including paths and server definitions.
+
+#### interactive.ts - Interactive Mode
+
+**Most Important Command**: Provides multi-select interface using enquirer.
+
+**Key Implementation Detail**:
+
+```typescript
+import { prompt } from 'enquirer';
+
+const response = await prompt({
+  type: 'multiselect',
+  name: 'servers',
+  message: 'Select MCP servers to enable',
+  choices: servers.map((name) => ({
+    name: name + colorize(hint, 'gray'),
+    value: name,
+    enabled: currentlyEnabled.includes(name), // Pre-select enabled servers
+  })),
+  hint: 'Use <space> to select, <a> to toggle all, <return> to submit',
+});
+
+// Calculate denied servers (those NOT selected)
+const deniedServers = servers.filter((s) => !response.servers.includes(s));
+
+// Update configuration
+updateLocalConfig(deniedServers);
+```
+
+**User Experience**:
+
+- Pre-selects currently enabled servers
+- Shows disabled servers with source indicator
+- Supports 'a' key to toggle all
+- Calculates deniedMcpServers as inverse of selection
+
+### 5. Display Utilities (display.ts)
+
+Provides colorized console output:
+
+```typescript
+export function colorize(
+  text: string,
+  style: 'green' | 'red' | 'yellow' | 'gray' | 'bold'
+): string {
+  const colors = {
+    green: '\x1b[32m',
+    red: '\x1b[31m',
+    yellow: '\x1b[33m',
+    gray: '\x1b[90m',
+    bold: '\x1b[1m',
+    reset: '\x1b[0m',
+  };
+  return `${colors[style]}${text}${colors.reset}`;
+}
+```
+
+## CLI Entry Point (index.ts)
+
+Routes commands to appropriate handlers:
+
+```typescript
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const command = args[0];
+
+  switch (command) {
+    case undefined:
+    case 'interactive':
+      await interactiveCommand();
+      break;
+
+    case 'list':
+      listCommand();
+      break;
+
+    case 'enable':
+      enableCommand(args.slice(1));
+      break;
+
+    case 'disable':
+      disableCommand(args.slice(1));
+      break;
+
+    case 'status':
+      statusCommand();
+      break;
+
+    case 'help':
+    case '--help':
+    case '-h':
+      displayHelp();
+      break;
+
+    default:
+      displayError(`Unknown command: ${command}`);
+      displayHelp();
+      process.exit(1);
+  }
+}
+```
+
+**Note**: No shebang in source file - esbuild adds it via banner configuration.
+
+## Build Configuration
+
+### package.json
+
+Key configuration for building executable CLI:
+
+```json
+{
+  "type": "commonjs",
+  "bin": {
+    "mcp-config": "./dist/mcp-config.cjs"
+  },
+  "scripts": {
+    "postbuild": "chmod +x dist/mcp-config.cjs"
+  },
+  "nx": {
+    "targets": {
+      "build": {
+        "executor": "@nx/esbuild:esbuild",
+        "options": {
+          "format": ["cjs"],
+          "outputFileName": "mcp-config.cjs",
+          "bundle": true,
+          "thirdParty": true,
+          "platform": "node",
+          "target": "node18",
+          "esbuildOptions": {
+            "banner": {
+              "js": "#!/usr/bin/env node"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Critical Points**:
+
+- CommonJS format for Node.js compatibility
+- Bundles all dependencies (including enquirer)
+- Adds shebang via esbuild banner (NOT in source file)
+- postbuild script makes output executable
+
+### Building
+
+```bash
+npx nx build mcp-config
+# Output: packages/mcp-config/dist/mcp-config.cjs
+```
+
+## Installation and Usage
+
+### Shell Alias Setup
+
+The tool is designed to be used via shell alias:
+
+**Bash/Zsh** (`~/.bashrc` or `~/.zshrc`):
+
+```bash
+alias mcp-config="/absolute/path/to/ai-toolkit/packages/mcp-config/dist/mcp-config.cjs"
+```
+
+**Fish** (`~/.config/fish/config.fish`):
+
+```fish
+alias mcp-config="/absolute/path/to/ai-toolkit/packages/mcp-config/dist/mcp-config.cjs"
+```
+
+After adding alias, reload shell:
+
+```bash
+source ~/.zshrc  # or ~/.bashrc or ~/.config/fish/config.fish
+```
+
+### Command Usage
+
+```bash
+# Interactive mode (recommended)
+mcp-config
+
+# List all servers
+mcp-config list
+
+# Enable servers
+mcp-config enable github linear
+
+# Disable servers
+mcp-config disable chrome-devtools
+
+# Show detailed status
+mcp-config status
+
+# Show help
+mcp-config help
+```
+
+## Dependencies
+
+### Runtime
+
+- `enquirer` (^2.4.1): Interactive prompts with multi-select support
+
+### Development
+
+- `@types/node` (^24.10.0): TypeScript types for Node.js APIs
+
+### Built-in Modules
+
+- `fs`: File system operations
+- `path`: Path manipulation
+- `os`: Operating system utilities (homedir)
+
+## Error Handling
+
+### No MCP Servers Configured
+
+When `~/.claude.json` doesn't contain `mcpServers`:
+
+```
+⚠ No MCP servers configured.
+
+To configure MCP servers, add them to ~/.claude.json:
+
+{
+  "mcpServers": {
+    "server-name": {
+      "command": "npx",
+      "args": ["-y", "package@latest"]
+    }
+  }
+}
+```
+
+### Permission Errors
+
+If executable permissions are missing:
+
+```bash
+chmod +x packages/mcp-config/dist/mcp-config.cjs
+```
+
+### Configuration Read Errors
+
+- Validates JSON syntax
+- Provides clear error messages
+- Gracefully handles missing files (creates if needed)
+
+## Testing Checklist
+
+### Manual Testing
+
+1. **List Command**: Verify server status display
+2. **Enable Command**: Remove from deniedMcpServers
+3. **Disable Command**: Add to deniedMcpServers (as objects)
+4. **Interactive Mode**: Multi-select interface with pre-selection
+5. **Status Command**: Show detailed configuration
+6. **Help Command**: Display usage information
+7. **Edge Cases**:
+   - No MCP servers configured
+   - Empty deniedMcpServers
+   - Non-existent local config
+   - Invalid JSON in configs
+
+### Automated Testing (Future)
+
+Unit tests should cover:
+
+- Configuration reading priority logic
+- Object format conversion in writer
+- Server status determination
+- CLI argument parsing
+- Error handling scenarios
+
+## Development Notes
+
+### Critical Implementation Details
+
+1. **Object Format**: `deniedMcpServers` MUST be array of objects, not strings
+2. **No Shebang in Source**: esbuild adds shebang - source file should not have one
+3. **enquirer Import**: Use `prompt` function, not `MultiSelect` class
+4. **Configuration Priority**: Local ALWAYS overrides global
+5. **Inverse Selection**: Interactive mode calculates denied as NOT selected
+
+### Common Pitfalls
+
+1. **Duplicate Shebang**: Don't add shebang to source file when esbuild banner adds one
+2. **enquirer Import Error**: Module doesn't export `MultiSelect` class directly
+3. **String vs Object Format**: deniedMcpServers must be objects, not strings
+4. **Working Directory**: Commands should run from project root, not package directory
+
+### Adding New Features
+
+To extend the tool:
+
+1. Add new command file in `src/commands/`
+2. Update command router in `src/index.ts`
+3. Add command to help text
+4. Update README.md with usage examples
+5. Update this CLAUDE.md with implementation details
+6. Consider adding tests
+
+## Integration with Claude Code
+
+### How Claude Code Uses Configuration
+
+Claude Code reads configuration in this order:
+
+1. Local `.claude/settings.local.json` (per-project)
+2. Global `~/.claude.json` (user-wide)
+3. Built-in defaults
+
+The `deniedMcpServers` array in local config is the primary mechanism for project-specific server management.
+
+### Restarting Claude Code
+
+After making configuration changes with mcp-config:
+
+1. Save the configuration
+2. Restart Claude Code for changes to take effect
+3. Verify with Claude's MCP server list
+
+## Future Enhancements
+
+Potential improvements:
+
+1. **Validation**: Verify server names exist before adding to denied list
+2. **Bulk Operations**: Enable/disable by category or pattern
+3. **History**: Track configuration changes
+4. **Export/Import**: Share configurations across projects
+5. **Server Info**: Show server details (command, args, env vars)
+6. **Configuration Templates**: Pre-configured setups for common use cases
+7. **Tests**: Comprehensive unit and integration tests
+
+## Maintenance Requirements
+
+⚠️ **IMPORTANT**: This CLAUDE.md file must be updated whenever:
+
+- Command functionality changes
+- Configuration format changes
+- New commands are added
+- Error handling improves
+- Build configuration changes
+- Dependencies are updated
+- Integration patterns change
+
+This documentation serves as the source of truth for AI assistants working with the mcp-config package.
+
+## Related Documentation
+
+- **README.md**: User-facing documentation with setup and usage instructions
+- **packages/ai-toolkit-nx-claude/CLAUDE.md**: Context on how this fits in the broader AI Toolkit
+- **Claude Code Documentation**: Official docs for MCP server configuration
+
+## Package Status
+
+**Current Status**: Complete and published
+
+- All core commands implemented and tested
+- Build process working correctly
+- Documentation complete
+- Published to npm as `@uniswap/ai-toolkit-claude-mcp-helper`
+- Integrated into automated publishing workflow
+
+**Not Implemented**:
+
+- Automated tests
+- Advanced features (validation, templates, etc.)

--- a/packages/mcp-config/README.md
+++ b/packages/mcp-config/README.md
@@ -1,0 +1,351 @@
+# MCP Config
+
+**Package**: `@uniswap/ai-toolkit-claude-mcp-helper`
+
+A standalone CLI tool to manage MCP (Model Context Protocol) servers for Claude Code workspaces.
+
+## Features
+
+- 📋 **List** all MCP servers with their enabled/disabled status
+- ✅ **Enable/Disable** servers individually or in bulk
+- 📊 **Status** view with detailed information
+- 🎯 **Interactive mode** with multi-select interface
+- 🔄 **Smart configuration** - local `.claude/settings.local.json` overrides global `~/.claude.json`
+- 🎨 **Colorized output** for better readability
+
+## Installation
+
+### Via npm (Recommended)
+
+Install globally for easy access from anywhere:
+
+```bash
+npm install -g @uniswap/ai-toolkit-claude-mcp-helper
+```
+
+Or use via npx without installation:
+
+```bash
+npx @uniswap/ai-toolkit-claude-mcp-helper list
+```
+
+### Build from Source
+
+If you're developing or contributing to this package:
+
+```bash
+# From the ai-toolkit monorepo root
+npx nx build mcp-config
+
+# The executable will be at: packages/mcp-config/dist/mcp-config.cjs
+```
+
+### Set Up Shell Alias (Development)
+
+Add an alias to your shell configuration for easy access from anywhere:
+
+#### Bash (~/.bashrc or ~/.bash_profile)
+
+```bash
+alias mcp-config="/absolute/path/to/ai-toolkit/packages/mcp-config/dist/mcp-config.cjs"
+```
+
+#### Zsh (~/.zshrc)
+
+```bash
+alias mcp-config="/absolute/path/to/ai-toolkit/packages/mcp-config/dist/mcp-config.cjs"
+```
+
+#### Fish (~/.config/fish/config.fish)
+
+```fish
+alias mcp-config="/absolute/path/to/ai-toolkit/packages/mcp-config/dist/mcp-config.cjs"
+```
+
+After adding the alias, reload your shell configuration:
+
+```bash
+# Bash/Zsh
+source ~/.zshrc  # or ~/.bashrc
+
+# Fish
+source ~/.config/fish/config.fish
+```
+
+## Usage
+
+### Interactive Mode (Recommended)
+
+Simply run `mcp-config` without arguments to enter interactive mode:
+
+```bash
+mcp-config
+```
+
+This will show a multi-select interface where you can:
+
+- Use ↑/↓ arrows to navigate
+- Press Space to toggle selection
+- Press 'a' to toggle all
+- Press Enter to save
+
+### List Servers
+
+View all MCP servers and their status:
+
+```bash
+mcp-config list
+```
+
+Output example:
+
+```text
+✓ Enabled Servers:
+  ✓ github
+  ✓ linear
+  ✓ notion
+
+✗ Disabled Servers:
+  ✗ chrome-devtools (local)
+  ✗ claude-historian (global)
+
+3 enabled, 2 disabled
+```
+
+### Enable Servers
+
+Enable one or more servers:
+
+```bash
+# Enable single server
+mcp-config enable github
+
+# Enable multiple servers
+mcp-config enable github linear notion
+```
+
+### Disable Servers
+
+Disable one or more servers:
+
+```bash
+# Disable single server
+mcp-config disable chrome-devtools
+
+# Disable multiple servers
+mcp-config disable chrome-devtools claude-historian
+```
+
+### Detailed Status
+
+Show comprehensive status information:
+
+```bash
+mcp-config status
+```
+
+## Configuration
+
+### How It Works
+
+MCP Config discovers MCP servers from multiple sources and manages their enabled/disabled state:
+
+#### MCP Server Sources
+
+1. **Global Config** (`~/.claude.json`)
+
+   - User-wide MCP server definitions in `mcpServers` object
+   - Accessible across all projects
+
+2. **Project-Specific Config** (`~/.claude.json` → `projects[cwd].mcpServers`)
+
+   - Project-specific MCP server definitions within global config
+   - Scoped to specific working directories
+
+3. **Project-Local Config** (`./.mcp.json`)
+   - Project-committed MCP server definitions
+   - Allows teams to share configurations via version control
+
+#### Enabled/Disabled State
+
+**Local Settings** (`./.claude/settings.local.json`)
+
+- Project-specific settings that control which discovered servers are enabled/disabled
+- `deniedMcpServers` array lists disabled servers
+- **Takes precedence over all server sources**
+
+### Configuration Priority
+
+- Servers are discovered from all three sources (global, project-specific, and .mcp.json)
+- Local settings in `.claude/settings.local.json` control enabled/disabled state
+- If a server is in `deniedMcpServers`, it's disabled regardless of where it was discovered
+- If a server is not in `deniedMcpServers`, it's enabled by default
+
+### DeniedMcpServers Format
+
+The `deniedMcpServers` array uses an **object format**:
+
+```json
+{
+  "deniedMcpServers": [
+    { "serverName": "chrome-devtools" },
+    { "serverName": "claude-historian" }
+  ]
+}
+```
+
+## Examples
+
+### Scenario: Disable a Server Locally
+
+You want to disable `chrome-devtools` only in the current project:
+
+```bash
+cd /path/to/your/project
+mcp-config disable chrome-devtools
+```
+
+This adds the server to `./.claude/settings.local.json`:
+
+```json
+{
+  "deniedMcpServers": [{ "serverName": "chrome-devtools" }]
+}
+```
+
+### Scenario: Enable All Servers in Project
+
+```bash
+mcp-config interactive
+# Select all servers (press 'a')
+# Press Enter to save
+```
+
+This removes all entries from `./.claude/settings.local.json.deniedMcpServers`.
+
+### Scenario: Share Team MCP Servers via .mcp.json
+
+Create a `.mcp.json` file in your project root to share MCP server configurations with your team:
+
+```json
+{
+  "mcpServers": {
+    "team-tool": {
+      "command": "npx",
+      "args": ["-y", "@your-org/team-mcp-server@latest"]
+    },
+    "project-specific": {
+      "command": "node",
+      "args": ["./scripts/mcp-server.js"]
+    }
+  }
+}
+```
+
+Commit this file to version control. Team members running `mcp-config` will see these servers alongside their personal global servers.
+
+### Scenario: Check What's Enabled
+
+```bash
+mcp-config list
+```
+
+Shows:
+
+- ✓ for enabled servers
+- ✗ for disabled servers
+- (local) or (global) indicator for disabled servers
+
+## Development
+
+### Project Structure
+
+```text
+packages/mcp-config/
+├── src/
+│   ├── index.ts              # CLI entry point
+│   ├── commands/
+│   │   ├── list.ts           # List command
+│   │   ├── enable.ts         # Enable command
+│   │   ├── disable.ts        # Disable command
+│   │   ├── status.ts         # Status command
+│   │   └── interactive.ts    # Interactive mode
+│   ├── config/
+│   │   ├── types.ts          # TypeScript interfaces
+│   │   ├── reader.ts         # Config reading logic
+│   │   └── writer.ts         # Config writing logic
+│   └── utils/
+│       └── display.ts        # Console output formatting
+├── package.json
+├── tsconfig.json
+└── README.md
+```
+
+### Building
+
+```bash
+npx nx build mcp-config
+```
+
+The build process:
+
+1. Compiles TypeScript to CommonJS
+2. Bundles all dependencies with esbuild
+3. Adds shebang (`#!/usr/bin/env node`)
+4. Makes output executable via postbuild script
+
+### Testing Locally
+
+```bash
+# Build
+npx nx build mcp-config
+
+# Run directly
+packages/mcp-config/dist/mcp-config.cjs list
+
+# Or use alias after setting it up
+mcp-config list
+```
+
+## Troubleshooting
+
+### "No MCP servers configured"
+
+This means your `~/.claude.json` doesn't have any `mcpServers` defined.
+
+**Solution**: Add MCP servers to your global config:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"]
+    },
+    "linear": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-linear"]
+    }
+  }
+}
+```
+
+### Changes Not Taking Effect
+
+Make sure you:
+
+1. Saved the configuration
+2. Restarted Claude Code
+3. Are in the correct directory (for local configs)
+
+### Permission Denied
+
+If you get permission errors when running the tool:
+
+```bash
+chmod +x packages/mcp-config/dist/mcp-config.cjs
+```
+
+## License
+
+Part of the AI Toolkit monorepo.

--- a/packages/mcp-config/jest.config.ts
+++ b/packages/mcp-config/jest.config.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config for the spec files
+const swcJestConfig = JSON.parse(
+  readFileSync(`${__dirname}/.spec.swcrc`, 'utf-8')
+);
+
+// Disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves
+swcJestConfig.swcrc = false;
+
+export default {
+  displayName: '@ai-toolkit/mcp-config',
+  preset: '../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: 'test-output/jest/coverage',
+  passWithNoTests: true,
+};

--- a/packages/mcp-config/package.json
+++ b/packages/mcp-config/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@uniswap/ai-toolkit-claude-mcp-helper",
+  "version": "1.0.0",
+  "private": false,
+  "description": "CLI tool for managing MCP servers in Claude Code workspaces",
+  "keywords": [
+    "claude-code",
+    "mcp",
+    "model-context-protocol",
+    "cli",
+    "uniswap",
+    "ai-toolkit"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/uniswap/ai-toolkit.git",
+    "directory": "packages/mcp-config"
+  },
+  "publishConfig": {
+    "access": "restricted"
+  },
+  "type": "commonjs",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "mcp-config": "./dist/mcp-config.cjs"
+  },
+  "files": [
+    "dist",
+    "!**/*.tsbuildinfo"
+  ],
+  "scripts": {
+    "postbuild": "chmod +x dist/mcp-config.cjs"
+  },
+  "nx": {
+    "targets": {
+      "build": {
+        "executor": "@nx/esbuild:esbuild",
+        "outputs": [
+          "{options.outputPath}"
+        ],
+        "options": {
+          "outputPath": "packages/mcp-config/dist",
+          "main": "packages/mcp-config/src/index.ts",
+          "tsConfig": "packages/mcp-config/tsconfig.lib.json",
+          "format": [
+            "cjs"
+          ],
+          "outputFileName": "mcp-config.cjs",
+          "bundle": true,
+          "thirdParty": true,
+          "platform": "node",
+          "target": "node18",
+          "generatePackageJson": false,
+          "esbuildOptions": {
+            "banner": {
+              "js": "#!/usr/bin/env node"
+            }
+          }
+        }
+      }
+    }
+  },
+  "dependencies": {
+    "enquirer": "^2.4.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.10.0",
+    "memfs": "^4.14.0"
+  }
+}

--- a/packages/mcp-config/src/commands/disable.spec.ts
+++ b/packages/mcp-config/src/commands/disable.spec.ts
@@ -1,0 +1,168 @@
+import { disableCommand } from './disable';
+import * as reader from '../config/reader';
+import * as writer from '../config/writer';
+import * as display from '../utils/display';
+
+jest.mock('../config/reader');
+jest.mock('../config/writer');
+jest.mock('../utils/display');
+
+describe('disable command', () => {
+  let consoleLogSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  it('should display error when no server names provided', () => {
+    disableCommand([]);
+
+    expect(display.displayError).toHaveBeenCalledWith(
+      'Please specify at least one server name to disable.'
+    );
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Usage: mcp-config disable')
+    );
+  });
+
+  it('should display error when server is not configured', () => {
+    jest
+      .spyOn(reader, 'getAvailableServers')
+      .mockReturnValue(['github', 'linear']);
+
+    disableCommand(['nonexistent']);
+
+    expect(display.displayError).toHaveBeenCalledWith(
+      'Server "nonexistent" is not configured.'
+    );
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Available servers: github, linear')
+    );
+  });
+
+  it('should display warning when server is already disabled', () => {
+    jest.spyOn(reader, 'getAvailableServers').mockReturnValue(['github']);
+    jest.spyOn(reader, 'getServerStatus').mockReturnValue({
+      name: 'github',
+      enabled: false,
+      source: 'local',
+    });
+
+    disableCommand(['github']);
+
+    expect(display.displayWarning).toHaveBeenCalledWith(
+      'Server "github" is already disabled.'
+    );
+    expect(writer.disableServer).not.toHaveBeenCalled();
+  });
+
+  it('should disable an enabled server successfully', () => {
+    jest.spyOn(reader, 'getAvailableServers').mockReturnValue(['github']);
+    jest.spyOn(reader, 'getServerStatus').mockReturnValue({
+      name: 'github',
+      enabled: true,
+      source: 'none',
+    });
+    jest.spyOn(writer, 'disableServer').mockImplementation();
+
+    disableCommand(['github']);
+
+    expect(writer.disableServer).toHaveBeenCalledWith('github');
+    expect(display.displaySuccess).toHaveBeenCalledWith(
+      'Disabled server "github".'
+    );
+  });
+
+  it('should disable multiple servers', () => {
+    jest
+      .spyOn(reader, 'getAvailableServers')
+      .mockReturnValue(['github', 'linear', 'notion']);
+    jest
+      .spyOn(reader, 'getServerStatus')
+      .mockImplementation((name: string) => ({
+        name,
+        enabled: true,
+        source: 'none',
+      }));
+    jest.spyOn(writer, 'disableServer').mockImplementation();
+
+    disableCommand(['github', 'linear']);
+
+    expect(writer.disableServer).toHaveBeenCalledWith('github');
+    expect(writer.disableServer).toHaveBeenCalledWith('linear');
+    expect(display.displaySuccess).toHaveBeenCalledTimes(2);
+  });
+
+  it('should handle errors when disabling a server', () => {
+    jest.spyOn(reader, 'getAvailableServers').mockReturnValue(['github']);
+    jest.spyOn(reader, 'getServerStatus').mockReturnValue({
+      name: 'github',
+      enabled: true,
+      source: 'none',
+    });
+    jest
+      .spyOn(writer, 'disableServer')
+      .mockImplementation(() => {
+        throw new Error('Write failed');
+      });
+
+    disableCommand(['github']);
+
+    expect(display.displayError).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to disable "github"')
+    );
+  });
+
+  it('should continue disabling other servers if one fails', () => {
+    jest
+      .spyOn(reader, 'getAvailableServers')
+      .mockReturnValue(['github', 'linear']);
+    jest
+      .spyOn(reader, 'getServerStatus')
+      .mockImplementation((name: string) => ({
+        name,
+        enabled: true,
+        source: 'none',
+      }));
+    jest
+      .spyOn(writer, 'disableServer')
+      .mockImplementationOnce(() => {
+        throw new Error('Write failed');
+      })
+      .mockImplementationOnce(() => {
+        // Second call succeeds
+      });
+
+    disableCommand(['github', 'linear']);
+
+    expect(writer.disableServer).toHaveBeenCalledWith('github');
+    expect(writer.disableServer).toHaveBeenCalledWith('linear');
+    expect(display.displayError).toHaveBeenCalledTimes(1);
+    expect(display.displaySuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('should skip non-configured servers and continue with others', () => {
+    jest.spyOn(reader, 'getAvailableServers').mockReturnValue(['github']);
+    jest.spyOn(reader, 'getServerStatus').mockReturnValue({
+      name: 'github',
+      enabled: true,
+      source: 'none',
+    });
+    jest.spyOn(writer, 'disableServer').mockImplementation();
+
+    disableCommand(['nonexistent', 'github']);
+
+    expect(display.displayError).toHaveBeenCalledWith(
+      'Server "nonexistent" is not configured.'
+    );
+    expect(writer.disableServer).toHaveBeenCalledWith('github');
+    expect(display.displaySuccess).toHaveBeenCalledWith(
+      'Disabled server "github".'
+    );
+  });
+});

--- a/packages/mcp-config/src/commands/disable.ts
+++ b/packages/mcp-config/src/commands/disable.ts
@@ -1,0 +1,41 @@
+import { getAvailableServers, getServerStatus } from '../config/reader';
+import { disableServer } from '../config/writer';
+import { displaySuccess, displayError, displayWarning } from '../utils/display';
+
+/**
+ * Disable one or more MCP servers
+ */
+export function disableCommand(serverNames: string[]): void {
+  if (serverNames.length === 0) {
+    displayError('Please specify at least one server name to disable.');
+    console.log('\nUsage: mcp-config disable <server-name> [<server-name>...]');
+    console.log('Example: mcp-config disable github supabase\n');
+    return;
+  }
+
+  const availableServers = getAvailableServers();
+
+  for (const serverName of serverNames) {
+    if (!availableServers.includes(serverName)) {
+      displayError(`Server "${serverName}" is not configured.`);
+      console.log(
+        `\nAvailable servers: ${availableServers.join(', ') || 'none'}\n`
+      );
+      continue;
+    }
+
+    const status = getServerStatus(serverName);
+
+    if (!status.enabled) {
+      displayWarning(`Server "${serverName}" is already disabled.`);
+      continue;
+    }
+
+    try {
+      disableServer(serverName);
+      displaySuccess(`Disabled server "${serverName}".`);
+    } catch (error) {
+      displayError(`Failed to disable "${serverName}": ${error}`);
+    }
+  }
+}

--- a/packages/mcp-config/src/commands/enable.spec.ts
+++ b/packages/mcp-config/src/commands/enable.spec.ts
@@ -1,0 +1,168 @@
+import { enableCommand } from './enable';
+import * as reader from '../config/reader';
+import * as writer from '../config/writer';
+import * as display from '../utils/display';
+
+jest.mock('../config/reader');
+jest.mock('../config/writer');
+jest.mock('../utils/display');
+
+describe('enable command', () => {
+  let consoleLogSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  it('should display error when no server names provided', () => {
+    enableCommand([]);
+
+    expect(display.displayError).toHaveBeenCalledWith(
+      'Please specify at least one server name to enable.'
+    );
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Usage: mcp-config enable')
+    );
+  });
+
+  it('should display error when server is not configured', () => {
+    jest
+      .spyOn(reader, 'getAvailableServers')
+      .mockReturnValue(['github', 'linear']);
+
+    enableCommand(['nonexistent']);
+
+    expect(display.displayError).toHaveBeenCalledWith(
+      'Server "nonexistent" is not configured.'
+    );
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Available servers: github, linear')
+    );
+  });
+
+  it('should display warning when server is already enabled', () => {
+    jest.spyOn(reader, 'getAvailableServers').mockReturnValue(['github']);
+    jest.spyOn(reader, 'getServerStatus').mockReturnValue({
+      name: 'github',
+      enabled: true,
+      source: 'none',
+    });
+
+    enableCommand(['github']);
+
+    expect(display.displayWarning).toHaveBeenCalledWith(
+      'Server "github" is already enabled.'
+    );
+    expect(writer.enableServer).not.toHaveBeenCalled();
+  });
+
+  it('should enable a disabled server successfully', () => {
+    jest.spyOn(reader, 'getAvailableServers').mockReturnValue(['github']);
+    jest.spyOn(reader, 'getServerStatus').mockReturnValue({
+      name: 'github',
+      enabled: false,
+      source: 'local',
+    });
+    jest.spyOn(writer, 'enableServer').mockImplementation();
+
+    enableCommand(['github']);
+
+    expect(writer.enableServer).toHaveBeenCalledWith('github');
+    expect(display.displaySuccess).toHaveBeenCalledWith(
+      'Enabled server "github".'
+    );
+  });
+
+  it('should enable multiple servers', () => {
+    jest
+      .spyOn(reader, 'getAvailableServers')
+      .mockReturnValue(['github', 'linear', 'notion']);
+    jest
+      .spyOn(reader, 'getServerStatus')
+      .mockImplementation((name: string) => ({
+        name,
+        enabled: false,
+        source: 'local',
+      }));
+    jest.spyOn(writer, 'enableServer').mockImplementation();
+
+    enableCommand(['github', 'linear']);
+
+    expect(writer.enableServer).toHaveBeenCalledWith('github');
+    expect(writer.enableServer).toHaveBeenCalledWith('linear');
+    expect(display.displaySuccess).toHaveBeenCalledTimes(2);
+  });
+
+  it('should handle errors when enabling a server', () => {
+    jest.spyOn(reader, 'getAvailableServers').mockReturnValue(['github']);
+    jest.spyOn(reader, 'getServerStatus').mockReturnValue({
+      name: 'github',
+      enabled: false,
+      source: 'local',
+    });
+    jest
+      .spyOn(writer, 'enableServer')
+      .mockImplementation(() => {
+        throw new Error('Write failed');
+      });
+
+    enableCommand(['github']);
+
+    expect(display.displayError).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to enable "github"')
+    );
+  });
+
+  it('should continue enabling other servers if one fails', () => {
+    jest
+      .spyOn(reader, 'getAvailableServers')
+      .mockReturnValue(['github', 'linear']);
+    jest
+      .spyOn(reader, 'getServerStatus')
+      .mockImplementation((name: string) => ({
+        name,
+        enabled: false,
+        source: 'local',
+      }));
+    jest
+      .spyOn(writer, 'enableServer')
+      .mockImplementationOnce(() => {
+        throw new Error('Write failed');
+      })
+      .mockImplementationOnce(() => {
+        // Second call succeeds
+      });
+
+    enableCommand(['github', 'linear']);
+
+    expect(writer.enableServer).toHaveBeenCalledWith('github');
+    expect(writer.enableServer).toHaveBeenCalledWith('linear');
+    expect(display.displayError).toHaveBeenCalledTimes(1);
+    expect(display.displaySuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('should skip non-configured servers and continue with others', () => {
+    jest.spyOn(reader, 'getAvailableServers').mockReturnValue(['github']);
+    jest.spyOn(reader, 'getServerStatus').mockReturnValue({
+      name: 'github',
+      enabled: false,
+      source: 'local',
+    });
+    jest.spyOn(writer, 'enableServer').mockImplementation();
+
+    enableCommand(['nonexistent', 'github']);
+
+    expect(display.displayError).toHaveBeenCalledWith(
+      'Server "nonexistent" is not configured.'
+    );
+    expect(writer.enableServer).toHaveBeenCalledWith('github');
+    expect(display.displaySuccess).toHaveBeenCalledWith(
+      'Enabled server "github".'
+    );
+  });
+});

--- a/packages/mcp-config/src/commands/enable.ts
+++ b/packages/mcp-config/src/commands/enable.ts
@@ -1,0 +1,41 @@
+import { getAvailableServers, getServerStatus } from '../config/reader';
+import { enableServer } from '../config/writer';
+import { displaySuccess, displayError, displayWarning } from '../utils/display';
+
+/**
+ * Enable one or more MCP servers
+ */
+export function enableCommand(serverNames: string[]): void {
+  if (serverNames.length === 0) {
+    displayError('Please specify at least one server name to enable.');
+    console.log('\nUsage: mcp-config enable <server-name> [<server-name>...]');
+    console.log('Example: mcp-config enable github supabase\n');
+    return;
+  }
+
+  const availableServers = getAvailableServers();
+
+  for (const serverName of serverNames) {
+    if (!availableServers.includes(serverName)) {
+      displayError(`Server "${serverName}" is not configured.`);
+      console.log(
+        `\nAvailable servers: ${availableServers.join(', ') || 'none'}\n`
+      );
+      continue;
+    }
+
+    const status = getServerStatus(serverName);
+
+    if (status.enabled) {
+      displayWarning(`Server "${serverName}" is already enabled.`);
+      continue;
+    }
+
+    try {
+      enableServer(serverName);
+      displaySuccess(`Enabled server "${serverName}".`);
+    } catch (error) {
+      displayError(`Failed to enable "${serverName}": ${error}`);
+    }
+  }
+}

--- a/packages/mcp-config/src/commands/interactive.ts
+++ b/packages/mcp-config/src/commands/interactive.ts
@@ -1,0 +1,138 @@
+// @ts-expect-error - enquirer doesn't have proper TypeScript exports
+import { MultiSelect } from 'enquirer';
+import {
+  getAllServerStatuses,
+  getAvailableServers,
+  hasMcpServers,
+} from '../config/reader';
+import { updateLocalConfig } from '../config/writer';
+import {
+  displaySuccess,
+  displayError,
+  displayWarning,
+  colorize,
+} from '../utils/display';
+
+/**
+ * Interactive mode with multi-select to enable/disable servers
+ */
+export async function interactiveCommand(): Promise<void> {
+  if (!hasMcpServers()) {
+    displayWarning('No MCP servers configured.');
+    console.log('\nTo configure MCP servers, add them to ~/.claude.json:\n');
+    console.log('{');
+    console.log('  "mcpServers": {');
+    console.log('    "server-name": {');
+    console.log('      "command": "npx",');
+    console.log('      "args": ["-y", "package@latest"]');
+    console.log('    }');
+    console.log('  }');
+    console.log('}\n');
+    return;
+  }
+
+  const servers = getAvailableServers();
+  const statuses = getAllServerStatuses();
+
+  console.log(colorize('\nMCP Server Configuration', 'bold'));
+  console.log(
+    'Here is a list of all MCP servers available to you in this working directory.'
+  );
+  console.log(
+    'Please select the servers you want enabled in this workspace, and unselect'
+  );
+  console.log('the ones you want to be disabled.\n');
+  console.log(
+    colorize(
+      'Narrowing enabled MCP servers saves tokens in the context window',
+      'gray'
+    )
+  );
+  console.log(
+    colorize(
+      'of each Claude Code chat, potentially improving your experience.\n',
+      'gray'
+    )
+  );
+  console.log(
+    colorize('Use ↑↓ to navigate, space to toggle, enter to save\n', 'gray')
+  );
+
+  try {
+    const choices = servers.map((name) => {
+      const status = statuses.find((s) => s.name === name);
+      const isEnabled = status?.enabled ?? true;
+
+      let hint = '';
+      if (isEnabled) {
+        hint = 'currently enabled';
+      } else if (status?.source === 'local') {
+        hint = 'disabled locally';
+      } else if (status?.source === 'global') {
+        hint = 'disabled globally';
+      }
+
+      return {
+        name: name,
+        hint: hint,
+        enabled: isEnabled,
+      };
+    });
+
+    // Get indices of enabled servers for initial selection
+    const initialIndices = choices
+      .map((choice, index) => (choice.enabled ? index : -1))
+      .filter((index) => index !== -1);
+
+    const prompt = new MultiSelect({
+      name: 'servers',
+      message: 'Select MCP servers to enable. Deselect ones to disable.',
+      choices: choices,
+      initial: initialIndices,
+      hint: 'Use <space> to select, <a> to toggle all, <return> to submit',
+      result(names: string[]) {
+        return names;
+      },
+    } as any);
+
+    const selected = await prompt.run();
+
+    // Calculate denied servers (those NOT selected)
+    const deniedServers = servers.filter((s) => !selected.includes(s));
+
+    // Update local config
+    updateLocalConfig(deniedServers);
+
+    console.log('');
+    displaySuccess('Configuration saved!');
+
+    // Show summary
+    const enabledCount = selected.length;
+    const disabledCount = deniedServers.length;
+
+    console.log(
+      colorize(`\n${enabledCount} enabled, ${disabledCount} disabled`, 'gray')
+    );
+
+    if (selected.length > 0) {
+      console.log(colorize('\nEnabled servers:', 'gray'));
+      selected.forEach((name: string) => {
+        console.log(colorize(`  • ${name}`, 'gray'));
+      });
+    }
+
+    if (deniedServers.length > 0) {
+      console.log(colorize('\nDisabled servers:', 'gray'));
+      deniedServers.forEach((name: string) => {
+        console.log(colorize(`  • ${name}`, 'gray'));
+      });
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message === '') {
+      // User cancelled (Ctrl+C)
+      console.log(colorize('\n\nCancelled.', 'yellow'));
+      return;
+    }
+    displayError(`Failed to save configuration: ${error}`);
+  }
+}

--- a/packages/mcp-config/src/commands/list.spec.ts
+++ b/packages/mcp-config/src/commands/list.spec.ts
@@ -1,0 +1,61 @@
+import { listCommand } from './list';
+import * as reader from '../config/reader';
+import * as display from '../utils/display';
+
+jest.mock('../config/reader');
+jest.mock('../utils/display');
+
+describe('list command', () => {
+  let consoleLogSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  it('should display warning when no MCP servers are configured', () => {
+    jest.spyOn(reader, 'hasMcpServers').mockReturnValue(false);
+
+    listCommand();
+
+    expect(display.displayWarning).toHaveBeenCalledWith(
+      'No MCP servers configured.'
+    );
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect.stringContaining('To configure MCP servers')
+    );
+  });
+
+  it('should display server list when servers are configured', () => {
+    const mockStatuses = [
+      { name: 'github', enabled: true, source: 'none' as const },
+      { name: 'linear', enabled: false, source: 'local' as const },
+    ];
+
+    jest.spyOn(reader, 'hasMcpServers').mockReturnValue(true);
+    jest.spyOn(reader, 'getAllServerStatuses').mockReturnValue(mockStatuses);
+
+    listCommand();
+
+    expect(reader.getAllServerStatuses).toHaveBeenCalled();
+    expect(display.displayServerList).toHaveBeenCalledWith(mockStatuses);
+  });
+
+  it('should display configuration example when no servers configured', () => {
+    jest.spyOn(reader, 'hasMcpServers').mockReturnValue(false);
+
+    listCommand();
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect.stringContaining('mcpServers')
+    );
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect.stringContaining('server-name')
+    );
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('npx'));
+  });
+});

--- a/packages/mcp-config/src/commands/list.ts
+++ b/packages/mcp-config/src/commands/list.ts
@@ -1,0 +1,24 @@
+import { getAllServerStatuses, hasMcpServers } from '../config/reader';
+import { displayServerList, displayWarning } from '../utils/display';
+
+/**
+ * List all MCP servers with their enabled/disabled status
+ */
+export function listCommand(): void {
+  if (!hasMcpServers()) {
+    displayWarning('No MCP servers configured.');
+    console.log('\nTo configure MCP servers, add them to ~/.claude.json:\n');
+    console.log('{');
+    console.log('  "mcpServers": {');
+    console.log('    "server-name": {');
+    console.log('      "command": "npx",');
+    console.log('      "args": ["-y", "package@latest"]');
+    console.log('    }');
+    console.log('  }');
+    console.log('}\n');
+    return;
+  }
+
+  const statuses = getAllServerStatuses();
+  displayServerList(statuses);
+}

--- a/packages/mcp-config/src/commands/status.spec.ts
+++ b/packages/mcp-config/src/commands/status.spec.ts
@@ -1,0 +1,62 @@
+import { statusCommand } from './status';
+import * as reader from '../config/reader';
+import * as display from '../utils/display';
+
+jest.mock('../config/reader');
+jest.mock('../utils/display');
+
+describe('status command', () => {
+  let consoleLogSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  it('should display warning when no MCP servers are configured', () => {
+    jest.spyOn(reader, 'hasMcpServers').mockReturnValue(false);
+
+    statusCommand();
+
+    expect(display.displayWarning).toHaveBeenCalledWith(
+      'No MCP servers configured.'
+    );
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect.stringContaining('To configure MCP servers')
+    );
+  });
+
+  it('should display detailed status when servers are configured', () => {
+    const mockStatuses = [
+      { name: 'github', enabled: true, source: 'none' as const },
+      { name: 'linear', enabled: false, source: 'local' as const },
+      { name: 'notion', enabled: true, source: 'none' as const },
+    ];
+
+    jest.spyOn(reader, 'hasMcpServers').mockReturnValue(true);
+    jest.spyOn(reader, 'getAllServerStatuses').mockReturnValue(mockStatuses);
+
+    statusCommand();
+
+    expect(reader.getAllServerStatuses).toHaveBeenCalled();
+    expect(display.displayDetailedStatus).toHaveBeenCalledWith(mockStatuses);
+  });
+
+  it('should display configuration example when no servers configured', () => {
+    jest.spyOn(reader, 'hasMcpServers').mockReturnValue(false);
+
+    statusCommand();
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect.stringContaining('mcpServers')
+    );
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect.stringContaining('server-name')
+    );
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('npx'));
+  });
+});

--- a/packages/mcp-config/src/commands/status.ts
+++ b/packages/mcp-config/src/commands/status.ts
@@ -1,0 +1,24 @@
+import { getAllServerStatuses, hasMcpServers } from '../config/reader';
+import { displayDetailedStatus, displayWarning } from '../utils/display';
+
+/**
+ * Show detailed status of all MCP servers
+ */
+export function statusCommand(): void {
+  if (!hasMcpServers()) {
+    displayWarning('No MCP servers configured.');
+    console.log('\nTo configure MCP servers, add them to ~/.claude.json:\n');
+    console.log('{');
+    console.log('  "mcpServers": {');
+    console.log('    "server-name": {');
+    console.log('      "command": "npx",');
+    console.log('      "args": ["-y", "package@latest"]');
+    console.log('    }');
+    console.log('  }');
+    console.log('}\n');
+    return;
+  }
+
+  const statuses = getAllServerStatuses();
+  displayDetailedStatus(statuses);
+}

--- a/packages/mcp-config/src/config/reader.spec.ts
+++ b/packages/mcp-config/src/config/reader.spec.ts
@@ -1,0 +1,520 @@
+import { vol } from 'memfs';
+import { join } from 'path';
+import * as os from 'os';
+import {
+  getGlobalConfigPath,
+  getLocalConfigPath,
+  getMcpJsonConfigPath,
+  readGlobalConfig,
+  readLocalConfig,
+  readMcpJsonConfig,
+  getAvailableServers,
+  getServerStatus,
+  getAllServerStatuses,
+  hasMcpServers,
+} from './reader';
+
+// Mock fs module with memfs
+jest.mock('fs', () => {
+  const memfs = jest.requireActual('memfs');
+  return memfs.fs;
+});
+
+// Mock os module
+jest.mock('os', () => ({
+  homedir: jest.fn(),
+}));
+
+describe('Configuration Reader', () => {
+  let mockHomedir: string;
+  let mockCwd: string;
+
+  beforeEach(() => {
+    // Set up mock directories
+    mockHomedir = '/home/testuser';
+    mockCwd = '/home/testuser/projects/test-project';
+
+    // Mock os.homedir
+    (os.homedir as jest.Mock).mockReturnValue(mockHomedir);
+
+    // Mock process.cwd
+    jest.spyOn(process, 'cwd').mockReturnValue(mockCwd);
+
+    // Reset virtual filesystem
+    vol.reset();
+
+    // Create mock directory structure
+    vol.mkdirSync(mockHomedir, { recursive: true });
+    vol.mkdirSync(mockCwd, { recursive: true });
+  });
+
+  afterEach(() => {
+    // Restore mocks
+    jest.restoreAllMocks();
+    vol.reset();
+  });
+
+  describe('Path Functions', () => {
+    it('should return correct global config path', () => {
+      const path = getGlobalConfigPath();
+      expect(path).toBe(join(mockHomedir, '.claude.json'));
+    });
+
+    it('should return correct local config path', () => {
+      const path = getLocalConfigPath();
+      expect(path).toBe(join(mockCwd, '.claude', 'settings.local.json'));
+    });
+
+    it('should return correct MCP JSON config path', () => {
+      const path = getMcpJsonConfigPath();
+      expect(path).toBe(join(mockCwd, '.mcp.json'));
+    });
+  });
+
+  describe('readGlobalConfig', () => {
+    it('should return empty config when file does not exist', () => {
+      const config = readGlobalConfig();
+      expect(config).toEqual({});
+    });
+
+    it('should read global config successfully', () => {
+      const mockConfig = {
+        mcpServers: {
+          github: {
+            command: 'npx',
+            args: ['-y', '@modelcontextprotocol/server-github'],
+          },
+          linear: {
+            command: 'npx',
+            args: ['-y', '@modelcontextprotocol/server-linear'],
+          },
+        },
+      };
+
+      vol.writeFileSync(
+        join(mockHomedir, '.claude.json'),
+        JSON.stringify(mockConfig)
+      );
+
+      const config = readGlobalConfig();
+      expect(config).toEqual(mockConfig);
+    });
+
+    it('should handle invalid JSON gracefully', () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      vol.writeFileSync(join(mockHomedir, '.claude.json'), 'invalid json{');
+
+      const config = readGlobalConfig();
+      expect(config).toEqual({});
+      expect(consoleSpy).toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should read config with projects section', () => {
+      const mockConfig = {
+        mcpServers: {
+          global1: { command: 'npx', args: ['global1'] },
+        },
+        projects: {
+          [mockCwd]: {
+            mcpServers: {
+              project1: { command: 'npx', args: ['project1'] },
+            },
+          },
+        },
+      };
+
+      vol.writeFileSync(
+        join(mockHomedir, '.claude.json'),
+        JSON.stringify(mockConfig)
+      );
+
+      const config = readGlobalConfig();
+      expect(config).toEqual(mockConfig);
+    });
+  });
+
+  describe('readLocalConfig', () => {
+    it('should return empty config when file does not exist', () => {
+      const config = readLocalConfig();
+      expect(config).toEqual({});
+    });
+
+    it('should read local config successfully', () => {
+      const mockConfig = {
+        deniedMcpServers: [{ serverName: 'github' }, { serverName: 'linear' }],
+      };
+
+      const localPath = join(mockCwd, '.claude', 'settings.local.json');
+      vol.mkdirSync(join(mockCwd, '.claude'), { recursive: true });
+      vol.writeFileSync(localPath, JSON.stringify(mockConfig));
+
+      const config = readLocalConfig();
+      expect(config).toEqual(mockConfig);
+    });
+
+    it('should handle invalid JSON gracefully', () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      const localPath = join(mockCwd, '.claude', 'settings.local.json');
+      vol.mkdirSync(join(mockCwd, '.claude'), { recursive: true });
+      vol.writeFileSync(localPath, 'invalid json{');
+
+      const config = readLocalConfig();
+      expect(config).toEqual({});
+      expect(consoleSpy).toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('readMcpJsonConfig', () => {
+    it('should return empty config when file does not exist', () => {
+      const config = readMcpJsonConfig();
+      expect(config).toEqual({});
+    });
+
+    it('should read .mcp.json config successfully', () => {
+      const mockConfig = {
+        mcpServers: {
+          'team-tool': {
+            command: 'node',
+            args: ['./scripts/team-tool.js'],
+          },
+        },
+      };
+
+      vol.writeFileSync(
+        join(mockCwd, '.mcp.json'),
+        JSON.stringify(mockConfig)
+      );
+
+      const config = readMcpJsonConfig();
+      expect(config).toEqual(mockConfig);
+    });
+
+    it('should handle invalid JSON gracefully', () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      vol.writeFileSync(join(mockCwd, '.mcp.json'), 'invalid json{');
+
+      const config = readMcpJsonConfig();
+      expect(config).toEqual({});
+      expect(consoleSpy).toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('getAvailableServers', () => {
+    it('should return empty array when no servers configured', () => {
+      const servers = getAvailableServers();
+      expect(servers).toEqual([]);
+    });
+
+    it('should return servers from global config', () => {
+      const mockConfig = {
+        mcpServers: {
+          github: { command: 'npx', args: ['github'] },
+          linear: { command: 'npx', args: ['linear'] },
+        },
+      };
+
+      vol.writeFileSync(
+        join(mockHomedir, '.claude.json'),
+        JSON.stringify(mockConfig)
+      );
+
+      const servers = getAvailableServers();
+      expect(servers).toEqual(['github', 'linear']);
+    });
+
+    it('should return servers from project-specific config', () => {
+      const mockConfig = {
+        projects: {
+          [mockCwd]: {
+            mcpServers: {
+              project1: { command: 'npx', args: ['project1'] },
+              project2: { command: 'npx', args: ['project2'] },
+            },
+          },
+        },
+      };
+
+      vol.writeFileSync(
+        join(mockHomedir, '.claude.json'),
+        JSON.stringify(mockConfig)
+      );
+
+      const servers = getAvailableServers();
+      expect(servers).toEqual(['project1', 'project2']);
+    });
+
+    it('should return servers from .mcp.json', () => {
+      const mockConfig = {
+        mcpServers: {
+          local1: { command: 'node', args: ['local1'] },
+          local2: { command: 'node', args: ['local2'] },
+        },
+      };
+
+      vol.writeFileSync(
+        join(mockCwd, '.mcp.json'),
+        JSON.stringify(mockConfig)
+      );
+
+      const servers = getAvailableServers();
+      expect(servers).toEqual(['local1', 'local2']);
+    });
+
+    it('should combine and deduplicate servers from all sources', () => {
+      // Global config
+      const globalConfig = {
+        mcpServers: {
+          github: { command: 'npx', args: ['github'] },
+          linear: { command: 'npx', args: ['linear'] },
+        },
+        projects: {
+          [mockCwd]: {
+            mcpServers: {
+              github: { command: 'npx', args: ['github-override'] },
+              notion: { command: 'npx', args: ['notion'] },
+            },
+          },
+        },
+      };
+
+      vol.writeFileSync(
+        join(mockHomedir, '.claude.json'),
+        JSON.stringify(globalConfig)
+      );
+
+      // Local .mcp.json
+      const localConfig = {
+        mcpServers: {
+          notion: { command: 'node', args: ['notion-local'] },
+          custom: { command: 'node', args: ['custom'] },
+        },
+      };
+
+      vol.writeFileSync(
+        join(mockCwd, '.mcp.json'),
+        JSON.stringify(localConfig)
+      );
+
+      const servers = getAvailableServers();
+      // Should deduplicate and sort
+      expect(servers).toEqual(['custom', 'github', 'linear', 'notion']);
+    });
+
+    it('should return sorted server names', () => {
+      const mockConfig = {
+        mcpServers: {
+          zebra: { command: 'npx', args: ['zebra'] },
+          apple: { command: 'npx', args: ['apple'] },
+          monkey: { command: 'npx', args: ['monkey'] },
+        },
+      };
+
+      vol.writeFileSync(
+        join(mockHomedir, '.claude.json'),
+        JSON.stringify(mockConfig)
+      );
+
+      const servers = getAvailableServers();
+      expect(servers).toEqual(['apple', 'monkey', 'zebra']);
+    });
+  });
+
+  describe('getServerStatus', () => {
+    it('should return enabled status when no config exists', () => {
+      const status = getServerStatus('github');
+      expect(status).toEqual({
+        name: 'github',
+        enabled: true,
+        source: 'none',
+      });
+    });
+
+    it('should return disabled status when server is in local deniedMcpServers', () => {
+      const localConfig = {
+        deniedMcpServers: [{ serverName: 'github' }],
+      };
+
+      const localPath = join(mockCwd, '.claude', 'settings.local.json');
+      vol.mkdirSync(join(mockCwd, '.claude'), { recursive: true });
+      vol.writeFileSync(localPath, JSON.stringify(localConfig));
+
+      const status = getServerStatus('github');
+      expect(status).toEqual({
+        name: 'github',
+        enabled: false,
+        source: 'local',
+      });
+    });
+
+    it('should return disabled status when server is in global disabledMcpServers', () => {
+      const globalConfig = {
+        projects: {
+          [mockCwd]: {
+            disabledMcpServers: ['github'],
+          },
+        },
+      };
+
+      vol.writeFileSync(
+        join(mockHomedir, '.claude.json'),
+        JSON.stringify(globalConfig)
+      );
+
+      const status = getServerStatus('github');
+      expect(status).toEqual({
+        name: 'github',
+        enabled: false,
+        source: 'global',
+      });
+    });
+
+    it('should prioritize local config over global config', () => {
+      // Global config says disabled
+      const globalConfig = {
+        projects: {
+          [mockCwd]: {
+            disabledMcpServers: ['github'],
+          },
+        },
+      };
+
+      vol.writeFileSync(
+        join(mockHomedir, '.claude.json'),
+        JSON.stringify(globalConfig)
+      );
+
+      // Local config also says disabled (but local should be checked first)
+      const localConfig = {
+        deniedMcpServers: [{ serverName: 'github' }],
+      };
+
+      const localPath = join(mockCwd, '.claude', 'settings.local.json');
+      vol.mkdirSync(join(mockCwd, '.claude'), { recursive: true });
+      vol.writeFileSync(localPath, JSON.stringify(localConfig));
+
+      const status = getServerStatus('github');
+      // Should return 'local' as source since it's checked first
+      expect(status).toEqual({
+        name: 'github',
+        enabled: false,
+        source: 'local',
+      });
+    });
+  });
+
+  describe('getAllServerStatuses', () => {
+    it('should return empty array when no servers configured', () => {
+      const statuses = getAllServerStatuses();
+      expect(statuses).toEqual([]);
+    });
+
+    it('should return status for all servers', () => {
+      const globalConfig = {
+        mcpServers: {
+          github: { command: 'npx', args: ['github'] },
+          linear: { command: 'npx', args: ['linear'] },
+          notion: { command: 'npx', args: ['notion'] },
+        },
+      };
+
+      vol.writeFileSync(
+        join(mockHomedir, '.claude.json'),
+        JSON.stringify(globalConfig)
+      );
+
+      const localConfig = {
+        deniedMcpServers: [{ serverName: 'linear' }],
+      };
+
+      const localPath = join(mockCwd, '.claude', 'settings.local.json');
+      vol.mkdirSync(join(mockCwd, '.claude'), { recursive: true });
+      vol.writeFileSync(localPath, JSON.stringify(localConfig));
+
+      const statuses = getAllServerStatuses();
+      expect(statuses).toHaveLength(3);
+      expect(statuses).toContainEqual({
+        name: 'github',
+        enabled: true,
+        source: 'none',
+      });
+      expect(statuses).toContainEqual({
+        name: 'linear',
+        enabled: false,
+        source: 'local',
+      });
+      expect(statuses).toContainEqual({
+        name: 'notion',
+        enabled: true,
+        source: 'none',
+      });
+    });
+  });
+
+  describe('hasMcpServers', () => {
+    it('should return false when no servers configured', () => {
+      const result = hasMcpServers();
+      expect(result).toBe(false);
+    });
+
+    it('should return true when servers are configured in global config', () => {
+      const mockConfig = {
+        mcpServers: {
+          github: { command: 'npx', args: ['github'] },
+        },
+      };
+
+      vol.writeFileSync(
+        join(mockHomedir, '.claude.json'),
+        JSON.stringify(mockConfig)
+      );
+
+      const result = hasMcpServers();
+      expect(result).toBe(true);
+    });
+
+    it('should return true when servers are configured in project config', () => {
+      const mockConfig = {
+        projects: {
+          [mockCwd]: {
+            mcpServers: {
+              project1: { command: 'npx', args: ['project1'] },
+            },
+          },
+        },
+      };
+
+      vol.writeFileSync(
+        join(mockHomedir, '.claude.json'),
+        JSON.stringify(mockConfig)
+      );
+
+      const result = hasMcpServers();
+      expect(result).toBe(true);
+    });
+
+    it('should return true when servers are configured in .mcp.json', () => {
+      const mockConfig = {
+        mcpServers: {
+          local1: { command: 'node', args: ['local1'] },
+        },
+      };
+
+      vol.writeFileSync(
+        join(mockCwd, '.mcp.json'),
+        JSON.stringify(mockConfig)
+      );
+
+      const result = hasMcpServers();
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/packages/mcp-config/src/config/reader.ts
+++ b/packages/mcp-config/src/config/reader.ts
@@ -1,0 +1,197 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import type {
+  ClaudeConfig,
+  McpConfig,
+  SettingsLocal,
+  ServerStatus,
+} from './types';
+
+/**
+ * Path to global Claude configuration
+ */
+export function getGlobalConfigPath(): string {
+  return join(homedir(), '.claude.json');
+}
+
+/**
+ * Path to local project settings
+ */
+export function getLocalConfigPath(): string {
+  return join(process.cwd(), '.claude', 'settings.local.json');
+}
+
+/**
+ * Path to project-local MCP configuration
+ */
+export function getMcpJsonConfigPath(): string {
+  return join(process.cwd(), '.mcp.json');
+}
+
+/**
+ * Read global Claude configuration from ~/.claude.json
+ */
+export function readGlobalConfig(): ClaudeConfig {
+  const configPath = getGlobalConfigPath();
+
+  if (!existsSync(configPath)) {
+    return {};
+  }
+
+  try {
+    const content = readFileSync(configPath, 'utf-8');
+    return JSON.parse(content) as ClaudeConfig;
+  } catch (error) {
+    console.error(`Failed to read global config: ${error}`);
+    return {};
+  }
+}
+
+/**
+ * Read local project settings from ./.claude/settings.local.json
+ */
+export function readLocalConfig(): SettingsLocal {
+  const configPath = getLocalConfigPath();
+
+  if (!existsSync(configPath)) {
+    return {};
+  }
+
+  try {
+    const content = readFileSync(configPath, 'utf-8');
+    return JSON.parse(content) as SettingsLocal;
+  } catch (error) {
+    console.error(`Failed to read local config: ${error}`);
+    return {};
+  }
+}
+
+/**
+ * Read project-local MCP configuration from ./.mcp.json
+ */
+export function readMcpJsonConfig(): McpConfig {
+  const configPath = getMcpJsonConfigPath();
+
+  if (!existsSync(configPath)) {
+    return {};
+  }
+
+  try {
+    const content = readFileSync(configPath, 'utf-8');
+    return JSON.parse(content) as McpConfig;
+  } catch (error) {
+    console.error(`Failed to read .mcp.json config: ${error}`);
+    return {};
+  }
+}
+
+/**
+ * Get all available MCP server names from all sources:
+ * 1. Global ~/.claude.json mcpServers
+ * 2. Project-specific ~/.claude.json projects[cwd].mcpServers
+ * 3. Project-local ./.mcp.json
+ */
+export function getAvailableServers(): string[] {
+  const servers = new Set<string>();
+  const cwd = process.cwd();
+
+  // 1. Global MCP servers from ~/.claude.json
+  const globalConfig = readGlobalConfig();
+  if (globalConfig.mcpServers) {
+    Object.keys(globalConfig.mcpServers).forEach((name) => servers.add(name));
+  }
+
+  // 2. Project-specific MCP servers from ~/.claude.json projects[cwd].mcpServers
+  if (globalConfig.projects?.[cwd]?.mcpServers) {
+    Object.keys(globalConfig.projects[cwd].mcpServers!).forEach((name) =>
+      servers.add(name)
+    );
+  }
+
+  // 3. Project-local MCP servers from ./.mcp.json
+  const mcpConfig = readMcpJsonConfig();
+  if (mcpConfig.mcpServers) {
+    Object.keys(mcpConfig.mcpServers).forEach((name) => servers.add(name));
+  }
+
+  return Array.from(servers).sort();
+}
+
+/**
+ * Check if a server is denied in the local configuration
+ */
+function isServerDeniedLocally(serverName: string): boolean {
+  const localConfig = readLocalConfig();
+
+  if (!localConfig.deniedMcpServers) {
+    return false;
+  }
+
+  return localConfig.deniedMcpServers.some(
+    (denied) => denied.serverName === serverName
+  );
+}
+
+/**
+ * Check if a server is disabled in the global configuration for current project
+ */
+function isServerDisabledGlobally(serverName: string): boolean {
+  const globalConfig = readGlobalConfig();
+  const cwd = process.cwd();
+
+  if (!globalConfig.projects || !globalConfig.projects[cwd]) {
+    return false;
+  }
+
+  const projectConfig = globalConfig.projects[cwd];
+
+  return projectConfig.disabledMcpServers?.includes(serverName) ?? false;
+}
+
+/**
+ * Get the status of an MCP server
+ * Local configuration takes precedence over global configuration
+ */
+export function getServerStatus(serverName: string): ServerStatus {
+  // 1. Check local config first (takes precedence)
+  if (isServerDeniedLocally(serverName)) {
+    return {
+      name: serverName,
+      enabled: false,
+      source: 'local',
+    };
+  }
+
+  // 2. Check global config for current project
+  if (isServerDisabledGlobally(serverName)) {
+    return {
+      name: serverName,
+      enabled: false,
+      source: 'global',
+    };
+  }
+
+  // 3. Default: enabled
+  return {
+    name: serverName,
+    enabled: true,
+    source: 'none',
+  };
+}
+
+/**
+ * Get status for all available servers
+ */
+export function getAllServerStatuses(): ServerStatus[] {
+  const servers = getAvailableServers();
+  return servers.map((name) => getServerStatus(name));
+}
+
+/**
+ * Check if MCP servers are configured
+ */
+export function hasMcpServers(): boolean {
+  const servers = getAvailableServers();
+  return servers.length > 0;
+}

--- a/packages/mcp-config/src/config/types.ts
+++ b/packages/mcp-config/src/config/types.ts
@@ -1,0 +1,67 @@
+/**
+ * Type definitions for MCP configuration files
+ */
+
+/**
+ * Represents a denied MCP server in the deniedMcpServers array
+ */
+export interface DeniedMcpServer {
+  serverName: string;
+}
+
+/**
+ * Configuration for an MCP server
+ */
+export interface McpServerConfig {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  type?: 'stdio' | 'http' | 'sse';
+  url?: string;
+}
+
+/**
+ * Per-project configuration in global ~/.claude.json
+ */
+export interface ProjectConfig {
+  mcpServers?: Record<string, McpServerConfig>;
+  disabledMcpServers?: string[];
+  enabledMcpjsonServers?: string[];
+  disabledMcpjsonServers?: string[];
+}
+
+/**
+ * Global Claude configuration (~/.claude.json)
+ */
+export interface ClaudeConfig {
+  mcpServers?: Record<string, McpServerConfig>;
+  projects?: Record<string, ProjectConfig>;
+}
+
+/**
+ * Local project settings (.claude/settings.local.json)
+ */
+export interface SettingsLocal {
+  permissions?: {
+    allow?: string[];
+    deny?: string[];
+    ask?: string[];
+  };
+  deniedMcpServers?: DeniedMcpServer[];
+}
+
+/**
+ * Status information for an MCP server
+ */
+export interface ServerStatus {
+  name: string;
+  enabled: boolean;
+  source: 'local' | 'global' | 'none';
+}
+
+/**
+ * Project-local MCP configuration (.mcp.json)
+ */
+export interface McpConfig {
+  mcpServers?: Record<string, McpServerConfig>;
+}

--- a/packages/mcp-config/src/config/writer.spec.ts
+++ b/packages/mcp-config/src/config/writer.spec.ts
@@ -1,0 +1,396 @@
+import { vol } from 'memfs';
+import { join } from 'path';
+import * as os from 'os';
+import { updateLocalConfig, enableServer, disableServer } from './writer';
+
+// Mock fs module with memfs
+jest.mock('fs', () => {
+  const memfs = jest.requireActual('memfs');
+  return memfs.fs;
+});
+
+// Mock os module
+jest.mock('os', () => ({
+  homedir: jest.fn(),
+}));
+
+describe('Configuration Writer', () => {
+  let mockHomedir: string;
+  let mockCwd: string;
+  let localConfigPath: string;
+
+  beforeEach(() => {
+    // Set up mock directories
+    mockHomedir = '/home/testuser';
+    mockCwd = '/home/testuser/projects/test-project';
+
+    // Mock os.homedir and process.cwd
+    (os.homedir as jest.Mock).mockReturnValue(mockHomedir);
+    jest.spyOn(process, 'cwd').mockReturnValue(mockCwd);
+
+    // Reset virtual filesystem
+    vol.reset();
+
+    // Create mock directory structure
+    vol.mkdirSync(mockHomedir, { recursive: true });
+    vol.mkdirSync(mockCwd, { recursive: true });
+
+    localConfigPath = join(mockCwd, '.claude', 'settings.local.json');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    vol.reset();
+  });
+
+  describe('updateLocalConfig', () => {
+    it('should create .claude directory if it does not exist', () => {
+      updateLocalConfig(['github']);
+
+      const dirExists = vol.existsSync(join(mockCwd, '.claude'));
+      expect(dirExists).toBe(true);
+    });
+
+    it('should create new config file with denied servers', () => {
+      updateLocalConfig(['github', 'linear']);
+
+      const content = vol.readFileSync(localConfigPath, 'utf-8') as string;
+      const config = JSON.parse(content);
+
+      expect(config).toEqual({
+        deniedMcpServers: [{ serverName: 'github' }, { serverName: 'linear' }],
+      });
+    });
+
+    it('should update existing config file', () => {
+      // Create initial config
+      vol.mkdirSync(join(mockCwd, '.claude'), { recursive: true });
+      vol.writeFileSync(
+        localConfigPath,
+        JSON.stringify({
+          permissions: { allow: ['read', 'write'] },
+          deniedMcpServers: [{ serverName: 'old-server' }],
+        })
+      );
+
+      // Update config
+      updateLocalConfig(['github', 'linear']);
+
+      const content = vol.readFileSync(localConfigPath, 'utf-8') as string;
+      const config = JSON.parse(content);
+
+      expect(config).toEqual({
+        permissions: { allow: ['read', 'write'] },
+        deniedMcpServers: [{ serverName: 'github' }, { serverName: 'linear' }],
+      });
+    });
+
+    it('should handle empty denied servers array', () => {
+      updateLocalConfig([]);
+
+      const content = vol.readFileSync(localConfigPath, 'utf-8') as string;
+      const config = JSON.parse(content);
+
+      expect(config).toEqual({
+        deniedMcpServers: [],
+      });
+    });
+
+    it('should preserve other config properties', () => {
+      // Create config with other properties
+      vol.mkdirSync(join(mockCwd, '.claude'), { recursive: true });
+      vol.writeFileSync(
+        localConfigPath,
+        JSON.stringify({
+          permissions: {
+            allow: ['read', 'write'],
+            deny: ['delete'],
+            ask: ['execute'],
+          },
+        })
+      );
+
+      updateLocalConfig(['github']);
+
+      const content = vol.readFileSync(localConfigPath, 'utf-8') as string;
+      const config = JSON.parse(content);
+
+      expect(config).toEqual({
+        permissions: {
+          allow: ['read', 'write'],
+          deny: ['delete'],
+          ask: ['execute'],
+        },
+        deniedMcpServers: [{ serverName: 'github' }],
+      });
+    });
+
+    it('should format JSON with 2-space indentation', () => {
+      updateLocalConfig(['github']);
+
+      const content = vol.readFileSync(localConfigPath, 'utf-8') as string;
+
+      // Check formatting
+      expect(content).toContain('{\n  "deniedMcpServers"');
+      expect(content).toContain('    {\n      "serverName": "github"\n    }');
+    });
+
+    it('should add newline at end of file', () => {
+      updateLocalConfig(['github']);
+
+      const content = vol.readFileSync(localConfigPath, 'utf-8') as string;
+
+      expect(content.endsWith('\n')).toBe(true);
+    });
+
+    it('should handle corrupted existing config gracefully', () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      vol.mkdirSync(join(mockCwd, '.claude'), { recursive: true });
+      vol.writeFileSync(localConfigPath, 'invalid json{');
+
+      updateLocalConfig(['github']);
+
+      const content = vol.readFileSync(localConfigPath, 'utf-8') as string;
+      const config = JSON.parse(content);
+
+      expect(config).toEqual({
+        deniedMcpServers: [{ serverName: 'github' }],
+      });
+      expect(consoleSpy).toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('enableServer', () => {
+    it('should do nothing if config file does not exist', () => {
+      // Should not throw error
+      expect(() => enableServer('github')).not.toThrow();
+
+      // Config file should still not exist
+      const exists = vol.existsSync(localConfigPath);
+      expect(exists).toBe(false);
+    });
+
+    it('should do nothing if deniedMcpServers is empty', () => {
+      vol.mkdirSync(join(mockCwd, '.claude'), { recursive: true });
+      vol.writeFileSync(
+        localConfigPath,
+        JSON.stringify({
+          permissions: { allow: ['read'] },
+        })
+      );
+
+      enableServer('github');
+
+      const content = vol.readFileSync(localConfigPath, 'utf-8') as string;
+      const config = JSON.parse(content);
+
+      expect(config).toEqual({
+        permissions: { allow: ['read'] },
+      });
+    });
+
+    it('should remove server from deniedMcpServers', () => {
+      vol.mkdirSync(join(mockCwd, '.claude'), { recursive: true });
+      vol.writeFileSync(
+        localConfigPath,
+        JSON.stringify({
+          deniedMcpServers: [
+            { serverName: 'github' },
+            { serverName: 'linear' },
+            { serverName: 'notion' },
+          ],
+        })
+      );
+
+      enableServer('linear');
+
+      const content = vol.readFileSync(localConfigPath, 'utf-8') as string;
+      const config = JSON.parse(content);
+
+      expect(config.deniedMcpServers).toEqual([
+        { serverName: 'github' },
+        { serverName: 'notion' },
+      ]);
+    });
+
+    it('should preserve other config properties', () => {
+      vol.mkdirSync(join(mockCwd, '.claude'), { recursive: true });
+      vol.writeFileSync(
+        localConfigPath,
+        JSON.stringify({
+          permissions: { allow: ['read', 'write'] },
+          deniedMcpServers: [{ serverName: 'github' }, { serverName: 'linear' }],
+        })
+      );
+
+      enableServer('github');
+
+      const content = vol.readFileSync(localConfigPath, 'utf-8') as string;
+      const config = JSON.parse(content);
+
+      expect(config).toEqual({
+        permissions: { allow: ['read', 'write'] },
+        deniedMcpServers: [{ serverName: 'linear' }],
+      });
+    });
+
+    it('should handle removing non-existent server gracefully', () => {
+      vol.mkdirSync(join(mockCwd, '.claude'), { recursive: true });
+      vol.writeFileSync(
+        localConfigPath,
+        JSON.stringify({
+          deniedMcpServers: [{ serverName: 'github' }],
+        })
+      );
+
+      // Should not throw error
+      expect(() => enableServer('nonexistent')).not.toThrow();
+
+      const content = vol.readFileSync(localConfigPath, 'utf-8') as string;
+      const config = JSON.parse(content);
+
+      // Should remain unchanged
+      expect(config.deniedMcpServers).toEqual([{ serverName: 'github' }]);
+    });
+
+    it('should throw error if config file is corrupted', () => {
+      vol.mkdirSync(join(mockCwd, '.claude'), { recursive: true });
+      vol.writeFileSync(localConfigPath, 'invalid json{');
+
+      expect(() => enableServer('github')).toThrow('Failed to read config');
+    });
+  });
+
+  describe('disableServer', () => {
+    it('should create .claude directory if it does not exist', () => {
+      disableServer('github');
+
+      const dirExists = vol.existsSync(join(mockCwd, '.claude'));
+      expect(dirExists).toBe(true);
+    });
+
+    it('should create new config file with denied server', () => {
+      disableServer('github');
+
+      const content = vol.readFileSync(localConfigPath, 'utf-8') as string;
+      const config = JSON.parse(content);
+
+      expect(config).toEqual({
+        deniedMcpServers: [{ serverName: 'github' }],
+      });
+    });
+
+    it('should add server to existing deniedMcpServers', () => {
+      vol.mkdirSync(join(mockCwd, '.claude'), { recursive: true });
+      vol.writeFileSync(
+        localConfigPath,
+        JSON.stringify({
+          deniedMcpServers: [{ serverName: 'github' }],
+        })
+      );
+
+      disableServer('linear');
+
+      const content = vol.readFileSync(localConfigPath, 'utf-8') as string;
+      const config = JSON.parse(content);
+
+      expect(config.deniedMcpServers).toEqual([
+        { serverName: 'github' },
+        { serverName: 'linear' },
+      ]);
+    });
+
+    it('should not duplicate server if already denied', () => {
+      vol.mkdirSync(join(mockCwd, '.claude'), { recursive: true });
+      vol.writeFileSync(
+        localConfigPath,
+        JSON.stringify({
+          deniedMcpServers: [{ serverName: 'github' }],
+        })
+      );
+
+      disableServer('github');
+
+      const content = vol.readFileSync(localConfigPath, 'utf-8') as string;
+      const config = JSON.parse(content);
+
+      expect(config.deniedMcpServers).toEqual([{ serverName: 'github' }]);
+    });
+
+    it('should preserve other config properties', () => {
+      vol.mkdirSync(join(mockCwd, '.claude'), { recursive: true });
+      vol.writeFileSync(
+        localConfigPath,
+        JSON.stringify({
+          permissions: { allow: ['read', 'write'] },
+        })
+      );
+
+      disableServer('github');
+
+      const content = vol.readFileSync(localConfigPath, 'utf-8') as string;
+      const config = JSON.parse(content);
+
+      expect(config).toEqual({
+        permissions: { allow: ['read', 'write'] },
+        deniedMcpServers: [{ serverName: 'github' }],
+      });
+    });
+
+    it('should initialize deniedMcpServers if it does not exist', () => {
+      vol.mkdirSync(join(mockCwd, '.claude'), { recursive: true });
+      vol.writeFileSync(
+        localConfigPath,
+        JSON.stringify({
+          permissions: { allow: ['read'] },
+        })
+      );
+
+      disableServer('github');
+
+      const content = vol.readFileSync(localConfigPath, 'utf-8') as string;
+      const config = JSON.parse(content);
+
+      expect(config.deniedMcpServers).toEqual([{ serverName: 'github' }]);
+    });
+
+    it('should handle corrupted existing config gracefully', () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      vol.mkdirSync(join(mockCwd, '.claude'), { recursive: true });
+      vol.writeFileSync(localConfigPath, 'invalid json{');
+
+      disableServer('github');
+
+      const content = vol.readFileSync(localConfigPath, 'utf-8') as string;
+      const config = JSON.parse(content);
+
+      expect(config).toEqual({
+        deniedMcpServers: [{ serverName: 'github' }],
+      });
+      expect(consoleSpy).toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should format JSON with 2-space indentation', () => {
+      disableServer('github');
+
+      const content = vol.readFileSync(localConfigPath, 'utf-8') as string;
+
+      expect(content).toContain('{\n  "deniedMcpServers"');
+      expect(content).toContain('    {\n      "serverName": "github"\n    }');
+    });
+
+    it('should add newline at end of file', () => {
+      disableServer('github');
+
+      const content = vol.readFileSync(localConfigPath, 'utf-8') as string;
+
+      expect(content.endsWith('\n')).toBe(true);
+    });
+  });
+});

--- a/packages/mcp-config/src/config/writer.ts
+++ b/packages/mcp-config/src/config/writer.ts
@@ -1,0 +1,133 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { dirname } from 'path';
+import type { DeniedMcpServer, SettingsLocal } from './types';
+import { getLocalConfigPath } from './reader';
+
+/**
+ * Ensure the .claude directory exists
+ */
+function ensureClaudeDirectory(): void {
+  const configPath = getLocalConfigPath();
+  const configDir = dirname(configPath);
+
+  if (!existsSync(configDir)) {
+    mkdirSync(configDir, { recursive: true });
+  }
+}
+
+/**
+ * Update local configuration with denied servers
+ * @param deniedServers Array of server names that should be denied
+ */
+export function updateLocalConfig(deniedServers: string[]): void {
+  ensureClaudeDirectory();
+
+  const configPath = getLocalConfigPath();
+  let config: SettingsLocal = {};
+
+  // Read existing config if it exists
+  if (existsSync(configPath)) {
+    try {
+      const content = readFileSync(configPath, 'utf-8');
+      config = JSON.parse(content) as SettingsLocal;
+    } catch (error) {
+      console.error(
+        `Failed to read existing config, creating new one: ${error}`
+      );
+      config = {};
+    }
+  }
+
+  // Update deniedMcpServers array with object format
+  config.deniedMcpServers = deniedServers.map(
+    (serverName): DeniedMcpServer => ({ serverName })
+  );
+
+  // Write updated config
+  try {
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+  } catch (error) {
+    throw new Error(`Failed to write config: ${error}`);
+  }
+}
+
+/**
+ * Enable a server by removing it from deniedMcpServers
+ */
+export function enableServer(serverName: string): void {
+  const configPath = getLocalConfigPath();
+
+  if (!existsSync(configPath)) {
+    // No config file means all servers are enabled, nothing to do
+    return;
+  }
+
+  let config: SettingsLocal;
+  try {
+    const content = readFileSync(configPath, 'utf-8');
+    config = JSON.parse(content) as SettingsLocal;
+  } catch (error) {
+    throw new Error(`Failed to read config: ${error}`);
+  }
+
+  if (!config.deniedMcpServers) {
+    // No denied servers, nothing to do
+    return;
+  }
+
+  // Remove server from denied list
+  config.deniedMcpServers = config.deniedMcpServers.filter(
+    (denied) => denied.serverName !== serverName
+  );
+
+  // Write updated config
+  try {
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+  } catch (error) {
+    throw new Error(`Failed to write config: ${error}`);
+  }
+}
+
+/**
+ * Disable a server by adding it to deniedMcpServers
+ */
+export function disableServer(serverName: string): void {
+  ensureClaudeDirectory();
+
+  const configPath = getLocalConfigPath();
+  let config: SettingsLocal = {};
+
+  // Read existing config if it exists
+  if (existsSync(configPath)) {
+    try {
+      const content = readFileSync(configPath, 'utf-8');
+      config = JSON.parse(content) as SettingsLocal;
+    } catch (error) {
+      console.error(
+        `Failed to read existing config, creating new one: ${error}`
+      );
+      config = {};
+    }
+  }
+
+  // Initialize deniedMcpServers if it doesn't exist
+  if (!config.deniedMcpServers) {
+    config.deniedMcpServers = [];
+  }
+
+  // Check if server is already denied
+  const alreadyDenied = config.deniedMcpServers.some(
+    (denied) => denied.serverName === serverName
+  );
+
+  if (!alreadyDenied) {
+    config.deniedMcpServers.push({ serverName });
+  }
+
+  // Write updated config
+  try {
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+  } catch (error) {
+    throw new Error(`Failed to write config: ${error}`);
+  }
+}

--- a/packages/mcp-config/src/index.ts
+++ b/packages/mcp-config/src/index.ts
@@ -1,0 +1,82 @@
+import { listCommand } from './commands/list';
+import { enableCommand } from './commands/enable';
+import { disableCommand } from './commands/disable';
+import { statusCommand } from './commands/status';
+import { interactiveCommand } from './commands/interactive';
+import { displayError, colorize } from './utils/display';
+
+/**
+ * Display help message
+ */
+function displayHelp(): void {
+  console.log(
+    colorize('\nMCP Config - Manage MCP servers for Claude Code', 'bold')
+  );
+  console.log(colorize('\nUsage:', 'bold'));
+  console.log('  mcp-config [command] [options]');
+  console.log(colorize('\nCommands:', 'bold'));
+  console.log('  list                       List all MCP servers with status');
+  console.log('  enable <server...>         Enable one or more servers');
+  console.log('  disable <server...>        Disable one or more servers');
+  console.log('  status                     Show detailed status');
+  console.log('  interactive                Interactive multi-select mode');
+  console.log('  help                       Show this help message');
+  console.log(colorize('\nExamples:', 'bold'));
+  console.log('  mcp-config                 # Interactive mode (default)');
+  console.log('  mcp-config list            # List all servers');
+  console.log('  mcp-config enable github   # Enable the github server');
+  console.log('  mcp-config disable supabase nx   # Disable multiple servers');
+  console.log(colorize('\nConfiguration:', 'bold'));
+  console.log('  Global:  ~/.claude.json');
+  console.log('  Local:   ./.claude/settings.local.json\n');
+}
+
+/**
+ * Parse CLI arguments and route to appropriate command
+ */
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const command = args[0];
+
+  try {
+    switch (command) {
+      case undefined:
+      case 'interactive':
+        await interactiveCommand();
+        break;
+
+      case 'list':
+        listCommand();
+        break;
+
+      case 'enable':
+        enableCommand(args.slice(1));
+        break;
+
+      case 'disable':
+        disableCommand(args.slice(1));
+        break;
+
+      case 'status':
+        statusCommand();
+        break;
+
+      case 'help':
+      case '--help':
+      case '-h':
+        displayHelp();
+        break;
+
+      default:
+        displayError(`Unknown command: ${command}`);
+        displayHelp();
+        process.exit(1);
+    }
+  } catch (error) {
+    displayError(`Error: ${error}`);
+    process.exit(1);
+  }
+}
+
+// Run the CLI
+main();

--- a/packages/mcp-config/src/lib/mcp-config.ts
+++ b/packages/mcp-config/src/lib/mcp-config.ts
@@ -1,0 +1,3 @@
+export function mcpConfig(): string {
+  return 'mcp-config';
+}

--- a/packages/mcp-config/src/utils/display.spec.ts
+++ b/packages/mcp-config/src/utils/display.spec.ts
@@ -1,0 +1,315 @@
+import {
+  colorize,
+  displayServerList,
+  displayDetailedStatus,
+  displaySuccess,
+  displayError,
+  displayWarning,
+  displayInfo,
+} from './display';
+import type { ServerStatus } from '../config/types';
+
+describe('Display Utilities', () => {
+  let consoleLogSpy: jest.SpyInstance;
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe('colorize', () => {
+    it('should wrap text with ANSI color codes', () => {
+      const result = colorize('test', 'green');
+      expect(result).toBe('\x1b[32mtest\x1b[0m');
+    });
+
+    it('should support red color', () => {
+      const result = colorize('error', 'red');
+      expect(result).toBe('\x1b[31merror\x1b[0m');
+    });
+
+    it('should support yellow color', () => {
+      const result = colorize('warning', 'yellow');
+      expect(result).toBe('\x1b[33mwarning\x1b[0m');
+    });
+
+    it('should support blue color', () => {
+      const result = colorize('info', 'blue');
+      expect(result).toBe('\x1b[34minfo\x1b[0m');
+    });
+
+    it('should support gray color', () => {
+      const result = colorize('muted', 'gray');
+      expect(result).toBe('\x1b[90mmuted\x1b[0m');
+    });
+
+    it('should support bold style', () => {
+      const result = colorize('bold text', 'bold');
+      expect(result).toBe('\x1b[1mbold text\x1b[0m');
+    });
+
+    it('should support reset', () => {
+      const result = colorize('reset', 'reset');
+      expect(result).toBe('\x1b[0mreset\x1b[0m');
+    });
+  });
+
+  describe('displayServerList', () => {
+    it('should display message when no servers configured', () => {
+      displayServerList([]);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('No MCP servers configured')
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Configure MCP servers in ~/.claude.json')
+      );
+    });
+
+    it('should display enabled servers', () => {
+      const statuses: ServerStatus[] = [
+        { name: 'github', enabled: true, source: 'none' },
+        { name: 'linear', enabled: true, source: 'none' },
+      ];
+
+      displayServerList(statuses);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('✓ Enabled Servers:')
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('✓')
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('github')
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('linear')
+      );
+    });
+
+    it('should display disabled servers with source', () => {
+      const statuses: ServerStatus[] = [
+        { name: 'github', enabled: false, source: 'local' },
+        { name: 'linear', enabled: false, source: 'global' },
+      ];
+
+      displayServerList(statuses);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('✗ Disabled Servers:')
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('github')
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('(local)')
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('linear')
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('(global)')
+      );
+    });
+
+    it('should display both enabled and disabled servers', () => {
+      const statuses: ServerStatus[] = [
+        { name: 'github', enabled: true, source: 'none' },
+        { name: 'linear', enabled: false, source: 'local' },
+        { name: 'notion', enabled: true, source: 'none' },
+      ];
+
+      displayServerList(statuses);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('✓ Enabled Servers:')
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('✗ Disabled Servers:')
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('2 enabled, 1 disabled')
+      );
+    });
+
+    it('should display count summary', () => {
+      const statuses: ServerStatus[] = [
+        { name: 'github', enabled: true, source: 'none' },
+        { name: 'linear', enabled: false, source: 'local' },
+        { name: 'notion', enabled: false, source: 'global' },
+      ];
+
+      displayServerList(statuses);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('1 enabled, 2 disabled')
+      );
+    });
+  });
+
+  describe('displayDetailedStatus', () => {
+    it('should display message when no servers configured', () => {
+      displayDetailedStatus([]);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('No MCP servers configured')
+      );
+    });
+
+    it('should display detailed status for enabled servers', () => {
+      const statuses: ServerStatus[] = [
+        { name: 'github', enabled: true, source: 'none' },
+      ];
+
+      displayDetailedStatus(statuses);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('MCP Server Status:')
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('github')
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Status:')
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Enabled')
+      );
+    });
+
+    it('should display detailed status for disabled servers with source', () => {
+      const statuses: ServerStatus[] = [
+        { name: 'github', enabled: false, source: 'local' },
+        { name: 'linear', enabled: false, source: 'global' },
+      ];
+
+      displayDetailedStatus(statuses);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('github')
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Disabled')
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('(local config)')
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('linear')
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('(global config)')
+      );
+    });
+
+    it('should display separator lines', () => {
+      const statuses: ServerStatus[] = [
+        { name: 'github', enabled: true, source: 'none' },
+      ];
+
+      displayDetailedStatus(statuses);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('─'.repeat(60))
+      );
+    });
+
+    it('should display summary with counts', () => {
+      const statuses: ServerStatus[] = [
+        { name: 'github', enabled: true, source: 'none' },
+        { name: 'linear', enabled: false, source: 'local' },
+        { name: 'notion', enabled: true, source: 'none' },
+      ];
+
+      displayDetailedStatus(statuses);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Total: 3 servers (2 enabled, 1 disabled)')
+      );
+    });
+  });
+
+  describe('displaySuccess', () => {
+    it('should display success message with checkmark', () => {
+      displaySuccess('Operation completed');
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('✓')
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Operation completed')
+      );
+    });
+
+    it('should use green color', () => {
+      displaySuccess('Success');
+
+      const call = consoleLogSpy.mock.calls[0][0];
+      expect(call).toContain('\x1b[32m'); // Green color code
+    });
+  });
+
+  describe('displayError', () => {
+    it('should display error message with X mark', () => {
+      displayError('Operation failed');
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('✗')
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Operation failed')
+      );
+    });
+
+    it('should use red color', () => {
+      displayError('Error');
+
+      const call = consoleErrorSpy.mock.calls[0][0];
+      expect(call).toContain('\x1b[31m'); // Red color code
+    });
+  });
+
+  describe('displayWarning', () => {
+    it('should display warning message with warning symbol', () => {
+      displayWarning('Be careful');
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('⚠')
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Be careful')
+      );
+    });
+
+    it('should use yellow color', () => {
+      displayWarning('Warning');
+
+      const call = consoleLogSpy.mock.calls[0][0];
+      expect(call).toContain('\x1b[33m'); // Yellow color code
+    });
+  });
+
+  describe('displayInfo', () => {
+    it('should display info message', () => {
+      displayInfo('Information message');
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Information message')
+      );
+    });
+
+    it('should use blue color', () => {
+      displayInfo('Info');
+
+      const call = consoleLogSpy.mock.calls[0][0];
+      expect(call).toContain('\x1b[34m'); // Blue color code
+    });
+  });
+});

--- a/packages/mcp-config/src/utils/display.ts
+++ b/packages/mcp-config/src/utils/display.ts
@@ -1,0 +1,135 @@
+import type { ServerStatus } from '../config/types';
+
+/**
+ * ANSI color codes
+ */
+const colors = {
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  gray: '\x1b[90m',
+};
+
+/**
+ * Format text with color
+ */
+export function colorize(text: string, color: keyof typeof colors): string {
+  return `${colors[color]}${text}${colors.reset}`;
+}
+
+/**
+ * Display a list of servers with their status
+ */
+export function displayServerList(statuses: ServerStatus[]): void {
+  if (statuses.length === 0) {
+    console.log(colorize('No MCP servers configured.', 'yellow'));
+    console.log(
+      colorize(
+        '\nConfigure MCP servers in ~/.claude.json to get started.',
+        'gray'
+      )
+    );
+    return;
+  }
+
+  const enabled = statuses.filter((s) => s.enabled);
+  const disabled = statuses.filter((s) => !s.enabled);
+
+  if (enabled.length > 0) {
+    console.log(colorize('\n✓ Enabled Servers:', 'bold'));
+    enabled.forEach((server) => {
+      console.log(`  ${colorize('✓', 'green')} ${server.name}`);
+    });
+  }
+
+  if (disabled.length > 0) {
+    console.log(colorize('\n✗ Disabled Servers:', 'bold'));
+    disabled.forEach((server) => {
+      const source =
+        server.source === 'local'
+          ? colorize('(local)', 'gray')
+          : colorize('(global)', 'gray');
+      console.log(`  ${colorize('✗', 'red')} ${server.name} ${source}`);
+    });
+  }
+
+  console.log(
+    colorize(`\n${enabled.length} enabled, ${disabled.length} disabled`, 'gray')
+  );
+}
+
+/**
+ * Display detailed status for servers
+ */
+export function displayDetailedStatus(statuses: ServerStatus[]): void {
+  if (statuses.length === 0) {
+    console.log(colorize('No MCP servers configured.', 'yellow'));
+    return;
+  }
+
+  console.log(colorize('\nMCP Server Status:', 'bold'));
+  console.log(colorize('─'.repeat(60), 'gray'));
+
+  statuses.forEach((server) => {
+    const statusIcon = server.enabled
+      ? colorize('✓', 'green')
+      : colorize('✗', 'red');
+    const statusText = server.enabled
+      ? colorize('Enabled', 'green')
+      : colorize('Disabled', 'red');
+
+    let sourceText = '';
+    if (!server.enabled) {
+      sourceText =
+        server.source === 'local'
+          ? colorize(' (local config)', 'gray')
+          : colorize(' (global config)', 'gray');
+    }
+
+    console.log(`${statusIcon} ${server.name}`);
+    console.log(`   Status: ${statusText}${sourceText}`);
+    console.log('');
+  });
+
+  const enabled = statuses.filter((s) => s.enabled).length;
+  const disabled = statuses.filter((s) => !s.enabled).length;
+
+  console.log(colorize('─'.repeat(60), 'gray'));
+  console.log(
+    colorize(
+      `Total: ${statuses.length} servers (${enabled} enabled, ${disabled} disabled)`,
+      'gray'
+    )
+  );
+}
+
+/**
+ * Display success message
+ */
+export function displaySuccess(message: string): void {
+  console.log(colorize(`✓ ${message}`, 'green'));
+}
+
+/**
+ * Display error message
+ */
+export function displayError(message: string): void {
+  console.error(colorize(`✗ ${message}`, 'red'));
+}
+
+/**
+ * Display warning message
+ */
+export function displayWarning(message: string): void {
+  console.log(colorize(`⚠ ${message}`, 'yellow'));
+}
+
+/**
+ * Display info message
+ */
+export function displayInfo(message: string): void {
+  console.log(colorize(message, 'blue'));
+}

--- a/packages/mcp-config/tsconfig.json
+++ b/packages/mcp-config/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/mcp-config/tsconfig.lib.json
+++ b/packages/mcp-config/tsconfig.lib.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"],
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src/**/*.ts"],
+  "references": [],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/packages/mcp-config/tsconfig.spec.json
+++ b/packages/mcp-config/tsconfig.spec.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/jest",
+    "types": ["jest", "node"],
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts",
+    "src/**/*.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,9 @@
     },
     {
       "path": "./apps/slack-oauth-backend"
+    },
+    {
+      "path": "./packages/mcp-config"
     }
   ]
 }


### PR DESCRIPTION
## Description

Completes DEV-125

- Introduced the `@uniswap/ai-toolkit-claude-mcp-helper` package, a CLI tool for managing MCP (Model Context Protocol) servers in Claude Code workspaces.
- Implemented commands for listing, enabling, disabling, and checking the status of MCP servers.
- Added interactive mode for multi-select server management.
- Configurations are read from global and local settings, with local settings taking precedence.
- Included comprehensive documentation and examples for usage.