### PR TITLE
feat(workflows): add PR type input for flexible PR creation in Claude task workflow

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -123,34 +123,36 @@ This workflow processes Linear issues autonomously using Claude Code. It's calle
 
 **Key Features:**
 
-| Feature                      | Description                                                                                             |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------- |
-| **7-Phase Workflow**         | Claude follows a structured approach: Understand → Explore → Plan → Implement → QA → Commit → Create PR |
+| Feature                      | Description                                                                                              |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------- |
+| **7-Phase Workflow**         | Claude follows a structured approach: Understand → Explore → Plan → Implement → QA → Commit → Create PR  |
 | **Autonomous Execution**     | Uses `--dangerously-skip-permissions` to run without permission prompts (safe in GitHub Actions sandbox) |
-| **Turn Budget Management**   | Prompt includes explicit turn budgets per phase to prevent over-exploration and ensure PR creation      |
-| **Fallback PR Creation**     | If Claude makes commits but fails to create a PR, workflow automatically creates a fallback draft PR    |
-| **Debug Mode**               | Full Claude output shown by default (`debug_mode: true`) to understand reasoning                        |
-| **Task Complexity Warnings** | Warns about tasks containing keywords like "audit", "review", "investigate"                             |
-| **Incremental Commits**      | Prompt instructs Claude to commit and push after each major piece of work to preserve progress          |
-| **Linear Integration**       | Updates Linear issue status to "In Progress" when draft PR is created                                   |
+| **Turn Budget Management**   | Prompt includes explicit turn budgets per phase to prevent over-exploration and ensure PR creation       |
+| **Fallback PR Creation**     | If Claude makes commits but fails to create a PR, workflow automatically creates a fallback PR           |
+| **Debug Mode**               | Full Claude output shown by default (`debug_mode: true`) to understand reasoning                         |
+| **Configurable PR Type**     | Choose between draft or published PRs via `pr_type` input (default: "draft")                             |
+| **Task Complexity Warnings** | Warns about tasks containing keywords like "audit", "review", "investigate"                              |
+| **Incremental Commits**      | Prompt instructs Claude to commit and push after each major piece of work to preserve progress           |
+| **Linear Integration**       | Updates Linear issue status to "In Progress" when PR is created                                          |
 
 **Turn Budget (built into prompt):**
 
-| Phase              | Turns   | Purpose                                      |
-| ------------------ | ------- | -------------------------------------------- |
+| Phase              | Turns   | Purpose                                          |
+| ------------------ | ------- | ------------------------------------------------ |
 | Understand/Explore | 1-30    | Read CLAUDE.md, explore codebase, identify files |
-| Plan/Implement     | 31-100  | Design approach and implement the solution   |
-| QA/Fix             | 101-130 | Run checks, fix critical issues              |
-| **Commit/PR**      | 131-150 | **RESERVED** - Must commit and create PR     |
+| Plan/Implement     | 31-100  | Design approach and implement the solution       |
+| QA/Fix             | 101-130 | Run checks, fix critical issues                  |
+| **Commit/PR**      | 131-150 | **RESERVED** - Must commit and create PR         |
 
 **Configuration:**
 
-| Input             | Default                    | Description                |
-| ----------------- | -------------------------- | -------------------------- |
-| `model`           | `claude-opus-4-5-20251101` | Claude model to use        |
-| `max_turns`       | `150`                      | Maximum conversation turns |
-| `debug_mode`      | `true`                     | Show full Claude output    |
-| `timeout_minutes` | `60`                       | Job timeout                |
+| Input             | Default                    | Description                                  |
+| ----------------- | -------------------------- | -------------------------------------------- |
+| `model`           | `claude-opus-4-5-20251101` | Claude model to use                          |
+| `max_turns`       | `150`                      | Maximum conversation turns                   |
+| `debug_mode`      | `true`                     | Show full Claude output                      |
+| `timeout_minutes` | `60`                       | Job timeout                                  |
+| `pr_type`         | `draft`                    | Type of PR to create: "draft" or "published" |
 
 **Validation Behavior:**
 
@@ -166,6 +168,7 @@ The job summary includes:
 
 - Task title and Linear issue link
 - Branch name and model used
+- PR type (draft or published)
 - Commit count
 - PR creation status (✅ Claude PR / ⚠️ Fallback PR / ❌ No PR)
 - Failure reason (if applicable)
@@ -185,6 +188,7 @@ with:
   target_branch: 'next'
   model: 'claude-opus-4-5-20251101'
   debug_mode: true
+  pr_type: 'draft' # or 'published' for non-draft PRs
 secrets:
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}

--- a/.github/workflows/_claude-task-worker.yml
+++ b/.github/workflows/_claude-task-worker.yml
@@ -36,6 +36,8 @@
 # - model: Claude model to use (default: claude-sonnet-4-5-20250929)
 # - timeout_minutes: Execution timeout (default: 60)
 # - linear_task_utils_tag: npm tag for @uniswap/ai-toolkit-linear-task-utils (default: "latest")
+# - debug_mode: Enable full Claude Code output for debugging (default: true)
+# - pr_type: Type of PR to create - "draft" or "published" (default: "draft")
 #
 # SECRETS REQUIRED:
 # - ANTHROPIC_API_KEY: Claude API key
@@ -109,6 +111,12 @@ on:
         required: false
         type: boolean
         default: true
+
+      pr_type:
+        description: "Type of PR to create: 'draft' or 'published'"
+        required: false
+        type: string
+        default: "draft"
 
     secrets:
       ANTHROPIC_API_KEY:
@@ -298,7 +306,7 @@ jobs:
 
           ### Phase 7: Create Pull Request (REQUIRED - turns 131-150)
 
-          **THIS PHASE IS MANDATORY.** You MUST create a draft PR using the GitHub CLI.
+          **THIS PHASE IS MANDATORY.** You MUST create a PR using the GitHub CLI.
 
           Run this command:
           ```bash
@@ -325,8 +333,7 @@ jobs:
           ---
           *Autonomous implementation using ${{ inputs.model }}*" \
             --base "${{ inputs.target_branch }}" \
-            --head "${{ inputs.branch_name }}" \
-            --draft
+            --head "${{ inputs.branch_name }}" ${{ inputs.pr_type == 'draft' && '--draft' || '' }}
           ```
 
           After creating the PR, verify it was created:
@@ -436,16 +443,15 @@ jobs:
           BRANCH_NAME: ${{ inputs.branch_name }}
           COMMIT_COUNT: ${{ steps.check-commits.outputs.commit_count }}
           MODEL: ${{ inputs.model }}
+          PR_TYPE: ${{ inputs.pr_type }}
         run: |
           echo "::warning::Claude made ${COMMIT_COUNT} commit(s) but did not create a PR. Creating fallback PR..."
 
           # Get commit summary for PR body
           COMMIT_LOG=$(git log origin/"$TARGET_BRANCH"..HEAD --oneline 2>/dev/null | head -20)
 
-          # Create the fallback PR
-          PR_URL=$(gh pr create \
-            --title "[${ISSUE_IDENTIFIER}] WIP: Partial implementation (fallback PR)" \
-            --body "$(cat <<BODY_EOF
+          # Build PR body content
+          PR_BODY=$(cat <<BODY_EOF
           ## ⚠️ Fallback PR - Incomplete Implementation
 
           Claude exhausted the turn limit or encountered an error before creating a PR.
@@ -469,10 +475,23 @@ jobs:
           ---
           *Fallback PR created automatically. Original task used ${MODEL}.*
           BODY_EOF
-          )" \
-            --base "$TARGET_BRANCH" \
-            --head "$BRANCH_NAME" \
-            --draft)
+          )
+
+          # Build PR create command with optional --draft flag
+          PR_ARGS=(
+            --title "[${ISSUE_IDENTIFIER}] WIP: Partial implementation (fallback PR)"
+            --body "$PR_BODY"
+            --base "$TARGET_BRANCH"
+            --head "$BRANCH_NAME"
+          )
+
+          # Add --draft flag if pr_type is 'draft'
+          if [ "$PR_TYPE" = "draft" ]; then
+            PR_ARGS+=(--draft)
+          fi
+
+          # Create the fallback PR
+          PR_URL=$(gh pr create "${PR_ARGS[@]}")
 
           echo "Created fallback PR: $PR_URL"
           echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
@@ -543,6 +562,8 @@ jobs:
           echo "**Model:** ${{ inputs.model }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Max Turns:** 150" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**PR Type:** ${{ inputs.pr_type }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           # Show commit count


### PR DESCRIPTION
<!-- claude-pr-description-start -->
## Summary
Adds a configurable `pr_type` input to the Claude task worker workflow, allowing users to choose between creating draft or published pull requests. This provides flexibility for workflows that need immediate visibility of PRs without the draft status.
## Changes
- **New `pr_type` input**: Added to `_claude-task-worker.yml` with options `"draft"` (default) or `"published"`
- **Dynamic PR creation**: Updated Phase 7 prompt instructions to conditionally include `--draft` flag based on `pr_type` input
- **Fallback PR support**: Modified fallback PR creation logic to respect the `pr_type` setting using bash array construction
- **Job summary enhancement**: Added PR type to the workflow job summary for visibility
- **Documentation updates**: Updated `.github/workflows/CLAUDE.md` with:
  - New configuration row for `pr_type` input
  - Updated feature table to mention configurable PR type
  - Added example usage showing `pr_type` option
## Technical Details
The implementation uses conditional bash logic to append the `--draft` flag only when `pr_type` is set to `"draft"`:
```yaml
--head "${{ inputs.branch_name }}"${{ inputs.pr_type == 'draft' && ' \
    --draft' || '' }}
```
For the fallback PR creation, the workflow now builds a bash array and conditionally adds the `--draft` flag:
```bash
if [ "$PR_TYPE" = "draft" ]; then
  PR_ARGS+=(--draft)
fi
```
This approach maintains backward compatibility (draft is the default) while enabling published PRs for workflows that need them.
<!-- claude-pr-description-end -->