### PR TITLE
feat(post-review): add custom token support for GraphQL thread resolution

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -290,7 +290,7 @@ Common secrets referenced:
 
 - `ANTHROPIC_API_KEY` - Claude AI API authentication (also requires the [Claude GitHub App](https://github.com/apps/claude) to be installed on the repository)
 - `NODE_AUTH_TOKEN` - NPM registry authentication (for publishing and installing `@uniswap` scoped packages)
-- `WORKFLOW_PAT` - Personal Access Token with `repo` scope for: (1) pushing commits/tags in force-publish, (2) cross-repo access to fetch default prompts from ai-toolkit in `_claude-code-review.yml` and `_generate-pr-metadata.yml`
+- `WORKFLOW_PAT` - Personal Access Token with `repo` scope for: (1) pushing commits/tags in force-publish, (2) cross-repo access to fetch default prompts from ai-toolkit in `_claude-code-review.yml` and `_generate-pr-metadata.yml`, (3) resolving review threads via GraphQL API in `_claude-code-review.yml` (the default `GITHUB_TOKEN` lacks permissions for the `resolveReviewThread` mutation)
 - `SERVICE_ACCOUNT_GPG_PRIVATE_KEY` - GPG key for signed commits/tags
 - `LINEAR_API_KEY` - Linear API authentication (for autonomous tasks)
 - `SLACK_WEBHOOK_URL` - Slack notifications

--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -595,6 +595,9 @@ jobs:
         id: post-review
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # WORKFLOW_PAT is used for GraphQL operations (resolving review threads)
+          # that require elevated permissions beyond what GITHUB_TOKEN provides
+          GH_TOKEN_FOR_GRAPHQL: ${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ inputs.pr_number }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           # Pass file path instead of content to avoid shell injection risks


### PR DESCRIPTION
<!-- claude-pr-description-start -->
## Summary
Adds custom token support to the post-review script for GraphQL operations, enabling proper authentication for the `resolveReviewThread` mutation which requires elevated permissions beyond what the default `GITHUB_TOKEN` provides.
## Changes
- **Refactored `gh` function signature**: Updated to accept an options object (`GhOptions`) for improved flexibility, supporting both custom tokens and input data while maintaining backward compatibility with the legacy string signature
- **Added `GH_TOKEN_FOR_GRAPHQL` support**: The `resolveReviewThread` function now uses a dedicated environment variable for GraphQL operations that require elevated permissions
- **Updated workflow configuration**: Modified `_claude-code-review.yml` to set `GH_TOKEN_FOR_GRAPHQL` using `WORKFLOW_PAT` with fallback to `GITHUB_TOKEN`
- **Enhanced documentation**: Updated `CLAUDE.md` to clarify that `WORKFLOW_PAT` is required for resolving review threads via the GraphQL API
## Technical Details
The GitHub `resolveReviewThread` GraphQL mutation requires permissions that the default `GITHUB_TOKEN` in Actions doesn't have. This PR introduces:
1. **New `GhOptions` interface**: Allows passing both `input` (for stdin data) and `token` (for custom authentication) to the `gh` helper function
2. **Token override mechanism**: When `opts.token` is provided, it overrides `GH_TOKEN` in the subprocess environment
3. **Graceful fallback**: If `GH_TOKEN_FOR_GRAPHQL` is not set, the script logs a warning and uses the default token
This ensures review thread resolution works in repositories where `WORKFLOW_PAT` is configured while gracefully degrading in environments without it.
<!-- claude-pr-description-end -->