### PR TITLE
feat(code-review): add force review option to bypass cache and enhance manual review triggers

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -70,6 +70,7 @@ This workflow performs automated PR code reviews using Claude AI with the follow
 - Formal GitHub reviews (APPROVE/REQUEST_CHANGES/COMMENT)
 - Inline comments on specific lines of code (as `github-actions[bot]`)
 - Patch-ID based caching to skip rebases (no actual code changes)
+- Manual trigger support for re-requesting reviews (bypasses cache)
 - Custom prompt support
 - Existing review comment context for re-reviews
 - Fast review mode for trivial PRs (< 20 lines)
@@ -100,6 +101,7 @@ This ensures all comments appear as `github-actions[bot]` using the official Ant
 | -------------------- | -------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | `pr_number`          | Yes      | -                                  | Pull request number to review                                                                                                  |
 | `base_ref`           | Yes      | -                                  | Base branch name (e.g., main, master)                                                                                          |
+| `force_review`       | No       | `false`                            | Force a full review even if the code hasn't changed (bypasses patch-ID cache)                                                  |
 | `model`              | No       | `claude-sonnet-4-5-20250929`       | Claude model to use for review                                                                                                 |
 | `max_turns`          | No       | unlimited                          | Maximum conversation turns for Claude                                                                                          |
 | `custom_prompt`      | No       | `""`                               | Custom prompt text (overrides prompt file and default)                                                                         |
@@ -146,6 +148,47 @@ secrets:
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}
 ```
+
+**Re-requesting a Review (Easiest Method):**
+
+The easiest way to trigger a fresh Claude review is through the GitHub PR UI:
+
+1. In your PR, find the `github-actions[bot]` reviewer in the "Reviewers" section
+2. Click the **re-request review** button (circular arrow icon ↻) next to it
+3. A new review will start automatically, bypassing the cache
+
+This is the same UX as re-requesting a review from any human reviewer!
+
+**When to use re-request:**
+
+- After addressing review comments without pushing new code
+- After infrastructure changes (e.g., updated prompts, new model)
+- When a previous review timed out or encountered errors
+- When you want a fresh perspective on unchanged code
+
+**Alternative: Manual Trigger via workflow_dispatch:**
+
+For advanced use cases, you can also trigger a review via the Actions tab:
+
+**Via GitHub CLI:**
+
+```bash
+# Trigger a forced review for PR #123
+gh workflow run "Claude Code Review" -f pr_number=123
+
+# Trigger without forcing (will respect cache)
+gh workflow run "Claude Code Review" -f pr_number=123 -f force_review=false
+```
+
+**Via GitHub UI:**
+
+1. Navigate to Actions → Claude Code Review
+2. Click "Run workflow"
+3. Enter the PR number
+4. Optionally toggle `force_review` (defaults to `true`)
+5. Click "Run workflow"
+
+When `force_review` is `true`, the workflow bypasses the patch-ID cache and runs a complete review even if the same code was previously reviewed.
 
 ### PR Metadata Generation (`_generate-pr-metadata.yml`)
 

--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -50,6 +50,12 @@ on:
         required: true
         type: string
 
+      force_review:
+        description: "Force a full review even if the code hasn't changed (bypasses patch-ID cache)"
+        required: false
+        type: boolean
+        default: false
+
       model:
         description: "Claude model to use for review"
         required: false
@@ -171,17 +177,27 @@ jobs:
           fi
 
       # Check cache to see if we've already reviewed this exact code
+      # Skip cache check entirely when force_review is enabled
       - name: Check Review Cache
         id: cache-check
+        if: inputs.force_review != true
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .review-cache
           key: review-pr${{ inputs.pr_number }}-patch-${{ steps.patch-id.outputs.patch_id }}
           lookup-only: true # Just check, don't restore
 
+      # Log when force review is enabled
+      - name: Force Review Enabled
+        if: inputs.force_review == true
+        run: |
+          echo "🔄 Force review enabled - bypassing cache check"
+          echo "   A full review will run regardless of previous reviews for this code"
+
       # Early exit if we've already reviewed this code (rebase detected)
+      # Never skip when force_review is enabled
       - name: Skip Review if No Changes
-        if: steps.cache-check.outputs.cache-hit == 'true'
+        if: steps.cache-check.outputs.cache-hit == 'true' && inputs.force_review != true
         run: |
           echo "✅ Skipping review - no actual code changes detected"
           echo ""
@@ -189,6 +205,8 @@ jobs:
           echo "Patch-ID: ${{ steps.patch-id.outputs.patch_id }}"
           echo ""
           echo "We've already reviewed this exact code, so skipping to save API costs."
+          echo ""
+          echo "💡 To force a new review, use the manual trigger with force_review: true"
           exit 0
 
       # Fetch existing review comments for context

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,26 +8,85 @@ name: Claude Code Review
 # - Auto-resolution of fixed issues on subsequent reviews
 # - Patch-ID based caching to skip rebases (no duplicate reviews)
 # - Iterative review tracking of previous comments
+# - Re-request review support (via GitHub UI "re-request review" button)
+#
+# TRIGGERS:
+# - Automatic: On PR open, synchronize (push), or ready_for_review
+# - Re-request: Click "re-request review" from github-actions[bot] in the PR UI
+# - Manual: Via workflow_dispatch with PR number and optional force_review flag
+#
+# RE-REQUEST REVIEW (Easiest Method):
+# In the GitHub PR UI, find the github-actions[bot] reviewer and click the
+# "re-request review" button (circular arrow icon). This bypasses the cache
+# and runs a fresh review even if the code hasn't changed.
+#
+# MANUAL TRIGGER (workflow_dispatch):
+# Alternatively, use the Actions tab to manually trigger a review:
+#   gh workflow run "Claude Code Review" -f pr_number=123
 #
 # The review uses the default prompt from this repository's
 # .github/prompts/default-pr-review.md
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
+      - review_requested # Triggered when review is requested/re-requested
+
+  # Manual trigger for re-requesting a review
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to review"
+        required: true
+        type: string
+      force_review:
+        description: "Force a full review even if the code hasn't changed (bypasses cache)"
+        required: false
+        type: boolean
+        default: true
 
 # Ensure only one review runs at a time per PR
 # New reviews wait for the current one to complete before starting
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number }}
+  group: claude-review-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: false
 
 jobs:
-  claude-review:
-    # Skip merge queue PRs, draft PRs (unless authored by claude[bot]), and release promotion PRs
-    # DEV-131 requirement #6: Skip workflow for production promotion PRs
-    # Exception: Always run on PRs authored by claude[bot] (autonomous task PRs)
+  # Fetch PR details for manual triggers (workflow_dispatch)
+  # This job retrieves base_ref which isn't available in workflow_dispatch context
+  get-pr-info:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    outputs:
+      base_ref: ${{ steps.pr-info.outputs.base_ref }}
+      head_ref: ${{ steps.pr-info.outputs.head_ref }}
+    steps:
+      - name: Get PR Info
+        id: pr-info
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          echo "ℹ️  Fetching PR #$PR_NUMBER info..."
+          PR_DATA=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER)
+
+          BASE_REF=$(echo "$PR_DATA" | jq -r '.base.ref')
+          HEAD_REF=$(echo "$PR_DATA" | jq -r '.head.ref')
+
+          echo "base_ref=$BASE_REF" >> $GITHUB_OUTPUT
+          echo "head_ref=$HEAD_REF" >> $GITHUB_OUTPUT
+
+          echo "✅ PR #$PR_NUMBER: base=$BASE_REF, head=$HEAD_REF"
+
+  # Automatic review triggered by pull_request events (opened, synchronize, ready_for_review)
+  # Does NOT run for review_requested events (those are handled by claude-review-rerequest)
+  claude-review-auto:
     if: |
+      github.event_name == 'pull_request' &&
+      github.event.action != 'review_requested' &&
       !contains(github.head_ref, 'gh-readonly-queue/') &&
       !startsWith(github.head_ref, 'release/next-to-main-') &&
       (
@@ -40,6 +99,7 @@ jobs:
     with:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
+      force_review: false
 
       # Use Opus 4.5 for comprehensive reviews with reliable inline comments
       # Opus is more capable at following complex multi-step instructions
@@ -61,13 +121,68 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}
 
-  # Auto-merge Dependabot security updates after successful review
-  auto-merge-dependabot:
-    needs: claude-review
+  # Re-request review triggered when someone clicks "re-request review" from github-actions[bot]
+  # This forces a fresh review even if the code hasn't changed (bypasses patch-ID cache)
+  # NOTE: Unlike claude-review-auto, this intentionally does NOT check for draft PRs.
+  # Users who explicitly re-request a review on a draft PR want a review.
+  claude-review-rerequest:
     if: |
+      github.event_name == 'pull_request' &&
+      github.event.action == 'review_requested' &&
+      github.event.requested_reviewer.login == 'github-actions[bot]' &&
+      !contains(github.head_ref, 'gh-readonly-queue/') &&
+      !startsWith(github.head_ref, 'release/next-to-main-')
+
+    uses: ./.github/workflows/_claude-code-review.yml
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      base_ref: ${{ github.base_ref }}
+      force_review: true # Always force when re-requesting
+
+      # Use Opus 4.5 for comprehensive reviews with reliable inline comments
+      model: 'claude-opus-4-5'
+
+      # Standard timeout for most PRs
+      timeout_minutes: 20
+
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}
+
+  # Manual review triggered by workflow_dispatch
+  # This runs after get-pr-info to have access to PR metadata
+  claude-review-manual:
+    needs: get-pr-info
+    if: |
+      github.event_name == 'workflow_dispatch' &&
+      !contains(needs.get-pr-info.outputs.head_ref, 'gh-readonly-queue/') &&
+      !startsWith(needs.get-pr-info.outputs.head_ref, 'release/next-to-main-')
+
+    uses: ./.github/workflows/_claude-code-review.yml
+    with:
+      pr_number: ${{ inputs.pr_number }}
+      base_ref: ${{ needs.get-pr-info.outputs.base_ref }}
+      force_review: ${{ inputs.force_review }}
+
+      # Use Opus 4.5 for comprehensive reviews with reliable inline comments
+      model: 'claude-opus-4-5'
+
+      # Standard timeout for most PRs
+      timeout_minutes: 20
+
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}
+
+  # Auto-merge Dependabot security updates after successful review
+  # Only runs for pull_request events (dependabot only triggers pull_request)
+  auto-merge-dependabot:
+    needs: claude-review-auto
+    if: |
+      github.event_name == 'pull_request' &&
       github.actor == 'dependabot[bot]' &&
       (contains(github.event.pull_request.title, 'security') || contains(github.event.pull_request.title, 'Bump')) &&
-      needs.claude-review.result == 'success'
+      needs.claude-review-auto.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
<!-- claude-pr-description-start -->
## Summary
Enhances the Claude Code Review workflow with a `force_review` option to bypass the patch-ID cache and adds support for re-requesting reviews via the GitHub UI, providing a familiar UX similar to re-requesting reviews from human reviewers.
## Changes
- **New `force_review` input**: Added to the reusable `_claude-code-review.yml` workflow, allowing callers to bypass the patch-ID cache and force a complete review even if the same code was previously reviewed
- **Re-request review support**: Added `review_requested` trigger to detect when someone clicks "re-request review" from `github-actions[bot]` in the PR UI, automatically triggering a forced review
- **Manual trigger via workflow_dispatch**: Added ability to manually trigger reviews from the Actions tab with configurable `force_review` flag (defaults to `true`)
- **Three-job architecture**: Refactored the main workflow into separate jobs for each trigger type:
  - `claude-review-auto`: Standard automatic reviews on PR open/sync/ready (respects cache)
  - `claude-review-rerequest`: Re-request reviews (always forces)
  - `claude-review-manual`: Manual workflow_dispatch reviews (configurable force)
- **PR info fetching**: Added `get-pr-info` job to retrieve base branch and PR metadata for manual triggers
- **Documentation**: Updated `.github/workflows/CLAUDE.md` with comprehensive usage instructions for re-requesting reviews and manual triggers
## Technical Details
The key architectural change separates the workflow into three distinct jobs based on trigger type, allowing different behaviors:
- Automatic reviews respect the cache (skip if code unchanged)
- Re-request reviews always force a new review (best UX for users)
- Manual reviews can be configured either way
The re-request trigger specifically checks for `github.event.requested_reviewer.login == 'github-actions[bot]'` to only respond when Claude's review is re-requested, not other reviewers.
## Usage
**Re-request a Review (Easiest):**
1. Find `github-actions[bot]` in the PR "Reviewers" section
2. Click the re-request review button (circular arrow icon)
**Manual Trigger:**
```bash
# Force review for PR #123
gh workflow run "Claude Code Review" -f pr_number=123
# Review without forcing (respects cache)
gh workflow run "Claude Code Review" -f pr_number=123 -f force_review=false
```
<!-- claude-pr-description-end -->