### PR TITLE
docs(workflows): clarify outcome consistency rules for PR reviews

### DIFF
--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -351,6 +351,16 @@ jobs:
             - \`APPROVE\`: No blocking issues, code is safe to merge
             - \`REQUEST_CHANGES\`: Critical bugs, security vulnerabilities, or data loss risks
             - \`COMMENT\`: Suggestions and improvements, but not blocking merge
+
+          **CRITICAL - Outcome Consistency Rule:**
+          Your \`pr_review_outcome\` MUST match your stated recommendation in \`pr_review_body\`.
+          - If your analysis finds NO issues and you recommend approval → use \`APPROVE\`
+          - If your analysis finds blocking issues → use \`REQUEST_CHANGES\`
+          - Only use \`COMMENT\` when you have suggestions but explicitly do NOT recommend approval yet
+
+          Do NOT default to \`COMMENT\` when you intend to approve. If you write "Recommendation: APPROVE"
+          or "No issues found, safe to merge" in your review body, the \`pr_review_outcome\` must be \`APPROVE\`.
+
           - \`inline_comments_new\`: Array of inline comments on specific lines (can be empty \`[]\`)
             - Each needs: \`path\` (file), \`line\` (number), \`body\` (feedback)
             - Optional: \`suggestion\` (corrected code snippet)


### PR DESCRIPTION
<!-- claude-pr-description-start -->
## Summary
Adds explicit guidance to the Claude code review workflow to ensure the `pr_review_outcome` field matches the stated recommendation in the `pr_review_body`. This addresses a consistency issue where the reviewer might recommend approval in the review text but use `COMMENT` as the outcome.
## Changes
- **Added Outcome Consistency Rule**: New critical guidance section in `_claude-code-review.yml` that clarifies when to use each outcome value
- **Explicit mapping guidance**: Clear rules mapping analysis findings to appropriate outcomes (`APPROVE`, `REQUEST_CHANGES`, `COMMENT`)
- **Anti-pattern warning**: Explicit instruction not to default to `COMMENT` when intending to approve
## Technical Details
The new guidance ensures:
- If the review body recommends approval → outcome must be `APPROVE`
- If the review body identifies blocking issues → outcome must be `REQUEST_CHANGES`
- `COMMENT` should only be used when there are suggestions but no explicit approval recommendation
This prevents mismatches where a review might state "No issues found, safe to merge" while incorrectly using `COMMENT` as the outcome, which could confuse PR authors about the actual review verdict.
<!-- claude-pr-description-end -->