### PR TITLE
fix(workflows): sync package-lock.json during automated versioning

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -65,6 +65,7 @@ These workflows are prefixed with two `__` and are only used within this reposit
     - **Auto mode** (push to main/next): Detects affected packages via Nx, publishes with conventional/prerelease versioning, generates changelogs, sends Slack notifications
     - **Force mode** (manual workflow_dispatch): Publishes user-specified packages with prerelease versioning, useful for new packages or failed releases
   - Handles atomic versioning, npm publish with OIDC, git commit/tag push, and GitHub release creation
+  - **Lockfile sync**: Automatically updates `package-lock.json` when package versions are bumped to keep workspace dependencies in sync
 
 ### Consumer Workflows
 

--- a/.github/workflows/_generate-pr-metadata.yml
+++ b/.github/workflows/_generate-pr-metadata.yml
@@ -1,4 +1,4 @@
-name: '[claude] Generate PR Title & Description'
+name: "[claude] Generate PR Title & Description"
 
 # Reusable workflow for generating PR titles and descriptions using Claude AI
 #
@@ -31,65 +31,65 @@ on:
   workflow_call:
     inputs:
       pr_number:
-        description: 'Pull request number to update'
+        description: "Pull request number to update"
         required: true
         type: string
 
       base_ref:
-        description: 'Base branch name (e.g., main, master)'
+        description: "Base branch name (e.g., main, master)"
         required: true
         type: string
 
       model:
-        description: 'Claude model to use for generation'
+        description: "Claude model to use for generation"
         required: false
         type: string
-        default: 'claude-sonnet-4-5-20250929'
+        default: "claude-sonnet-4-5-20250929"
 
       max_turns:
-        description: 'Maximum conversation turns for Claude. Omit to use unlimited turns.'
+        description: "Maximum conversation turns for Claude. Omit to use unlimited turns."
         required: false
         type: number
 
       custom_prompt:
-        description: 'Custom prompt text (overrides prompt file and default). Output instructions will be automatically appended.'
+        description: "Custom prompt text (overrides prompt file and default). Output instructions will be automatically appended."
         required: false
         type: string
-        default: ''
+        default: ""
 
       custom_prompt_path:
-        description: 'Path to custom prompt file in repository (e.g., .github/prompts/generate-pr-metadata.md)'
+        description: "Path to custom prompt file in repository (e.g., .github/prompts/generate-pr-metadata.md)"
         required: false
         type: string
-        default: '.github/prompts/generate-pr-title-description.md'
+        default: ".github/prompts/generate-pr-title-description.md"
 
       timeout_minutes:
-        description: 'Job timeout in minutes'
+        description: "Job timeout in minutes"
         required: false
         type: number
         default: 15
 
       allowed_tools:
-        description: 'Comma-separated list of allowed tools for Claude. Leave empty for default read-only set.'
+        description: "Comma-separated list of allowed tools for Claude. Leave empty for default read-only set."
         required: false
         type: string
-        default: ''
+        default: ""
 
       commit_history_count:
-        description: 'Number of recent commits to analyze for title patterns'
+        description: "Number of recent commits to analyze for title patterns"
         required: false
         type: number
         default: 30
 
       pr_history_count:
-        description: 'Number of recent merged PRs to analyze for description patterns'
+        description: "Number of recent merged PRs to analyze for description patterns"
         required: false
         type: number
         default: 10
 
     secrets:
       ANTHROPIC_API_KEY:
-        description: 'Anthropic API key for Claude access'
+        description: "Anthropic API key for Claude access"
         required: true
 
 jobs:
@@ -99,6 +99,7 @@ jobs:
 
     # Fixed permissions (cannot be overridden by calling workflow)
     permissions:
+      id-token: write # Required to create ID tokens for Claude Code Action
       contents: read # Required to read repository code
       pull-requests: write # Required to update PR title and description
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -703,7 +703,16 @@ jobs:
               jq --arg version "$NEW_VERSION" '.version = $version' "$PROJECT_ROOT/package.json" > "$PROJECT_ROOT/package.json.tmp"
               mv "$PROJECT_ROOT/package.json.tmp" "$PROJECT_ROOT/package.json"
 
+              # Update package-lock.json to reflect workspace dependency changes
+              echo "  Updating package-lock.json..."
+              npm install --package-lock-only --ignore-scripts
+
               git add "$PROJECT_ROOT/package.json"
+              # Include package-lock.json if it changed
+              if ! git diff --cached --quiet package-lock.json 2>/dev/null; then
+                git add package-lock.json
+                echo "  Including package-lock.json in commit"
+              fi
               git commit -m "chore(release): $package@$NEW_VERSION"
               git tag -m "Release ${package}@${NEW_VERSION}" "${package}@${NEW_VERSION}"
 
@@ -715,6 +724,18 @@ jobs:
                 continue
               fi
               NEW_VERSION=$(jq -r '.version' "$PROJECT_ROOT/package.json")
+
+              # Update package-lock.json to reflect workspace dependency changes
+              echo "  Updating package-lock.json..."
+              npm install --package-lock-only --ignore-scripts
+
+              # Amend the nx release commit to include package-lock.json if it changed
+              if ! git diff --quiet package-lock.json 2>/dev/null; then
+                git add package-lock.json
+                git commit --amend --no-edit
+                echo "  Amended commit to include package-lock.json"
+              fi
+
               echo "✅ Versioning complete"
             fi
             echo "New version: $NEW_VERSION"

--- a/package-lock.json
+++ b/package-lock.json
@@ -24907,7 +24907,7 @@
     },
     "packages/ai-toolkit-nx-claude": {
       "name": "@uniswap/ai-toolkit-nx-claude",
-      "version": "0.5.17",
+      "version": "0.5.18-next.1",
       "dependencies": {
         "@nx/devkit": "*",
         "enquirer": "*"
@@ -24922,7 +24922,7 @@
     },
     "packages/claude-mcp-helper": {
       "name": "@uniswap/ai-toolkit-claude-mcp-helper",
-      "version": "1.0.6",
+      "version": "1.0.7-next.1",
       "dependencies": {
         "enquirer": "^2.4.1"
       },
@@ -24983,7 +24983,7 @@
     },
     "packages/linear-task-utils": {
       "name": "@uniswap/ai-toolkit-linear-task-utils",
-      "version": "0.0.1",
+      "version": "0.0.2-next.1",
       "license": "MIT",
       "dependencies": {
         "@linear/sdk": "^33.0.0",
@@ -24999,7 +24999,7 @@
     },
     "packages/notion-publisher": {
       "name": "@uniswap/ai-toolkit-notion-publisher",
-      "version": "0.0.1",
+      "version": "0.0.2-next.1",
       "dependencies": {
         "@notionhq/client": "^2.2.15",
         "@tryfabric/martian": "^1.2.4",


### PR DESCRIPTION
## Summary

Fixes a critical issue in the package publishing workflow where `package-lock.json` was not being updated when package versions were bumped, causing workspace dependency drift and potential installation issues.

## Changes

- **Automatic lockfile sync**: Added `npm install --package-lock-only --ignore-scripts` after both manual and automated versioning to regenerate `package-lock.json`
- **Commit integration**: Includes `package-lock.json` in version commits when changes are detected
  - For manual versioning: adds lockfile to the release commit
  - For automated versioning (nx release): amends the nx-generated commit to include lockfile
- **Documentation updates**: Added lockfile sync feature to workflow documentation in `.github/workflows/CLAUDE.md`
- **Permission fix**: Added `id-token: write` permission to `_generate-pr-metadata.yml` for Claude Code Action ID token generation
- **Style fixes**: Normalized quote style in `_generate-pr-metadata.yml` (single quotes to double quotes)

## Technical Details

The workflow now runs `npm install --package-lock-only` after version bumps to ensure workspace dependencies reflect the new versions. The `--ignore-scripts` flag prevents lifecycle scripts from running during the lockfile update.

For conventional versioning (nx release), the lockfile is added via `git commit --amend --no-edit` to maintain clean commit history. For manual prerelease versioning, the lockfile is included in the initial version commit.

## Testing

Updated package versions in `package-lock.json` now correctly reflect the bumped versions:
- `@uniswap/ai-toolkit-nx-claude@0.5.18-next.1`
- `@uniswap/ai-toolkit-claude-mcp-helper@1.0.7-next.1`
- `@uniswap/ai-toolkit-linear-task-utils@0.0.2-next.1`
- `@uniswap/ai-toolkit-notion-publisher@0.0.2-next.1`