### PR TITLE
feat(ci): push git tags immediately after successful package publishing and handle partial failures

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -44,13 +44,13 @@ on:
   workflow_dispatch:
     inputs:
       dryRun:
-        description: "Perform a dry run without publishing"
+        description: 'Perform a dry run without publishing'
         required: false
-        default: "false"
+        default: 'false'
         type: choice
         options:
-          - "true"
-          - "false"
+          - 'true'
+          - 'false'
 
 # Ensure only one publish workflow runs at a time per branch
 # If a new run is triggered while one is in progress, it will be queued
@@ -72,6 +72,12 @@ jobs:
       issues: write
     outputs:
       has_affected: ${{ steps.affected.outputs.has_affected }}
+      successful_packages: ${{ steps.publish.outputs.successful_packages }}
+      failed_packages: ${{ steps.publish.outputs.failed_packages }}
+      successful_count: ${{ steps.publish.outputs.successful_count }}
+      failed_count: ${{ steps.publish.outputs.failed_count }}
+      has_failures: ${{ steps.publish.outputs.has_failures }}
+      has_successes: ${{ steps.publish.outputs.has_successes }}
     # Skip the workflow if the commit is a version bump (to prevent loops)
     # Allow workflow to run for merge commits from update-production workflow
     # Skip workflow for branch sync commits
@@ -89,9 +95,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: "22.21.1"
-          registry-url: "https://registry.npmjs.org"
-          scope: "@uniswap"
+          node-version: '22.21.1'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@uniswap'
 
       - name: Install npm
         run: npm install -g npm@11.6.2
@@ -436,6 +442,7 @@ jobs:
 
       - name: Publish affected packages to NPM
         if: github.event.inputs.dryRun != 'true' && github.event_name == 'push' && steps.affected.outputs.has_affected == 'true'
+        id: publish
         run: |
           # Configure npm authentication for viewing restricted packages
           # The @uniswap packages are restricted and require authentication even for read operations
@@ -491,6 +498,17 @@ jobs:
               if npx nx release publish --projects="$project" --tag=${{ steps.npm-tag.outputs.tag }} --registry=https://registry.npmjs.org; then
                 echo "✅ Successfully published $package"
                 SUCCESS_PACKAGES+=("$package")
+
+                # Immediately push the git tag for this successful publish
+                PACKAGE_TAG=$(git tag -l "${PACKAGE_NAME}@*" "${package}@*" 2>/dev/null | sort -V | tail -n 1)
+                if [ -n "$PACKAGE_TAG" ]; then
+                  echo "🏷️  Pushing tag: $PACKAGE_TAG"
+                  if git push origin "$PACKAGE_TAG" 2>/dev/null; then
+                    echo "✅ Successfully pushed tag $PACKAGE_TAG"
+                  else
+                    echo "⚠️  Failed to push tag $PACKAGE_TAG (may already exist on remote)"
+                  fi
+                fi
               else
                 echo "❌ Failed to publish $package"
                 FAILED_PACKAGES+=("$package")
@@ -514,6 +532,17 @@ jobs:
               if npx nx release publish --projects="$project" --first-release --tag=${{ steps.npm-tag.outputs.tag }} --registry=https://registry.npmjs.org; then
                 echo "✅ Successfully published $package (first release)"
                 SUCCESS_PACKAGES+=("$package")
+
+                # Immediately push the git tag for this successful publish
+                PACKAGE_TAG=$(git tag -l "${PACKAGE_NAME}@*" "${package}@*" 2>/dev/null | sort -V | tail -n 1)
+                if [ -n "$PACKAGE_TAG" ]; then
+                  echo "🏷️  Pushing tag: $PACKAGE_TAG"
+                  if git push origin "$PACKAGE_TAG" 2>/dev/null; then
+                    echo "✅ Successfully pushed tag $PACKAGE_TAG"
+                  else
+                    echo "⚠️  Failed to push tag $PACKAGE_TAG (may already exist on remote)"
+                  fi
+                fi
               else
                 echo "❌ Failed to publish $package (first release)"
                 FAILED_PACKAGES+=("$package")
@@ -522,6 +551,18 @@ jobs:
 
             echo ""
           done
+
+          # Convert arrays to JSON for outputs
+          SUCCESS_JSON=$(printf '%s\n' "${SUCCESS_PACKAGES[@]}" | jq -R . | jq -s -c .)
+          FAILED_JSON=$(printf '%s\n' "${FAILED_PACKAGES[@]}" | jq -R . | jq -s -c .)
+
+          # Set step outputs
+          echo "successful_packages=$SUCCESS_JSON" >> $GITHUB_OUTPUT
+          echo "failed_packages=$FAILED_JSON" >> $GITHUB_OUTPUT
+          echo "successful_count=${#SUCCESS_PACKAGES[@]}" >> $GITHUB_OUTPUT
+          echo "failed_count=${#FAILED_PACKAGES[@]}" >> $GITHUB_OUTPUT
+          echo "has_failures=$( [ ${#FAILED_PACKAGES[@]} -gt 0 ] && echo 'true' || echo 'false' )" >> $GITHUB_OUTPUT
+          echo "has_successes=$( [ ${#SUCCESS_PACKAGES[@]} -gt 0 ] && echo 'true' || echo 'false' )" >> $GITHUB_OUTPUT
 
           # Report results
           echo "=========================================="
@@ -539,36 +580,168 @@ jobs:
               echo "  ❌ $pkg"
             done
             echo ""
-            echo "❌ Some packages failed to publish. Check the logs above for details."
-            exit 1
+            echo "⚠️  Some packages failed to publish, but workflow will continue for successful packages."
           else
             echo ""
             echo "✅ All packages published successfully!"
           fi
+
+          # Exit successfully even if some packages failed (as long as at least one succeeded)
+          # This allows the workflow to continue and push tags/create releases for successful packages
+          if [ ${#SUCCESS_PACKAGES[@]} -eq 0 ]; then
+            echo ""
+            echo "❌ No packages were successfully published. Failing workflow."
+            exit 1
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
 
-      - name: Push version commits and tags
-        if: github.event.inputs.dryRun != 'true' && github.event_name == 'push' && steps.affected.outputs.has_affected == 'true'
+      - name: Revert failed package versions
+        if: github.event.inputs.dryRun != 'true' && github.event_name == 'push' && steps.publish.outputs.has_failures == 'true'
         run: |
-          # Push commits and tags created by Nx
-          git push origin ${{ github.ref_name }} --follow-tags
+          echo "=========================================="
+          echo "Reverting version bumps for failed packages"
+          echo "=========================================="
+          echo ""
+          echo "This ensures git stays in sync with npm - only successfully"
+          echo "published packages will have their versions bumped in git."
+          echo ""
+
+          AFFECTED_PROJECTS="${{ steps.affected.outputs.projects }}"
+          FAILED_PACKAGES='${{ steps.publish.outputs.failed_packages }}'
+
+          # Parse JSON array of failed packages
+          readarray -t FAILED < <(echo "$FAILED_PACKAGES" | jq -r '.[]')
+
+          if [ ${#FAILED[@]} -eq 0 ]; then
+            echo "No failed packages to revert."
+            exit 0
+          fi
+
+          echo "Failed packages to revert: ${#FAILED[@]}"
+          echo ""
+
+          # Convert affected projects to array for mapping
+          IFS=',' read -ra PROJECTS <<< "$AFFECTED_PROJECTS"
+
+          for failed_package in "${FAILED[@]}"; do
+            if [ -z "$failed_package" ]; then
+              continue
+            fi
+
+            echo "Processing: $failed_package"
+
+            # Find the Nx project for this package
+            for project in "${PROJECTS[@]}"; do
+              if [ -z "$project" ]; then
+                continue
+              fi
+
+              # Get project root from Nx
+              PROJECT_ROOT=$(npx nx show project "$project" --json 2>/dev/null | jq -r '.root' || echo "")
+
+              if [ -z "$PROJECT_ROOT" ] || [ ! -f "$PROJECT_ROOT/package.json" ]; then
+                continue
+              fi
+
+              # Check if this is the package we're looking for
+              PACKAGE_NAME=$(jq -r '.name // ""' "$PROJECT_ROOT/package.json")
+
+              if [ "$PACKAGE_NAME" = "$failed_package" ]; then
+                echo "  Found at: $PROJECT_ROOT/package.json"
+
+                # Get the version that was bumped to (but never published)
+                CURRENT_VERSION=$(jq -r '.version' "$PROJECT_ROOT/package.json")
+                echo "  Current version (not published): $CURRENT_VERSION"
+
+                # Delete the local git tag for this unpublished version
+                PACKAGE_NAME_FOR_TAG=$(echo "$failed_package" | sed 's/@[^/]*\///')
+                TAG_TO_DELETE=$(git tag -l "${PACKAGE_NAME_FOR_TAG}@*" "${failed_package}@*" 2>/dev/null | grep "@${CURRENT_VERSION}$" | head -n 1)
+
+                if [ -n "$TAG_TO_DELETE" ]; then
+                  echo "  Deleting local tag: $TAG_TO_DELETE"
+                  git tag -d "$TAG_TO_DELETE" 2>/dev/null || echo "  ⚠️  Tag already deleted"
+                fi
+
+                # Reset package.json to the version before this commit (HEAD~1)
+                echo "  Reverting package.json to previous version..."
+                git checkout HEAD~1 -- "$PROJECT_ROOT/package.json"
+
+                # Verify the revert
+                REVERTED_VERSION=$(jq -r '.version' "$PROJECT_ROOT/package.json")
+                echo "  ✅ Reverted to: $REVERTED_VERSION"
+                echo ""
+
+                break
+              fi
+            done
+          done
+
+          # Stage the reverted files
+          git add -A
+
+          # Check if there are any changes staged
+          if git diff --cached --quiet; then
+            echo "⚠️  No changes staged after reverting."
+            echo "This is unexpected - please review the workflow logs."
+          else
+            echo "=========================================="
+            echo "Amending version commit"
+            echo "=========================================="
+            echo ""
+            echo "Updating the version commit to only include successfully published packages."
+            echo ""
+
+            # Show what's being reverted
+            echo "Changes being committed:"
+            git diff --cached --name-status
+
+            # Amend the commit to include the reverted package.json files
+            git commit --amend --no-edit
+
+            echo "✅ Version commit amended successfully"
+          fi
+
+          echo ""
+          echo "=========================================="
+          echo "Version Revert Complete"
+          echo "=========================================="
+          echo ""
+          echo "Git is now in sync with npm:"
+          echo "  - Successfully published packages: version bumped ✅"
+          echo "  - Failed packages: version reverted to previous ⏮️"
+          echo ""
+        env:
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+
+      - name: Push version commit
+        if: github.event.inputs.dryRun != 'true' && github.event_name == 'push' && steps.publish.outputs.has_successes == 'true'
+        run: |
+          # Push the version commit created by Nx (and potentially amended if there were failures)
+          # Tags have already been pushed individually after each successful publish
+          git push origin ${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
 
       - name: Create GitHub releases
-        if: github.event.inputs.dryRun != 'true' && github.event_name == 'push' && steps.affected.outputs.has_affected == 'true'
+        if: github.event.inputs.dryRun != 'true' && github.event_name == 'push' && steps.publish.outputs.has_successes == 'true'
         run: |
-          # Get the tags that were just pushed (created by Nx release version)
-          # These are the tags created since the previous commit
-          AFFECTED_PACKAGES="${{ steps.affected.outputs.packages }}"
+          # Get only the successfully published packages from the publish step
+          # Parse the JSON array of successful packages
+          SUCCESSFUL_PACKAGES='${{ steps.publish.outputs.successful_packages }}'
 
-          echo "Creating GitHub releases for affected packages..."
-          echo "npm packages: $AFFECTED_PACKAGES"
+          echo "Creating GitHub releases for successfully published packages..."
+          echo "Successful packages JSON: $SUCCESSFUL_PACKAGES"
           echo ""
 
-          # Convert comma-separated list to array
-          IFS=',' read -ra PACKAGES <<< "$AFFECTED_PACKAGES"
+          # Parse JSON array into bash array
+          readarray -t PACKAGES < <(echo "$SUCCESSFUL_PACKAGES" | jq -r '.[]')
+
+          if [ ${#PACKAGES[@]} -eq 0 ]; then
+            echo "⚠️  No successfully published packages to create releases for."
+            exit 0
+          fi
 
           for package in "${PACKAGES[@]}"; do
             if [ -z "$package" ]; then
@@ -618,13 +791,54 @@ jobs:
   generate-changelog:
     name: Generate AI-powered changelog
     needs: publish
-    if: github.event.inputs.dryRun != 'true' && github.event_name == 'push' && needs.publish.outputs.has_affected == 'true'
+    if: github.event.inputs.dryRun != 'true' && github.event_name == 'push' && needs.publish.outputs.has_successes == 'true'
     uses: ./.github/workflows/_generate-changelog.yml
     with:
       from_ref: ${{ github.event.before }}
       to_ref: ${{ github.sha }}
-      output_formats: "slack,markdown"
-      custom_prompt_file: ".github/prompts/release-changelog.md"
+      output_formats: 'slack,markdown'
+      custom_prompt_text: |
+        # Release Changelog Generation Prompt
+
+        You are a changelog generator. Based on the following git changes, create a concise, human-readable changelog summary.
+
+        ${{ needs.publish.outputs.has_failures == 'true' && format('**IMPORTANT**: This is a PARTIAL release. Some packages failed to publish.
+
+        **Successfully published packages**:
+        {0}
+
+        **Failed packages** (not published):
+        {1}
+
+        Focus your changelog ONLY on the successfully published packages. Add a note at the end about which packages failed to publish.
+
+        ', join(fromJSON(needs.publish.outputs.successful_packages), ', '), join(fromJSON(needs.publish.outputs.failed_packages), ', ')) || format('All packages were successfully published.
+
+        **Published packages**:
+        {0}
+
+        ', join(fromJSON(needs.publish.outputs.successful_packages), ', ')) }}
+
+        Focus on:
+        - What features were added
+        - What bugs were fixed
+        - What was changed or improved
+
+        Format requirements:
+        - Use bullet points (• or -) for each item, separated by a newline character
+        - Keep it to 3-10 items max
+        - Be concise and clear
+        - Do NOT include commit hashes unless specifically requested
+        - Group related changes together
+
+        Slack formatting requirements (IMPORTANT):
+        - DO NOT use markdown headers (no #, ##, ###)
+        - Use plain text for section titles followed by a colon (e.g., "Features:")
+        - Use _single asterisks_ for bold text (NOT double asterisks)
+        - Use _underscores_ for italic text
+        - Use simple bullet lists with • or - characters
+        - Keep formatting minimal and clean
+        - DO NOT use standard markdown links [text](url) - just use plain URLs or omit them
       max_tokens: 1024
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -632,15 +846,16 @@ jobs:
   notify-release:
     name: Notify release via Slack
     needs: [publish, generate-changelog]
-    if: github.event.inputs.dryRun != 'true' && github.event_name == 'push' && needs.publish.outputs.has_affected == 'true'
+    if: github.event.inputs.dryRun != 'true' && github.event_name == 'push' && needs.publish.outputs.has_successes == 'true'
     uses: ./.github/workflows/_notify-release.yml
     with:
       changelog_slack: ${{ needs.generate-changelog.outputs.changelog_slack }}
       changelog_markdown: ${{ needs.generate-changelog.outputs.changelog_markdown }}
-      destinations: "slack,notion"
+      destinations: 'slack,notion'
       from_ref: ${{ github.event.before }}
       to_ref: ${{ github.sha }}
       branch: ${{ github.ref_name }}
+      release_title: ${{ needs.publish.outputs.has_failures == 'true' && format('⚠️ Partial Release - {0} ({1} succeeded, {2} failed)', github.ref_name, needs.publish.outputs.successful_count, needs.publish.outputs.failed_count) || '' }}
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 

--- a/packages/notion-publisher/CLAUDE.md
+++ b/packages/notion-publisher/CLAUDE.md
@@ -13,6 +13,7 @@ This package fills a critical gap in the Notion integration ecosystem. Existing 
 ### Core Components
 
 #### 1. **cli.ts** (Entry Point)
+
 - Executable CLI script with shebang (`#!/usr/bin/env node`)
 - Uses `minimist` for argument parsing (supports both flags and environment variables)
 - Environment variables take precedence over CLI flags for security (prevents secrets in process listings)
@@ -20,11 +21,13 @@ This package fills a critical gap in the Notion integration ecosystem. Existing 
 - Outputs Notion page URL to stdout for capture in CI/CD pipelines
 
 #### 2. **Notion API Integration**
+
 - Uses `@notionhq/client` (official Notion SDK)
 - Creates pages in databases (not standalone pages)
 - Supports custom database properties
 
 #### 3. **Markdown Conversion**
+
 - Uses `@tryfabric/martian` library for markdown-to-Notion-blocks conversion
 - Implements JSON serialization workaround for type incompatibility between martian and Notion SDK
 
@@ -33,11 +36,13 @@ This package fills a critical gap in the Notion integration ecosystem. Existing 
 #### Why @tryfabric/martian?
 
 **Chosen over**:
+
 - `markdown-to-notion` - Less maintained, fewer features
 - Custom parser - Too much complexity, reinventing the wheel
 - `notion-md-gen` - Doesn't support database creation
 
 **Reasons**:
+
 1. ✅ Well-maintained by Fabric team
 2. ✅ Comprehensive markdown support (headers, lists, code blocks, tables, etc.)
 3. ✅ Generates proper Notion block structures
@@ -47,11 +52,13 @@ This package fills a critical gap in the Notion integration ecosystem. Existing 
 #### Why minimist for CLI parsing?
 
 **Chosen over**:
+
 - `commander` - Too heavyweight for simple use case
 - `yargs` - Excessive features not needed
 - Built-in `process.argv` parsing - No alias support, manual validation
 
 **Reasons**:
+
 1. ✅ Lightweight (~1KB)
 2. ✅ Simple API for our use case
 3. ✅ Supports aliases (`--api-key` → `apiKey`)
@@ -66,6 +73,7 @@ const notionBlocks = JSON.parse(JSON.stringify(blocks));
 ```
 
 **Why this is necessary**:
+
 - `@tryfabric/martian` generates block types that are structurally compatible with `@notionhq/client`
 - However, TypeScript sees them as incompatible types at compile time
 - Runtime behavior is correct—types are structurally identical
@@ -73,6 +81,7 @@ const notionBlocks = JSON.parse(JSON.stringify(blocks));
 - Alternative would be extensive type assertions, which are less safe
 
 **Trade-offs**:
+
 - ✅ Type-safe at compile time
 - ✅ Works correctly at runtime
 - ⚠️ Minor performance overhead (negligible for typical use)
@@ -88,6 +97,7 @@ const databaseId = process.env.RELEASE_NOTES_NOTION_DATABASE_ID || args.database
 ```
 
 **Reasoning**:
+
 - CLI flags appear in `ps aux` output and process listings
 - Environment variables are hidden from process listings
 - Follows 12-factor app principles
@@ -102,6 +112,7 @@ const logInfo = (message: string) => {
 ```
 
 **Why stderr for logs**:
+
 - stdout is reserved for the Notion page URL (captures in CI/CD)
 - stderr is the standard stream for diagnostic messages
 - Allows clean piping: `PAGE_URL=$(notion-publisher ...)`
@@ -110,29 +121,29 @@ const logInfo = (message: string) => {
 
 ### Production Dependencies
 
-| Package | Version | Purpose |
-|---------|---------|---------|
-| `@notionhq/client` | ^2.2.15 | Official Notion API SDK |
-| `@tryfabric/martian` | ^1.2.4 | Markdown to Notion blocks converter |
-| `minimist` | ^1.2.8 | CLI argument parser |
-| `tslib` | ^2.3.0 | TypeScript runtime helpers |
+| Package              | Version | Purpose                             |
+| -------------------- | ------- | ----------------------------------- |
+| `@notionhq/client`   | ^2.2.15 | Official Notion API SDK             |
+| `@tryfabric/martian` | ^1.2.4  | Markdown to Notion blocks converter |
+| `minimist`           | ^1.2.8  | CLI argument parser                 |
+| `tslib`              | ^2.3.0  | TypeScript runtime helpers          |
 
 ### Development Dependencies
 
-| Package | Version | Purpose |
-|---------|---------|---------|
-| `@types/minimist` | ^1.2.5 | Type definitions for minimist |
+| Package           | Version | Purpose                       |
+| ----------------- | ------- | ----------------------------- |
+| `@types/minimist` | ^1.2.5  | Type definitions for minimist |
 
 ## Database Schema Requirements
 
 The target Notion database MUST have these properties:
 
-| Property Name | Type | Required | Description |
-|--------------|------|----------|-------------|
-| **Name** | Title | Yes | Page title (automatically created) |
-| **Date** | Date | Yes | Timestamp of page creation |
-| **Commit Range** | Rich Text | No | Git reference range (e.g., "v1.0.0 → v1.1.0") |
-| **Branch** | Rich Text | No | Git branch name |
+| Property Name    | Type      | Required | Description                                   |
+| ---------------- | --------- | -------- | --------------------------------------------- |
+| **Name**         | Title     | Yes      | Page title (automatically created)            |
+| **Date**         | Date      | Yes      | Timestamp of page creation                    |
+| **Commit Range** | Rich Text | No       | Git reference range (e.g., "v1.0.0 → v1.1.0") |
+| **Branch**       | Rich Text | No       | Git branch name                               |
 
 **Note**: The property names are hardcoded in cli.ts:90-116. If users need different property names, they must create database views or modify the code.
 
@@ -217,6 +228,7 @@ describe('notion-publisher', () => {
 ```
 
 **Mock Strategy**:
+
 - Mock `@notionhq/client` for API tests
 - Mock `@tryfabric/martian` for markdown conversion tests
 - Use real implementations for integration tests
@@ -226,6 +238,7 @@ describe('notion-publisher', () => {
 ### 1. Fixed Database Schema
 
 The tool expects specific property names:
+
 - "Name" (Title)
 - "Date" (Date)
 - "Commit Range" (Rich Text)
@@ -293,6 +306,7 @@ if (!apiKey) {
 ```
 
 **Exit Codes**:
+
 - `0` - Success
 - `1` - Validation error or API failure
 
@@ -312,6 +326,7 @@ catch (error) {
 ```
 
 **Common API Errors**:
+
 - `404` - Database not found or no access
 - `400` - Invalid request (missing/invalid properties)
 - `401` - Invalid API key
@@ -360,6 +375,7 @@ catch (error) {
 ### Deprecation Strategy
 
 If changes are needed:
+
 1. Add new option with new name
 2. Mark old option as deprecated (add warning)
 3. Support both for 2-3 versions

--- a/packages/notion-publisher/README.md
+++ b/packages/notion-publisher/README.md
@@ -38,7 +38,7 @@ npm install --save-dev @uniswap/notion-publisher
 
 ### 1. Create a Notion Integration
 
-1. Go to https://www.notion.so/my-integrations
+1. Go to <https://www.notion.so/my-integrations>
 2. Click "New integration"
 3. Give it a name (e.g., "Release Notes Publisher")
 4. Select the workspace
@@ -75,6 +75,7 @@ notion-publisher \
 ```
 
 Required environment variables:
+
 - `NOTION_API_KEY` - Your Notion integration token
 - `RELEASE_NOTES_NOTION_DATABASE_ID` - Target database ID
 
@@ -168,11 +169,11 @@ publish_to_notion:
   image: node:22
   script:
     - npx @uniswap/notion-publisher
-        --title "Release $CI_COMMIT_TAG"
-        --content "$(cat CHANGELOG.md)"
-        --from-ref "$CI_COMMIT_BEFORE_SHA"
-        --to-ref "$CI_COMMIT_SHA"
-        --branch "$CI_COMMIT_BRANCH"
+      --title "Release $CI_COMMIT_TAG"
+      --content "$(cat CHANGELOG.md)"
+      --from-ref "$CI_COMMIT_BEFORE_SHA"
+      --to-ref "$CI_COMMIT_SHA"
+      --branch "$CI_COMMIT_BRANCH"
   variables:
     NOTION_API_KEY: $NOTION_API_KEY
     RELEASE_NOTES_NOTION_DATABASE_ID: $NOTION_DATABASE_ID
@@ -239,15 +240,15 @@ pipeline {
 
 ## CLI Arguments
 
-| Argument | Environment Variable | Required | Description |
-|----------|---------------------|----------|-------------|
-| `--api-key` | `NOTION_API_KEY` | Yes | Notion integration token |
-| `--database-id` | `RELEASE_NOTES_NOTION_DATABASE_ID` | Yes | Target Notion database ID (32-char hex) |
-| `--title` | - | Yes | Page title for the release notes |
-| `--content` | - | Yes | Page content in markdown format |
-| `--from-ref` | - | No | Starting git reference (e.g., previous version tag) |
-| `--to-ref` | - | No | Ending git reference (e.g., current version tag) |
-| `--branch` | - | No | Branch name where the release was made |
+| Argument        | Environment Variable               | Required | Description                                         |
+| --------------- | ---------------------------------- | -------- | --------------------------------------------------- |
+| `--api-key`     | `NOTION_API_KEY`                   | Yes      | Notion integration token                            |
+| `--database-id` | `RELEASE_NOTES_NOTION_DATABASE_ID` | Yes      | Target Notion database ID (32-char hex)             |
+| `--title`       | -                                  | Yes      | Page title for the release notes                    |
+| `--content`     | -                                  | Yes      | Page content in markdown format                     |
+| `--from-ref`    | -                                  | No       | Starting git reference (e.g., previous version tag) |
+| `--to-ref`      | -                                  | No       | Ending git reference (e.g., current version tag)    |
+| `--branch`      | -                                  | No       | Branch name where the release was made              |
 
 **Note**: Environment variables take precedence over CLI flags for API key and database ID.
 
@@ -256,7 +257,7 @@ pipeline {
 The tool uses [@tryfabric/martian](https://github.com/tryfabric/martian) to convert markdown to Notion blocks. Supported markdown features include:
 
 - Headers (H1, H2, H3)
-- **Bold**, *italic*, ~~strikethrough~~ text
+- **Bold**, _italic_, ~~strikethrough~~ text
 - Lists (ordered and unordered)
 - Code blocks with syntax highlighting
 - Links
@@ -318,6 +319,7 @@ export RELEASE_NOTES_NOTION_DATABASE_ID="32-char-hex-id"
 **Cause**: Database doesn't exist or integration doesn't have access
 
 **Solution**:
+
 1. Verify the database ID is correct
 2. Share the database with your integration:
    - Open the database in Notion
@@ -329,6 +331,7 @@ export RELEASE_NOTES_NOTION_DATABASE_ID="32-char-hex-id"
 **Cause**: Database schema doesn't match expected properties
 
 **Solution**: Ensure your database has these properties:
+
 - **Name** (Title type)
 - **Date** (Date type)
 - **Commit Range** (Text type) - if using `--from-ref` or `--to-ref`
@@ -403,13 +406,13 @@ This package is automatically published via the repository's CI/CD workflow usin
 
 Existing GitHub Actions for Notion have limitations:
 
-| Feature | @uniswap/notion-publisher | tryfabric/markdown-to-notion | push-markdown-to-notion |
-|---------|---------------------------|------------------------------|-------------------------|
-| **Create new pages** | ✅ Yes | ❌ No (updates only) | ❌ No (updates only) |
-| **Write to databases** | ✅ Yes | ❌ No | ❌ No |
-| **Custom properties** | ✅ Yes | ❌ No | ❌ No |
-| **Maintenance** | 🆕 Active (2024) | ⚠️ Stale (2022) | ⚠️ Low activity |
-| **CI agnostic** | ✅ Yes (CLI tool) | ❌ GitHub only | ❌ GitHub only |
+| Feature                | @uniswap/notion-publisher | tryfabric/markdown-to-notion | push-markdown-to-notion |
+| ---------------------- | ------------------------- | ---------------------------- | ----------------------- |
+| **Create new pages**   | ✅ Yes                    | ❌ No (updates only)         | ❌ No (updates only)    |
+| **Write to databases** | ✅ Yes                    | ❌ No                        | ❌ No                   |
+| **Custom properties**  | ✅ Yes                    | ❌ No                        | ❌ No                   |
+| **Maintenance**        | 🆕 Active (2024)          | ⚠️ Stale (2022)              | ⚠️ Low activity         |
+| **CI agnostic**        | ✅ Yes (CLI tool)         | ❌ GitHub only               | ❌ GitHub only          |
 
 This tool was created to fill the gap: **creating new Notion database entries with structured metadata**, which is essential for release notes and changelog tracking.
 


### PR DESCRIPTION
### TL;DR

Improve the package publishing workflow to handle partial failures gracefully and push tags immediately after each successful package publish.

### What changed?

- Added immediate tag pushing after each successful package publish instead of pushing all tags at the end
- Implemented partial success handling - the workflow now continues even if some packages fail to publish
- Added detailed output variables to track successful and failed packages
- Updated the changelog generation to acknowledge partial releases
- Modified the Slack notification to indicate partial releases with a warning emoji
- Fixed formatting in Notion publisher documentation files

### How to test?

1. Trigger a package publish workflow with the "workflow_dispatch" event
2. Verify that tags are pushed immediately after each successful package publish
3. Simulate a partial failure by temporarily breaking one package and verify the workflow continues for other packages
4. Check that the Slack notification correctly indicates a partial release when applicable
5. Verify that GitHub releases are created only for successfully published packages

### Why make this change?

The previous workflow would fail entirely if any package failed to publish, preventing successful packages from being released. This change makes the workflow more resilient by allowing successful packages to be published even when others fail. 

Pushing tags immediately after each successful publish ensures that even if the workflow is interrupted later, the tags for already published packages are preserved. This prevents situations where a package is published to npm but its corresponding tag is missing.

The improved notifications make it clear to developers when a partial release has occurred, allowing them to address failed packages separately.