### PR TITLE
feat(workflows): add linear_task_utils_tag input for customizable npm package version

### DIFF
--- a/.github/workflows/_claude-task-worker.yml
+++ b/.github/workflows/_claude-task-worker.yml
@@ -35,6 +35,7 @@
 # - target_branch: Branch to create PR against (default: "next")
 # - model: Claude model to use (default: claude-sonnet-4-5-20250929)
 # - timeout_minutes: Execution timeout (default: 60)
+# - linear_task_utils_tag: npm tag for @uniswap/ai-toolkit-linear-task-utils (default: "latest")
 #
 # SECRETS REQUIRED:
 # - ANTHROPIC_API_KEY: Claude API key
@@ -96,6 +97,12 @@ on:
         required: false
         type: number
         default: 60
+
+      linear_task_utils_tag:
+        description: "npm tag for @uniswap/ai-toolkit-linear-task-utils (latest or next)"
+        required: false
+        type: string
+        default: "latest"
 
     secrets:
       ANTHROPIC_API_KEY:
@@ -307,13 +314,16 @@ jobs:
       - name: Update Linear issue
         if: steps.check-pr.outputs.pr_exists == 'true'
         run: |
-          npx @uniswap/ai-toolkit-linear-task-utils@latest update-issue \
-            --issue-id "${{ inputs.issue_id }}" \
+          npx "@uniswap/ai-toolkit-linear-task-utils@${LINEAR_TASK_UTILS_TAG}" update-issue \
+            --issue-id "$ISSUE_ID" \
             --status "In Review" \
-            --pr-url "${{ steps.check-pr.outputs.pr_url }}"
+            --pr-url "$PR_URL"
         env:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+          LINEAR_TASK_UTILS_TAG: ${{ inputs.linear_task_utils_tag }}
+          ISSUE_ID: ${{ inputs.issue_id }}
+          PR_URL: ${{ steps.check-pr.outputs.pr_url }}
 
       # Create job summary
       - name: Create job summary

--- a/.github/workflows/claude-auto-tasks.yml
+++ b/.github/workflows/claude-auto-tasks.yml
@@ -64,10 +64,23 @@ on:
         type: string
         default: "next"
 
+      linear_task_utils_tag:
+        description: "npm tag for @uniswap/ai-toolkit-linear-task-utils"
+        required: false
+        type: choice
+        options:
+          - "latest"
+          - "next"
+        default: "next"
+
 # Prevent concurrent runs
 concurrency:
   group: claude-auto-tasks
   cancel-in-progress: false
+
+# Resolved values (handles fallback for scheduled runs where inputs.* are empty)
+env:
+  LINEAR_TASK_UTILS_TAG: ${{ inputs.linear_task_utils_tag || 'next' }}
 
 jobs:
   # Job 1: Query Linear and prepare the task matrix
@@ -76,6 +89,7 @@ jobs:
     outputs:
       matrix: ${{ steps.query.outputs.result }}
       has_tasks: ${{ steps.query.outputs.has_tasks }}
+      linear_task_utils_tag: ${{ env.LINEAR_TASK_UTILS_TAG }}
 
     steps:
       # Security scanning
@@ -100,22 +114,25 @@ jobs:
       # Ensure the claude label exists
       - name: Ensure label exists
         run: |
-          npx @uniswap/ai-toolkit-linear-task-utils@latest ensure-label \
-            --team "${{ inputs.linear_team }}" \
-            --label "${{ inputs.linear_label }}"
+          npx "@uniswap/ai-toolkit-linear-task-utils@${LINEAR_TASK_UTILS_TAG}" ensure-label \
+            --team "$LINEAR_TEAM" \
+            --label "$LINEAR_LABEL"
         env:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+          LINEAR_TASK_UTILS_TAG: ${{ env.LINEAR_TASK_UTILS_TAG }}
+          LINEAR_TEAM: ${{ inputs.linear_team }}
+          LINEAR_LABEL: ${{ inputs.linear_label }}
 
       # Query Linear for issues
       - name: Query Linear issues
         id: query
         run: |
-          RESULT=$(npx @uniswap/ai-toolkit-linear-task-utils@latest query \
-            --team "${{ inputs.linear_team }}" \
-            --label "${{ inputs.linear_label }}" \
+          RESULT=$(npx "@uniswap/ai-toolkit-linear-task-utils@${LINEAR_TASK_UTILS_TAG}" query \
+            --team "$LINEAR_TEAM" \
+            --label "$LINEAR_LABEL" \
             --statuses "Backlog,Todo" \
-            --max "${{ inputs.max_issues }}")
+            --max "$MAX_ISSUES")
 
           echo "result=$RESULT" >> $GITHUB_OUTPUT
 
@@ -131,6 +148,10 @@ jobs:
         env:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+          LINEAR_TASK_UTILS_TAG: ${{ env.LINEAR_TASK_UTILS_TAG }}
+          LINEAR_TEAM: ${{ inputs.linear_team }}
+          LINEAR_LABEL: ${{ inputs.linear_label }}
+          MAX_ISSUES: ${{ inputs.max_issues }}
 
       # Create summary for prepare job
       - name: Create prepare summary
@@ -182,6 +203,7 @@ jobs:
       target_branch: ${{ inputs.target_branch }}
       model: ${{ inputs.model }}
       timeout_minutes: 60
+      linear_task_utils_tag: ${{ needs.prepare.outputs.linear_task_utils_tag }}
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}


### PR DESCRIPTION
<!-- claude-pr-description-start -->
<!-- claude-pr-description-start -->
## Summary

Adds a `linear_task_utils_tag` input to the Claude auto-tasks workflows, allowing users to specify which npm tag (`latest` or `next`) to use when running `@uniswap/ai-toolkit-linear-task-utils` commands. This provides flexibility to test pre-release versions of the linear task utilities package in the workflow.

## Changes

- **New workflow input**: Added `linear_task_utils_tag` input to both `claude-auto-tasks.yml` and `_claude-task-worker.yml` with options for `latest` and `next` tags
- **Environment variable usage**: Refactored all `npx` commands to use environment variables instead of direct `${{ }}` interpolation, following GitHub Actions security best practices for expression injection prevention
- **Scheduled run support**: Added workflow-level environment variable with fallback (`inputs.linear_task_utils_tag || 'next'`) to handle scheduled runs where inputs are empty
- **Job output propagation**: Added `linear_task_utils_tag` as a job output from the prepare job to pass to the worker workflow

## Technical Details

The workflow now:
1. Accepts `linear_task_utils_tag` as a choice input (default: `next` for manual triggers)
2. Resolves the tag at workflow level with fallback for scheduled runs
3. Passes the resolved tag through job outputs to the reusable worker workflow
4. Uses environment variables in all bash scripts to prevent expression injection

This enables testing pre-release versions of `@uniswap/ai-toolkit-linear-task-utils` without modifying workflow files, which is useful when iterating on the linear task utilities package.
<!-- claude-pr-description-end -->
<!-- claude-pr-description-end -->