### PR TITLE
chore(ai-toolkit-nx-claude): change custom addon install's default to true

### DIFF
--- a/packages/ai-toolkit-nx-claude/src/generators/init/schema.json
+++ b/packages/ai-toolkit-nx-claude/src/generators/init/schema.json
@@ -133,7 +133,7 @@
     "installAddons": {
       "type": "boolean",
       "description": "Install addons like spec-mcp-workflow",
-      "default": false,
+      "default": true,
       "prompt-when": "installMode === 'custom'",
       "prompt-message": "🔌 Install addons/mcps?",
       "prompt-type": "confirm"


### PR DESCRIPTION
I've never used false here, so I'm setting it to true to speed up how I use and test this command