### PR TITLE
feat(workflows): detect reusable workflow changes in publish workflow

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -191,6 +191,7 @@ These workflows are prefixed with two `__` and are only used within this reposit
     - **Force mode** (manual workflow_dispatch): Publishes user-specified packages with prerelease versioning, useful for new packages or failed releases
   - Handles atomic versioning, npm publish with OIDC, git commit/tag push, and GitHub release creation
   - **Lockfile sync**: Automatically updates `package-lock.json` when package versions are bumped to keep workspace dependencies in sync
+  - **Workflow change detection**: Detects changes to reusable workflow files (prefixed with `_`) and triggers branch sync and notifications even when no packages need to be published
 
 ### Consumer Workflows
 
@@ -335,6 +336,7 @@ The publishing functionality is consolidated into a single unified workflow due 
 │                                                                   │
 │  1. detect                                                        │
 │     ├── Auto: Detect affected packages via Nx                    │
+│     ├── Auto: Detect reusable workflow changes (_.yml files)    │
 │     └── Force: Resolve user-specified packages                   │
 │                                                                   │
 │  2. publish                                                       │
@@ -344,16 +346,19 @@ The publishing functionality is consolidated into a single unified workflow due 
 │     ├── Push commits + tags                                      │
 │     └── Create GitHub releases                                   │
 │                                                                   │
-│  3. generate-changelog (Auto mode only)                          │
+│  3. generate-changelog (Auto mode only, when packages published) │
 │     └── AI-generated release notes                               │
 │                                                                   │
-│  4. notify-release (Auto mode only)                              │
-│     └── Slack notifications                                      │
+│  4. notify-release (Auto mode only, when packages published)     │
+│     └── Slack notifications for package releases                 │
 │                                                                   │
-│  5. sync-next (Auto mode, main branch only)                      │
-│     └── Sync main → next branch                                  │
+│  5. notify-workflow-changes (Auto mode, workflow changes only)   │
+│     └── Slack notifications for workflow updates                 │
 │                                                                   │
-│  6. summary (Force mode only)                                    │
+│  6. sync-next (Auto mode, main branch only)                      │
+│     └── Sync main → next branch (packages OR workflows changed)  │
+│                                                                   │
+│  7. summary (Force mode only)                                    │
 │     └── Publish summary                                          │
 │                                                                   │
 └───────────────────────────────────────────────────────────────────┘

--- a/.github/workflows/_claude-task-worker.yml
+++ b/.github/workflows/_claude-task-worker.yml
@@ -379,9 +379,11 @@ jobs:
       # Check how many commits were made
       - name: Check commit count
         id: check-commits
+        env:
+          TARGET_BRANCH: ${{ inputs.target_branch }}
         run: |
           # Count commits beyond the base branch
-          COMMITS=$(git log origin/${{ inputs.target_branch }}..HEAD --oneline 2>/dev/null | wc -l | tr -d ' ')
+          COMMITS=$(git log origin/"$TARGET_BRANCH"..HEAD --oneline 2>/dev/null | wc -l | tr -d ' ')
           echo "commit_count=$COMMITS" >> $GITHUB_OUTPUT
           echo "Commits made: $COMMITS"
 
@@ -432,16 +434,21 @@ jobs:
           PR_EXISTS: ${{ steps.check-pr.outputs.pr_exists }}
           PR_URL: ${{ steps.check-pr.outputs.pr_url }}
           COMMIT_COUNT: ${{ steps.check-commits.outputs.commit_count }}
+          ISSUE_IDENTIFIER: ${{ inputs.issue_identifier }}
+          ISSUE_TITLE: ${{ inputs.issue_title }}
+          ISSUE_URL: ${{ inputs.issue_url }}
+          BRANCH_NAME: ${{ inputs.branch_name }}
+          MODEL: ${{ inputs.model }}
         run: |
-          echo "## Task: ${{ inputs.issue_identifier }}" >> $GITHUB_STEP_SUMMARY
+          echo "## Task: $ISSUE_IDENTIFIER" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Title:** ${{ inputs.issue_title }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Title:** $ISSUE_TITLE" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Linear Issue:** [${{ inputs.issue_identifier }}](${{ inputs.issue_url }})" >> $GITHUB_STEP_SUMMARY
+          echo "**Linear Issue:** [$ISSUE_IDENTIFIER]($ISSUE_URL)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Branch:** \`${{ inputs.branch_name }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Branch:** \`$BRANCH_NAME\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Model:** ${{ inputs.model }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Model:** $MODEL" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Max Turns:** 150" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -14,6 +14,14 @@ name: Publish Packages
 # - Push to next: Auto mode with 'next' npm tag, prerelease versioning
 # - workflow_dispatch: Force mode with 'next' npm tag, prerelease versioning
 #
+# WORKFLOW CHANGE DETECTION:
+# In addition to package publishing, this workflow also detects changes to reusable workflow
+# files (prefixed with _ in .github/workflows/). When workflow files change:
+# - The next branch is synced with main (ensures workflow updates propagate)
+# - A Slack notification is sent about the workflow changes
+# This ensures that workflow updates are tracked and communicated even when no packages
+# need to be published.
+#
 # REQUIRED SECRETS:
 # - WORKFLOW_PAT: For pushing commits/tags
 # - NODE_AUTH_TOKEN: For npm publishing
@@ -62,6 +70,8 @@ jobs:
     environment: ${{ github.event_name == 'push' && 'Production' || null }}
     outputs:
       has_packages: ${{ steps.resolve.outputs.has_packages }}
+      has_workflow_changes: ${{ steps.workflow-changes.outputs.has_workflow_changes }}
+      should_continue: ${{ steps.resolve.outputs.has_packages == 'true' || steps.workflow-changes.outputs.has_workflow_changes == 'true' }}
       projects: ${{ steps.resolve.outputs.projects }}
       packages: ${{ steps.resolve.outputs.packages }}
       package_count: ${{ steps.resolve.outputs.package_count }}
@@ -166,6 +176,47 @@ jobs:
           else
             echo "Using commit before push: $BASE_SHA"
             echo "base=$BASE_SHA" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Detect reusable workflow changes
+        id: workflow-changes
+        if: github.event_name == 'push'
+        env:
+          BASE_SHA: ${{ steps.base-sha.outputs.base }}
+        run: |
+          echo "=========================================="
+          echo "Checking for reusable workflow changes"
+          echo "=========================================="
+
+          # Get list of changed files between base and HEAD
+          CHANGED_FILES=$(git diff --name-only "$BASE_SHA" HEAD 2>/dev/null || echo "")
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "ℹ️  No files changed"
+            echo "has_workflow_changes=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+          echo ""
+
+          # Check for changes to reusable workflows (files prefixed with _ in .github/workflows/)
+          # These are shared workflows that other repositories may depend on
+          WORKFLOW_CHANGES=$(echo "$CHANGED_FILES" | grep -E '^\.github/workflows/_.*\.yml$' || echo "")
+
+          if [ -n "$WORKFLOW_CHANGES" ]; then
+            echo "✅ Found reusable workflow changes:"
+            echo "$WORKFLOW_CHANGES"
+            echo ""
+            echo "has_workflow_changes=true" >> $GITHUB_OUTPUT
+
+            # Count changed workflows
+            WORKFLOW_COUNT=$(echo "$WORKFLOW_CHANGES" | wc -l | tr -d ' ')
+            echo "📊 $WORKFLOW_COUNT reusable workflow(s) changed"
+          else
+            echo "ℹ️  No reusable workflow changes detected"
+            echo "has_workflow_changes=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Resolve packages to publish
@@ -1146,16 +1197,144 @@ jobs:
       NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
 
   # ============================================================================
+  # NOTIFY WORKFLOW CHANGES: Notification when only workflow files changed
+  # ============================================================================
+  # This job handles the case where reusable workflow files were updated
+  # but no npm packages were published. It ensures stakeholders are aware
+  # of workflow changes that may affect dependent repositories.
+  notify-workflow-changes:
+    name: Notify workflow changes
+    runs-on: ubuntu-24.04
+    needs: [detect, publish]
+    # Run when workflow files changed but no packages were published
+    # (the notify-release job handles the case when packages ARE published)
+    if: |
+      always() &&
+      github.event_name == 'push' &&
+      needs.detect.outputs.is_dry_run != 'true' &&
+      needs.detect.outputs.has_workflow_changes == 'true' &&
+      (needs.detect.outputs.has_packages != 'true' || needs.publish.outputs.has_successes != 'true')
+
+    steps:
+      - uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
+
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Identify changed workflows
+        id: changed-workflows
+        env:
+          BASE_SHA: ${{ needs.detect.outputs.base_sha }}
+        run: |
+          # Get list of changed reusable workflow files
+          WORKFLOW_CHANGES=$(git diff --name-only "$BASE_SHA" HEAD 2>/dev/null | grep -E '^\.github/workflows/_.*\.yml$' || echo "")
+
+          if [ -z "$WORKFLOW_CHANGES" ]; then
+            echo "workflow_list=" >> $GITHUB_OUTPUT
+            echo "workflow_count=0" >> $GITHUB_OUTPUT
+          else
+            # Format as comma-separated list
+            WORKFLOW_LIST=$(echo "$WORKFLOW_CHANGES" | tr '\n' ',' | sed 's/,$//')
+            WORKFLOW_COUNT=$(echo "$WORKFLOW_CHANGES" | wc -l | tr -d ' ')
+            echo "workflow_list=$WORKFLOW_LIST" >> $GITHUB_OUTPUT
+            echo "workflow_count=$WORKFLOW_COUNT" >> $GITHUB_OUTPUT
+            echo "Changed workflows: $WORKFLOW_LIST"
+          fi
+
+      - name: Send Slack notification for workflow changes
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          BRANCH_NAME: ${{ github.ref_name }}
+          WORKFLOW_LIST: ${{ steps.changed-workflows.outputs.workflow_list }}
+          WORKFLOW_COUNT: ${{ steps.changed-workflows.outputs.workflow_count }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          # Format the workflow list for Slack
+          FORMATTED_WORKFLOWS=$(echo "$WORKFLOW_LIST" | tr ',' '\n' | sed 's|^\.github/workflows/||' | while read f; do echo "• $f"; done)
+
+          # Build Slack message payload
+          PAYLOAD=$(cat <<EOF
+          {
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": "🔧 Workflow Update - $BRANCH_NAME",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "*$WORKFLOW_COUNT reusable workflow(s) updated*\n\n$FORMATTED_WORKFLOWS"
+                }
+              },
+              {
+                "type": "context",
+                "elements": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "<$REPO_URL/commit/$COMMIT_SHA|View commit> | <$REPO_URL/tree/$BRANCH_NAME/.github/workflows|Browse workflows>"
+                  }
+                ]
+              }
+            ]
+          }
+          EOF
+          )
+
+          # Send to Slack
+          if [ -n "$SLACK_WEBHOOK_URL" ]; then
+            curl -X POST -H 'Content-type: application/json' \
+              --data "$PAYLOAD" \
+              "$SLACK_WEBHOOK_URL" \
+              --silent --show-error --fail || echo "⚠️ Failed to send Slack notification"
+            echo "✅ Sent Slack notification for workflow changes"
+          else
+            echo "⚠️ SLACK_WEBHOOK_URL not configured, skipping notification"
+          fi
+
+      - name: Generate workflow summary
+        env:
+          WORKFLOW_LIST: ${{ steps.changed-workflows.outputs.workflow_list }}
+          WORKFLOW_COUNT: ${{ steps.changed-workflows.outputs.workflow_count }}
+          BRANCH_NAME: ${{ github.ref_name }}
+        run: |
+          echo "## 🔧 Workflow Update" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Branch:** $BRANCH_NAME" >> $GITHUB_STEP_SUMMARY
+          echo "**Workflows updated:** $WORKFLOW_COUNT" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Changed Workflows" >> $GITHUB_STEP_SUMMARY
+          echo "$WORKFLOW_LIST" | tr ',' '\n' | sed 's|^\.github/workflows/||' | while read f; do
+            [ -n "$f" ] && echo "- \`$f\`" >> $GITHUB_STEP_SUMMARY
+          done
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "ℹ️ No npm packages were published in this update." >> $GITHUB_STEP_SUMMARY
+
+  # ============================================================================
   # SYNC NEXT: Sync next branch with main after main releases (auto mode only)
   # ============================================================================
+  # Runs when packages are published OR when reusable workflow files are changed
+  # This ensures the next branch stays in sync with main for all significant changes
   sync-next:
     name: Sync next branch with main
     runs-on: ubuntu-24.04
     needs: [detect, publish]
+    # Run if we're on main, it's a push event, not a dry run, AND either:
+    # - packages were published successfully, OR
+    # - reusable workflow files were changed (even if no packages to publish)
     if: |
+      always() &&
       github.ref_name == 'main' &&
       github.event_name == 'push' &&
-      needs.detect.outputs.is_dry_run != 'true'
+      needs.detect.outputs.is_dry_run != 'true' &&
+      (needs.publish.outputs.has_successes == 'true' || needs.detect.outputs.has_workflow_changes == 'true')
     permissions:
       contents: write
 


### PR DESCRIPTION
## Summary

Add workflow change detection to the `publish-packages.yml` workflow to detect changes to reusable workflow files (prefixed with `_` in `.github/workflows/`). This ensures that:

- The `next` branch is synced with `main` when workflow files change
- Slack notifications are sent about workflow updates
- These actions happen even when no npm packages need to be published

## Problem

Previously, the publish workflow only continued through the release process (sync next, notify via Slack/Notion, etc.) when there were packages to publish. If changes were made to shared GitHub Actions workflows (the reusable `_*.yml` files) without any package changes, these workflow updates would not trigger the branch sync or notifications.

## Solution

Added a new detection step in the `detect` job that checks if any reusable workflow files (`.github/workflows/_*.yml`) have changed. The workflow now:

1. **Detects workflow changes** in addition to package changes
2. **Runs `sync-next`** when either packages were published OR workflow files changed
3. **Sends Slack notifications** specifically about workflow updates when no packages were published

## Changes

- Add `has_workflow_changes` and `should_continue` outputs to the detect job
- Add new `notify-workflow-changes` job for workflow-only updates (sends Slack notification)
- Update `sync-next` job condition to run when workflows OR packages change
- Update workflow header comments to document the new feature
- Update `.github/workflows/CLAUDE.md` documentation

## Test Plan

- [ ] Create a test branch with only workflow file changes (no package changes)
- [ ] Verify the `detect` job correctly identifies workflow changes
- [ ] Verify the `notify-workflow-changes` job runs and sends a Slack notification
- [ ] Verify the `sync-next` job runs for workflow-only changes
- [ ] Verify the existing package publishing flow still works correctly

Closes DEV-152