### PR TITLE
chore(workflows): improve inline comment instructions in Claude Code Review

### DIFF
--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -1,4 +1,4 @@
-name: '[claude] Claude Code Review'
+name: "[claude] Claude Code Review"
 
 # Reusable workflow for automated PR code reviews using Claude AI
 #
@@ -35,40 +35,40 @@ on:
   workflow_call:
     inputs:
       pr_number:
-        description: 'Pull request number to review'
+        description: "Pull request number to review"
         required: true
         type: string
 
       base_ref:
-        description: 'Base branch name (e.g., main, master)'
+        description: "Base branch name (e.g., main, master)"
         required: true
         type: string
 
       model:
-        description: 'Claude model to use for review'
+        description: "Claude model to use for review"
         required: false
         type: string
-        default: 'claude-sonnet-4-5-20250929'
+        default: "claude-sonnet-4-5-20250929"
 
       max_turns:
-        description: 'Maximum conversation turns for Claude. Omit to use unlimited turns (may help with track_progress Issue #602).'
+        description: "Maximum conversation turns for Claude. Omit to use unlimited turns (may help with track_progress Issue #602)."
         required: false
         type: number
 
       custom_prompt:
-        description: 'Custom prompt text (overrides prompt file and default). Verdict logic will be automatically appended.'
+        description: "Custom prompt text (overrides prompt file and default). Verdict logic will be automatically appended."
         required: false
         type: string
-        default: ''
+        default: ""
 
       custom_prompt_path:
-        description: 'Path to custom prompt file in repository (e.g., .claude/prompts/claude-pr-bot.md)'
+        description: "Path to custom prompt file in repository (e.g., .claude/prompts/claude-pr-bot.md)"
         required: false
         type: string
-        default: '.claude/prompts/claude-pr-bot.md'
+        default: ".claude/prompts/claude-pr-bot.md"
 
       timeout_minutes:
-        description: 'Job timeout in minutes'
+        description: "Job timeout in minutes"
         required: false
         type: number
         default: 30
@@ -77,11 +77,11 @@ on:
         description: 'Comma-separated list of allowed tools for Claude (e.g., "Read,Grep,Glob,Bash(git log),Write"). Leave empty for default permissive set.'
         required: false
         type: string
-        default: ''
+        default: ""
 
     secrets:
       ANTHROPIC_API_KEY:
-        description: 'Anthropic API key for Claude access'
+        description: "Anthropic API key for Claude access"
         required: true
 
 jobs:
@@ -326,13 +326,30 @@ jobs:
 
           ---
 
-          # ⚠️ CRITICAL FINAL STEP: Create Inline Comments FIRST
+          # ⚠️ CRITICAL FINAL STEP: Create Review with Inline Comments FIRST
 
-          **BEFORE creating the verdict files above, you MUST:**
+          **BEFORE creating the verdict files above, you MUST submit your PR review with inline comments.**
 
-          1. Call \`mcp__github__create_pull_request_review\` with the \`comments\` array containing at least 1 inline comment
-          2. Each comment needs: \`path\` (file path), \`line\` (line number), \`body\` (your feedback)
-          3. ONLY AFTER inline comments are created, then create the verdict files
+          ## Creating a Review with Inline Comments (Single Call)
+
+          Use \`mcp__github__create_pull_request_review\` to submit a formal review with inline comments in one call.
+          This tool runs as \`github-actions[bot]\` and supports inline comments via the \`comments\` array.
+
+          ### Decision Tree - For EACH potential inline comment:
+
+          1. **Check against existing PR comments first:**
+             - Same file and line already commented? → SKIP
+             - Same issue already mentioned elsewhere? → SKIP
+             - Similar pattern already noted in another file? → SKIP
+
+          2. **If not a duplicate, evaluate importance:**
+             - Critical bug or security issue? → ADD TO COMMENTS ARRAY
+             - Clear improvement with obvious fix? → ADD TO COMMENTS ARRAY
+             - Engineering principle opportunity with clear benefit? → ADD TO COMMENTS ARRAY
+             - Minor style preference? → SKIP
+             - Nitpick without real value? → SKIP
+
+          ### Submit Review with Inline Comments:
 
           **Example call you MUST make:**
           \`\`\`
@@ -340,13 +357,68 @@ jobs:
             owner: "$REPO_OWNER",
             repo: "$REPO_NAME",
             pull_number: $PR_NUMBER,
-            body: "Review summary",
             event: "COMMENT",
+            body: "## Code Review Summary\\n\\n[Your review summary here]",
             comments: [
-              { path: "src/example.ts", line: 42, body: "Your feedback here" }
+              {
+                path: "src/example.ts",
+                line: 42,
+                body: "Issue description with suggestion"
+              },
+              {
+                path: "src/other.ts",
+                line: 15,
+                body: "Another inline comment"
+              }
             ]
           })
           \`\`\`
+
+          **Parameters:**
+          - \`owner\`: Repository owner ("$REPO_OWNER")
+          - \`repo\`: Repository name ("$REPO_NAME")
+          - \`pull_number\`: PR number ($PR_NUMBER)
+          - \`event\`: "COMMENT" (neutral), "APPROVE", or "REQUEST_CHANGES"
+          - \`body\`: Overall review summary (markdown supported)
+          - \`comments\`: Array of inline comments with:
+            - \`path\`: Relative file path (e.g., "src/components/Button.tsx")
+            - \`line\`: Line number in the NEW version of the file
+            - \`body\`: Your comment text (markdown supported)
+
+          **GitHub Suggestion Block Format:**
+          To suggest code changes, use this format in the comment body:
+          \`\`\`suggestion
+          ONLY the replacement code for the commented lines
+          \`\`\`
+          Remember: Suggestion blocks must contain ONLY the replacement lines, not surrounding context.
+
+          ## Useful Tools
+
+          To see what files changed and their line numbers:
+
+          \`\`\`
+          mcp__github__get_pull_request_files({
+            owner: "$REPO_OWNER",
+            repo: "$REPO_NAME",
+            pull_number: $PR_NUMBER
+          })
+          \`\`\`
+
+          To check existing comments (avoid duplicates):
+
+          \`\`\`
+          mcp__github__get_pull_request_comments({
+            owner: "$REPO_OWNER",
+            repo: "$REPO_NAME",
+            pull_number: $PR_NUMBER
+          })
+          \`\`\`
+
+          ## Important Notes
+
+          1. **Submit the review with inline comments FIRST**
+          2. **THEN create verdict files** (.claude-review-verdict.txt and .claude-review-summary.md)
+          3. All comments appear as \`github-actions[bot]\`
 
           **Reviews without inline comments will be flagged as incomplete.**
           INLINE_REMINDER_EOF
@@ -382,20 +454,21 @@ jobs:
           else
             # Define tools as array for better maintainability and to eliminate
             # shell string parsing nuances. Each tool is a separate array element.
+            #
+            # Tools prefixed with "mcp__github__" are built-in to claude-code-action
+            # and run as github-actions[bot]. These include PR review capabilities
+            # with inline comment support via the "comments" array parameter.
             TOOLS=(
-              # GitHub MCP tools for PR interaction
+              # Built-in GitHub MCP tools (from claude-code-action)
+              # These run as github-actions[bot] using GITHUB_TOKEN
               "mcp__github__get_pull_request"
               "mcp__github__get_pull_request_files"
-              "mcp__github__get_pull_request_diff"
               "mcp__github__get_pull_request_comments"
-              "mcp__github__get_pull_request_reviews"
-              "mcp__github__get_pull_request_review_comments"
-              "mcp__github__create_review_comment"
-              "mcp__github__resolve_review_thread"
-              "mcp__github__list_review_comments"
               "mcp__github__create_pull_request_review"
+              "mcp__github__get_file_contents"
+              "mcp__github__list_commits"
 
-              # File operations
+              # File operations (built-in to claude-code-action)
               "Read"
               "Grep"
               "Glob"


### PR DESCRIPTION
<!-- claude-pr-description-start -->
<!-- claude-pr-description-start -->
## Summary

Enhances the Claude Code Review workflow with clearer inline comment instructions and a streamlined tool configuration. The improved documentation provides step-by-step guidance for creating PR reviews with inline comments, including a decision tree for comment relevance and duplicate detection.

## Changes

- **Expanded inline comment instructions**: Replaced brief instructions with comprehensive documentation including:
  - Decision tree for evaluating each potential inline comment (duplicate checking + importance evaluation)
  - Full parameter documentation for `mcp__github__create_pull_request_review`
  - GitHub suggestion block format examples
  - Useful tools section for checking files and existing comments

- **Streamlined allowed tools list**: Simplified the default GitHub MCP tools from 10 to 6 essential ones:
  - Kept: `get_pull_request`, `get_pull_request_files`, `get_pull_request_comments`, `create_pull_request_review`
  - Added: `get_file_contents`, `list_commits`
  - Removed: `get_pull_request_diff`, `get_pull_request_reviews`, `get_pull_request_review_comments`, `create_review_comment`, `resolve_review_thread`, `list_review_comments`

- **Improved tool documentation**: Added clarifying comments explaining that `mcp__github__*` tools are built-in to claude-code-action and run as `github-actions[bot]`

- **Quote style normalization**: Updated YAML string quotes from single to double quotes for consistency

## Notes

The changes focus on providing clearer guidance for Claude to create effective inline comments during code reviews, with emphasis on avoiding duplicates and focusing on meaningful feedback rather than nitpicks.
<!-- claude-pr-description-end -->
<!-- claude-pr-description-end -->

<!-- claude-pr-description-end -->