### PR TITLE
feat(workflows): preserve user content in PR metadata generation

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -55,6 +55,46 @@ These workflows are prefixed with `_` and may be called from other repositories:
 - `_generate-pr-metadata.yml` - AI-generated PR titles and descriptions
 - `_notify-release.yml` - Slack notification dispatcher
 
+### PR Metadata Generation (`_generate-pr-metadata.yml`)
+
+This workflow generates PR titles and descriptions using Claude AI with the following features:
+
+**Content Preservation with Markers:**
+
+The workflow wraps generated descriptions in HTML comment markers to enable selective updates:
+
+```html
+<!-- claude-pr-description-start -->
+... AI-generated content ...
+<!-- claude-pr-description-end -->
+```
+
+When regenerating a PR description:
+
+- Content **before** `<!-- claude-pr-description-start -->` is preserved (user's prefix)
+- Content **after** `<!-- claude-pr-description-end -->` is preserved (user's suffix)
+- Only the content between markers is replaced with new AI-generated content
+
+This allows users to add custom notes, disclaimers, or additional context that survives regeneration.
+
+**Example PR body with user additions:**
+
+```markdown
+> **Note:** This PR requires manual QA testing before merge.
+
+<!-- claude-pr-description-start -->
+
+## Summary
+
+- Added new authentication flow
+- Updated user session handling
+<!-- claude-pr-description-end -->
+
+---
+
+**Related Issues:** #123, #456
+```
+
 ### Shared Internal Workflows
 
 These workflows are prefixed with two `__` and are only used within this repository:

--- a/.github/workflows/_generate-pr-metadata.yml
+++ b/.github/workflows/_generate-pr-metadata.yml
@@ -498,6 +498,10 @@ jobs:
           DEFAULT_TITLE="chore: update PR"
           DEFAULT_DESCRIPTION="*This PR description was auto-generated but the generation process encountered an issue.*"
 
+          # Marker constants for identifying auto-generated content
+          START_MARKER="<!-- claude-pr-description-start -->"
+          END_MARKER="<!-- claude-pr-description-end -->"
+
           echo "Starting PR metadata update for PR #$PR_NUMBER"
 
           # Read title from file or use default
@@ -518,12 +522,71 @@ jobs:
           fi
 
           # Read description from file or use default
-          NEW_DESCRIPTION="$DEFAULT_DESCRIPTION"
+          GENERATED_DESCRIPTION="$DEFAULT_DESCRIPTION"
           if [ -f "$DESCRIPTION_FILE" ]; then
-            NEW_DESCRIPTION=$(cat "$DESCRIPTION_FILE")
-            echo "Read description from file (${#NEW_DESCRIPTION} chars)"
+            GENERATED_DESCRIPTION=$(cat "$DESCRIPTION_FILE")
+            echo "Read description from file (${#GENERATED_DESCRIPTION} chars)"
           else
             echo "No description file found at $DESCRIPTION_FILE, using default message"
+          fi
+
+          # Fetch current PR body to preserve user content outside markers
+          echo "Fetching current PR body to check for user content..."
+          CURRENT_BODY=$(gh pr view "$PR_NUMBER" --json body --jq '.body // ""')
+
+          # Initialize preserved content variables
+          CONTENT_BEFORE=""
+          CONTENT_AFTER=""
+
+          # Check if current body has our markers
+          if echo "$CURRENT_BODY" | grep -q "$START_MARKER"; then
+            echo "Found existing markers in PR body, preserving user content..."
+
+            # Extract content BEFORE the start marker (user's prefix content)
+            CONTENT_BEFORE=$(echo "$CURRENT_BODY" | awk -v marker="$START_MARKER" '
+              BEGIN { found=0 }
+              $0 ~ marker { found=1; exit }
+              { if (!found) print }
+            ')
+
+            # Extract content AFTER the end marker (user's suffix content)
+            CONTENT_AFTER=$(echo "$CURRENT_BODY" | awk -v marker="$END_MARKER" '
+              BEGIN { found=0 }
+              { if (found) print }
+              $0 ~ marker { found=1 }
+            ')
+
+            # Trim trailing/leading whitespace but preserve internal structure
+            CONTENT_BEFORE=$(echo "$CONTENT_BEFORE" | sed -e 's/[[:space:]]*$//')
+            CONTENT_AFTER=$(echo "$CONTENT_AFTER" | sed -e 's/^[[:space:]]*//')
+
+            if [ -n "$CONTENT_BEFORE" ]; then
+              echo "  Preserved ${#CONTENT_BEFORE} chars of user content before markers"
+            fi
+            if [ -n "$CONTENT_AFTER" ]; then
+              echo "  Preserved ${#CONTENT_AFTER} chars of user content after markers"
+            fi
+          else
+            echo "No existing markers found, this appears to be a fresh generation"
+          fi
+
+          # Build final description with markers and preserved content
+          # Using printf to properly handle newlines in YAML
+          NEW_DESCRIPTION=""
+
+          # Add preserved content before markers (if any)
+          if [ -n "$CONTENT_BEFORE" ]; then
+            NEW_DESCRIPTION="${CONTENT_BEFORE}"$'\n\n'
+          fi
+
+          # Add the marked generated content
+          NEW_DESCRIPTION="${NEW_DESCRIPTION}${START_MARKER}"$'\n'
+          NEW_DESCRIPTION="${NEW_DESCRIPTION}${GENERATED_DESCRIPTION}"$'\n'
+          NEW_DESCRIPTION="${NEW_DESCRIPTION}${END_MARKER}"
+
+          # Add preserved content after markers (if any)
+          if [ -n "$CONTENT_AFTER" ]; then
+            NEW_DESCRIPTION="${NEW_DESCRIPTION}"$'\n\n'"${CONTENT_AFTER}"
           fi
 
           # Update PR using gh CLI

--- a/package-lock.json
+++ b/package-lock.json
@@ -24907,7 +24907,7 @@
     },
     "packages/ai-toolkit-nx-claude": {
       "name": "@uniswap/ai-toolkit-nx-claude",
-      "version": "0.5.18-next.1",
+      "version": "0.5.18-next.2",
       "dependencies": {
         "@nx/devkit": "*",
         "enquirer": "*"
@@ -24922,7 +24922,7 @@
     },
     "packages/claude-mcp-helper": {
       "name": "@uniswap/ai-toolkit-claude-mcp-helper",
-      "version": "1.0.7-next.1",
+      "version": "1.0.7-next.2",
       "dependencies": {
         "enquirer": "^2.4.1"
       },
@@ -24983,7 +24983,7 @@
     },
     "packages/linear-task-utils": {
       "name": "@uniswap/ai-toolkit-linear-task-utils",
-      "version": "0.0.2-next.1",
+      "version": "0.0.2-next.2",
       "license": "MIT",
       "dependencies": {
         "@linear/sdk": "^33.0.0",
@@ -24999,7 +24999,7 @@
     },
     "packages/notion-publisher": {
       "name": "@uniswap/ai-toolkit-notion-publisher",
-      "version": "0.0.2-next.1",
+      "version": "0.0.2-next.2",
       "dependencies": {
         "@notionhq/client": "^2.2.15",
         "@tryfabric/martian": "^1.2.4",


### PR DESCRIPTION
<!-- claude-pr-description-start -->
## Summary

Enhances the `_generate-pr-metadata.yml` workflow to preserve user-added content in PR descriptions during AI regeneration. The workflow now wraps generated content with HTML comment markers, allowing users to add custom notes, disclaimers, or additional context that survives subsequent metadata updates.

## Changes

- **Content preservation markers**: Added `<!-- claude-pr-description-start -->` and `<!-- claude-pr-description-end -->` markers to wrap AI-generated PR descriptions
- **User content extraction**: Implemented logic to detect existing markers and extract content before/after them during regeneration
- **Smart description assembly**: Updated PR body construction to preserve user's prefix content (before start marker) and suffix content (after end marker) while replacing only the marked AI-generated section
- **Documentation**: Added comprehensive usage examples and feature explanation to `.github/workflows/CLAUDE.md`
- **Package versions**: Bumped package versions in `package-lock.json` from `-next.1` to `-next.2`

## Technical Details

The workflow now:
1. Fetches the current PR body using `gh pr view`
2. Uses `awk` to extract content before and after the markers
3. Assembles the final description by combining: preserved prefix + marked generated content + preserved suffix
4. Only replaces content between markers on subsequent regenerations

This enables workflows like:
```markdown
> **Note:** This PR requires manual QA testing before merge.

<!-- claude-pr-description-start -->
## Summary
... AI-generated content ...
<!-- claude-pr-description-end -->

---
**Related Issues:** #123, #456
```

Where both the note at the top and related issues at the bottom are preserved across regenerations.

## Benefits

- **Flexibility**: Users can add context-specific notes without losing them during AI regeneration
- **Collaboration**: Enables manual annotations alongside automated descriptions
- **Selective updates**: Only the AI-generated content is replaced, preserving intentional user additions
<!-- claude-pr-description-end -->