### PR TITLE
chore(ci): add test hook to lefthook configuration

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -75,6 +75,27 @@ All workflows follow consistent patterns:
 4. **Caching**: NPM dependencies, Nx computation cache
 5. **Artifacts**: Store important outputs
 
+### Repository Variables
+
+Version pinning is centralized using GitHub repository variables (`vars.*`):
+
+| Variable | Value | Purpose |
+|----------|-------|---------|
+| `NODE_VERSION` | `22.21.1` | Node.js version for all workflows |
+| `NPM_VERSION` | `11.6.2` | npm version (required for OIDC publishing) |
+
+**Usage in workflows:**
+
+```yaml
+- uses: actions/setup-node@...
+  with:
+    node-version: ${{ vars.NODE_VERSION }}
+
+- run: npm install -g npm@${{ vars.NPM_VERSION }}
+```
+
+**To update versions:** Change the repository variables in GitHub Settings > Secrets and variables > Actions > Variables. All workflows will automatically use the new values.
+
 ### Secrets
 
 Common secrets referenced:

--- a/.github/workflows/_notify-release.yml
+++ b/.github/workflows/_notify-release.yml
@@ -330,7 +330,7 @@ jobs:
       - name: Setup Node.js for Notion publishing
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: '22'
+          node-version: ${{ vars.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
           scope: '@uniswap'
 

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -25,13 +25,16 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
+
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: "22.21.1"
-          cache: "npm"
+          node-version: ${{ vars.NODE_VERSION }}
+          cache: 'npm'
+
       - name: Install npm
-        run: npm install -g npm@11.6.2
+        run: npm install -g npm@${{ vars.NPM_VERSION }}
+
       - name: Verify package-lock.json
         run: |
           echo "Checking if package-lock.json is up to date..."

--- a/.github/workflows/claude-welcome.yml
+++ b/.github/workflows/claude-welcome.yml
@@ -10,7 +10,7 @@ jobs:
     with:
       workflow_deployment_date: "2025-11-14"
       expiration_months: 3
-      documentation_url: "https://github.com/Uniswap/ai-toolkit/docs/guides/claude-integration.md"
+      documentation_url: "https://github.com/Uniswap/ai-toolkit/blob/main/docs/guides/claude-integration.md"
       welcome_message: |
         👋 Hi!
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -104,16 +104,15 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: '22.21.1'
+          node-version: ${{ vars.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
           scope: '@uniswap'
 
       - name: Install npm
-        run: npm install -g npm@11.6.2
-        # IMPORTANT: Pinning to npm 11.6.2 for two reasons:
+        # IMPORTANT: Pinning npm version for two reasons:
         # 1. OIDC trusted publishing requires npm >= 11.5.1
         # 2. Using a pinned version prevents lockfile format changes in CI
-        # Local developers should use: npm install -g npm@11.6.2
+        run: npm install -g npm@${{ vars.NPM_VERSION }}
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -36,6 +36,14 @@ pre-commit:
         - rebase
       fail_text: 'Typechecking failed. Please fix the issues before committing.'
 
+    test:
+      run: npx nx affected --target=test --base=HEAD~1
+      tags: test
+      skip:
+        - merge
+        - rebase
+      fail_text: 'Tests failed. Please fix the failing tests before committing.'
+
     lint-markdown:
       glob: '*.md'
       run: sh scripts/lefthook/lint-markdown.sh
@@ -45,10 +53,12 @@ pre-commit:
         - rebase
       fail_text: 'Markdown linting failed. Please fix the issues before committing.'
     # Update CLAUDE.md files based on changed files
+    # Skip with: SKIP_CLAUDE=1 git commit -m "message"
     update-claude-docs:
       run: sh scripts/lefthook/update-claude-docs.sh
       tags: claude-docs
       skip:
         - merge
         - rebase
+        - run: '[ "$SKIP_CLAUDE" = "1" ]'
       fail_text: 'Failed to update CLAUDE.md files. Please run `claude -p "/update-claude-md"` manually.'


### PR DESCRIPTION
- Introduced a new test hook that runs affected tests using 'npx nx affected --target=test --base=HEAD~1'.
- Configured the hook to skip during merge and rebase operations, with a failure message prompting users to fix failing tests before committing.