### PR TITLE
feat(workflows): implement real-time status updates for PR reviews

### DIFF
--- a/.github/scripts/post-review.ts
+++ b/.github/scripts/post-review.ts
@@ -9,18 +9,39 @@
  * validated JSON directly via `structured_output`. This script expects clean
  * JSON input (no preamble text or code fences needed).
  *
+ * MODES:
+ * - review (default): Posts a full review from Claude's JSON output
+ * - in-progress: Posts a "review in progress" placeholder comment
+ * - skipped: Preserves existing review content with a "still valid" status banner (cache hit)
+ *            If no substantial review exists, posts a fallback "no review needed" message
+ *
  * @usage
+ *   # Full review mode (default)
  *   npx tsx .github/scripts/post-review.ts \
+ *     --owner "Uniswap" \
+ *     --repo "ai-toolkit" \
+ *     --pr-number 123
+ *
+ *   # In-progress mode (no JSON needed)
+ *   npx tsx .github/scripts/post-review.ts \
+ *     --mode in-progress \
+ *     --owner "Uniswap" \
+ *     --repo "ai-toolkit" \
+ *     --pr-number 123
+ *
+ *   # Skipped mode (cache hit, no JSON needed)
+ *   npx tsx .github/scripts/post-review.ts \
+ *     --mode skipped \
  *     --owner "Uniswap" \
  *     --repo "ai-toolkit" \
  *     --pr-number 123
  *
  * @environment
  *   GITHUB_TOKEN - GitHub token for API authentication (required)
- *   REVIEW_JSON_FILE - Path to file containing review JSON (preferred)
- *   REVIEW_JSON - Direct JSON content (alternative to file)
+ *   REVIEW_JSON_FILE - Path to file containing review JSON (for 'review' mode)
+ *   REVIEW_JSON - Direct JSON content (alternative to file, for 'review' mode)
  *
- * @input The review JSON must match this schema:
+ * @input The review JSON must match this schema (only for 'review' mode):
  *   {
  *     "pr_review_body": string,        // Markdown review content
  *     "pr_review_outcome": string,     // "APPROVE" | "REQUEST_CHANGES" | "COMMENT"
@@ -273,14 +294,145 @@ ${suggestion}
 // Constants
 // =============================================================================
 
-/** HTML comment marker used to identify and update the bot's review comment */
+/** HTML comment marker used to identify the bot's review comment */
 const REVIEW_COMMENT_MARKER = '<!-- claude-pr-review-bot -->';
+
+/** Markers for the status section (updated on every mode change) */
+const STATUS_START_MARKER = '<!-- claude-pr-review-status-start -->';
+const STATUS_END_MARKER = '<!-- claude-pr-review-status-end -->';
+
+/** Markers for the content section (only updated when review completes) */
+const CONTENT_START_MARKER = '<!-- claude-pr-review-content-start -->';
+const CONTENT_END_MARKER = '<!-- claude-pr-review-content-end -->';
 
 /** Footer added to the main review comment explaining how to trigger a re-review */
 const REVIEW_FOOTER = `
+
 ---
 
 <sub>💡 **Want a fresh review?** Add a comment containing \`@request-claude-review\` to trigger a new review at any time.</sub>`;
+
+// -----------------------------------------------------------------------------
+// Status Templates
+// -----------------------------------------------------------------------------
+
+/** Status shown while Claude is analyzing the PR */
+const STATUS_IN_PROGRESS = `## 🤖 Claude Code Review
+
+> 🔄 **Review in progress...** Claude is analyzing this pull request. If a review can be seen below, it will be replaced by the results of this one.
+>
+> <sub>⏱️ Reviews typically complete within 5-15 minutes depending on PR size.</sub>`;
+
+/** Status shown when review completes successfully */
+const STATUS_COMPLETE = `## 🤖 Claude Code Review
+
+> ✅ **Review complete**`;
+
+/** Status shown when cache hit detected (no code changes since last review) */
+const STATUS_SKIPPED = `## 🤖 Claude Code Review
+
+> ✅ **Review still valid** — No new code changes detected since the last review.
+>
+> <sub>💡 To force a fresh review, add a comment containing \`@request-claude-review\`.</sub>`;
+
+/** Status shown when review fails */
+const STATUS_FAILED = `## 🤖 Claude Code Review
+
+> ❌ **Review failed** — An error occurred during analysis. Check the workflow logs for details.
+>
+> <sub>💡 To retry, add a comment containing \`@request-claude-review\`.</sub>`;
+
+// -----------------------------------------------------------------------------
+// Content Templates
+// -----------------------------------------------------------------------------
+
+/** Placeholder content shown before first review completes */
+const CONTENT_PLACEHOLDER = `*Waiting for review to complete...*`;
+
+/** Content shown when no review exists and cache hit (first PR with no changes) */
+const CONTENT_NO_REVIEW_NEEDED = `This PR has no code changes that require review.`;
+
+// =============================================================================
+// Comment Structure Helpers
+// =============================================================================
+
+/**
+ * Represents the parsed structure of a review comment.
+ */
+interface ParsedReviewComment {
+  /** Content of the status section (between status markers) */
+  status: string;
+  /** Content of the review section (between content markers) */
+  content: string;
+  /** Whether the comment had valid marker structure */
+  hasValidStructure: boolean;
+}
+
+/**
+ * Parses an existing comment body to extract status and content sections.
+ * Returns default empty values if markers are not found.
+ */
+function parseReviewComment(body: string): ParsedReviewComment {
+  const statusStartIdx = body.indexOf(STATUS_START_MARKER);
+  const statusEndIdx = body.indexOf(STATUS_END_MARKER);
+  const contentStartIdx = body.indexOf(CONTENT_START_MARKER);
+  const contentEndIdx = body.indexOf(CONTENT_END_MARKER);
+
+  // Check if all markers are present and in correct order
+  const hasValidStructure =
+    statusStartIdx !== -1 &&
+    statusEndIdx !== -1 &&
+    contentStartIdx !== -1 &&
+    contentEndIdx !== -1 &&
+    statusStartIdx < statusEndIdx &&
+    statusEndIdx < contentStartIdx &&
+    contentStartIdx < contentEndIdx;
+
+  if (!hasValidStructure) {
+    return {
+      status: '',
+      content: '',
+      hasValidStructure: false,
+    };
+  }
+
+  const status = body.substring(statusStartIdx + STATUS_START_MARKER.length, statusEndIdx).trim();
+
+  const content = body
+    .substring(contentStartIdx + CONTENT_START_MARKER.length, contentEndIdx)
+    .trim();
+
+  return {
+    status,
+    content,
+    hasValidStructure: true,
+  };
+}
+
+/**
+ * Builds a complete review comment body with the marker structure.
+ *
+ * Structure:
+ * ```
+ * <!-- claude-pr-review-bot -->
+ * <!-- claude-pr-review-status-start -->
+ * {status content}
+ * <!-- claude-pr-review-status-end -->
+ * <!-- claude-pr-review-content-start -->
+ * {review content}
+ * <!-- claude-pr-review-content-end -->
+ * {footer}
+ * ```
+ */
+function buildReviewComment(status: string, content: string): string {
+  return `${REVIEW_COMMENT_MARKER}
+${STATUS_START_MARKER}
+${status}
+${STATUS_END_MARKER}
+${CONTENT_START_MARKER}
+${content}
+${CONTENT_END_MARKER}${REVIEW_FOOTER}`;
+}
 
 // =============================================================================
 // GitHub API Functions
@@ -319,23 +471,90 @@ function findExistingBotComment(owner: string, repo: string, prNumber: number): 
 }
 
 /**
- * Creates or updates the main review comment on the PR.
- * This is an editable issue comment (not a review) that persists across reviews.
+ * Gets the body content of an existing PR comment by ID.
+ * Returns the comment body if found, null otherwise.
+ */
+function getCommentBody(owner: string, repo: string, commentId: number): string | null {
+  log(`Fetching body of comment ${commentId}...`);
+
+  try {
+    const result = gh([
+      'api',
+      `repos/${owner}/${repo}/issues/comments/${commentId}`,
+      '--jq',
+      '.body',
+    ]);
+
+    if (result) {
+      log(`Retrieved comment body (${result.length} chars)`);
+      return result;
+    }
+
+    log('Comment body was empty');
+    return null;
+  } catch (err) {
+    log(`Failed to fetch comment body: ${(err as Error).message}`);
+    return null;
+  }
+}
+
+/**
+ * Options for upserting a review comment.
+ */
+interface UpsertReviewCommentOptions {
+  /** The status section content */
+  status: string;
+  /** The content section (review body). If undefined, preserves existing content. */
+  content?: string;
+}
+
+/**
+ * Creates or updates the main review comment on the PR using marker-based structure.
  *
- * @returns The comment URL
+ * - If no existing comment: creates new comment with status and content
+ * - If existing comment with valid structure: updates sections as specified
+ * - If existing comment without valid structure: replaces entire comment
+ *
+ * When `content` is undefined, only the status section is updated (preserving existing content).
+ *
+ * @returns The comment ID and URL
  */
 function upsertReviewComment(
   owner: string,
   repo: string,
   prNumber: number,
-  body: string
+  options: UpsertReviewCommentOptions
 ): { id: number; html_url: string } {
-  // Prepend the marker to the body
-  const markedBody = `${REVIEW_COMMENT_MARKER}\n${body}`;
-
   const existingCommentId = findExistingBotComment(owner, repo, prNumber);
 
+  let finalBody: string;
+
   if (existingCommentId) {
+    // Fetch existing comment to check structure
+    const existingBody = getCommentBody(owner, repo, existingCommentId);
+
+    if (existingBody) {
+      const parsed = parseReviewComment(existingBody);
+
+      if (parsed.hasValidStructure && options.content === undefined) {
+        // Status-only update: preserve existing content
+        log('Updating status section only, preserving content...');
+        finalBody = buildReviewComment(options.status, parsed.content);
+      } else if (parsed.hasValidStructure && options.content !== undefined) {
+        // Full update: replace both sections
+        log('Updating both status and content sections...');
+        finalBody = buildReviewComment(options.status, options.content);
+      } else {
+        // No valid structure, replace entire comment
+        log('Existing comment has no valid marker structure, replacing entirely...');
+        finalBody = buildReviewComment(options.status, options.content ?? CONTENT_PLACEHOLDER);
+      }
+    } else {
+      // Couldn't fetch existing body, create fresh
+      log('Could not fetch existing comment body, creating fresh structure...');
+      finalBody = buildReviewComment(options.status, options.content ?? CONTENT_PLACEHOLDER);
+    }
+
     log(`Updating existing comment ${existingCommentId}...`);
 
     const result = gh(
@@ -347,7 +566,7 @@ function upsertReviewComment(
         '--input',
         '-',
       ],
-      JSON.stringify({ body: markedBody })
+      JSON.stringify({ body: finalBody })
     );
 
     try {
@@ -359,7 +578,9 @@ function upsertReviewComment(
       throw new Error('Failed to update comment');
     }
   } else {
+    // No existing comment, create new one
     log('Creating new review comment...');
+    finalBody = buildReviewComment(options.status, options.content ?? CONTENT_PLACEHOLDER);
 
     const result = gh(
       [
@@ -370,7 +591,7 @@ function upsertReviewComment(
         '--input',
         '-',
       ],
-      JSON.stringify({ body: markedBody })
+      JSON.stringify({ body: finalBody })
     );
 
     try {
@@ -931,6 +1152,7 @@ async function main(): Promise<void> {
       'pr-number': { type: 'string' },
       'review-json': { type: 'string' },
       'dry-run': { type: 'boolean', default: false },
+      mode: { type: 'string', default: 'review' }, // 'review' | 'in-progress' | 'skipped'
     },
     strict: true,
   });
@@ -939,11 +1161,66 @@ async function main(): Promise<void> {
   const repo = values.repo;
   const prNumber = parseInt(values['pr-number'] || '', 10);
   const dryRun = values['dry-run'];
+  const mode = values.mode as 'review' | 'in-progress' | 'skipped';
 
   // Validate required inputs
   if (!owner || !repo || isNaN(prNumber)) {
     logError('Missing required arguments: --owner, --repo, --pr-number');
     process.exit(1);
+  }
+
+  // Handle special modes that don't require review JSON
+  if (mode === 'in-progress') {
+    log(`Running in ${mode} mode for ${owner}/${repo}#${prNumber}`);
+
+    // In-progress mode: update status only, preserve existing content
+    // If no existing content, show placeholder
+    if (dryRun) {
+      log(`DRY RUN - Would update status to in-progress (preserving content)`);
+      console.log(buildReviewComment(STATUS_IN_PROGRESS, CONTENT_PLACEHOLDER));
+      process.exit(0);
+    }
+
+    try {
+      // Pass undefined for content to preserve existing review content
+      const result = upsertReviewComment(owner, repo, prNumber, {
+        status: STATUS_IN_PROGRESS,
+        // content: undefined - preserves existing content
+      });
+      log(`In-progress status posted: ${result.html_url}`);
+      console.log(`comment_url=${result.html_url}`);
+      console.log(`comment_id=${result.id}`);
+      process.exit(0);
+    } catch (error) {
+      logError(`Failed to post ${mode} comment: ${(error as Error).message}`);
+      process.exit(1);
+    }
+  }
+
+  // Handle skipped mode - update status only, preserve existing review content
+  if (mode === 'skipped') {
+    log(`Running in skipped mode for ${owner}/${repo}#${prNumber}`);
+
+    if (dryRun) {
+      log(`DRY RUN - Would update status to skipped (preserving content)`);
+      console.log(buildReviewComment(STATUS_SKIPPED, CONTENT_PLACEHOLDER));
+      process.exit(0);
+    }
+
+    try {
+      // Pass undefined for content to preserve existing review content
+      const result = upsertReviewComment(owner, repo, prNumber, {
+        status: STATUS_SKIPPED,
+        // content: undefined - preserves existing content
+      });
+      log(`Skipped status posted: ${result.html_url}`);
+      console.log(`comment_url=${result.html_url}`);
+      console.log(`comment_id=${result.id}`);
+      process.exit(0);
+    } catch (error) {
+      logError(`Failed to post skipped comment: ${(error as Error).message}`);
+      process.exit(1);
+    }
   }
 
   // Get review JSON from sources (priority order):
@@ -1039,8 +1316,9 @@ async function main(): Promise<void> {
     side: comment.side || ('RIGHT' as const),
   }));
 
-  // Build the full review body for the editable comment
-  let reviewBody = reviewOutput.pr_review_body;
+  // Build the review content (Claude's review body + optional skipped comments)
+  // Note: The footer is handled by buildReviewComment, not added here
+  let reviewContent = reviewOutput.pr_review_body;
   if (skippedComments.length > 0) {
     const skippedSection = `\n\n---\n\n<details>\n<summary>ℹ️ ${
       skippedComments.length
@@ -1052,27 +1330,28 @@ async function main(): Promise<void> {
           }`
       )
       .join('\n\n')}\n\n</details>`;
-    reviewBody += skippedSection;
+    reviewContent += skippedSection;
   }
 
-  // Add footer with instructions for triggering a re-review
-  reviewBody += REVIEW_FOOTER;
-
   // HYBRID APPROACH:
-  // 1. Create/update an editable PR comment with the full review content
+  // 1. Create/update an editable PR comment with marker-based structure
   // 2. Submit a minimal formal review with just the verdict (and inline comments)
   //
   // This ensures:
   // - Only ONE main review comment exists at any time (editable)
+  // - Status and content sections can be updated independently
   // - Formal review verdict is still recorded for branch protection
   // - Inline comments are attached to specific lines
 
   let commentResult: { id: number; html_url: string } | null = null;
   let reviewResult: { id: number; html_url: string } | null = null;
 
-  // Step 1: Create or update the main review comment (editable)
+  // Step 1: Create or update the main review comment (editable) with both status and content
   try {
-    commentResult = upsertReviewComment(owner, repo, prNumber, reviewBody);
+    commentResult = upsertReviewComment(owner, repo, prNumber, {
+      status: STATUS_COMPLETE,
+      content: reviewContent,
+    });
     log(`Review comment ${commentResult.id} saved at: ${commentResult.html_url}`);
   } catch (error) {
     logError(`Failed to upsert review comment: ${(error as Error).message}`);
@@ -1090,7 +1369,7 @@ async function main(): Promise<void> {
         (formattedComments.length > 0
           ? ` _${formattedComments.length} inline comment(s) are attached below._`
           : '')
-      : reviewBody; // Fallback to full body if comment failed
+      : reviewContent; // Fallback to review content if comment failed
 
     reviewResult = createReview({
       owner,

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -69,6 +69,7 @@ This workflow performs automated PR code reviews using Claude AI with the follow
 
 - Formal GitHub reviews (APPROVE/REQUEST_CHANGES/COMMENT)
 - Inline comments on specific lines of code (as `github-actions[bot]`)
+- **Real-time status updates**: Shows "review in progress" immediately when workflow starts
 - Patch-ID based caching to skip rebases (no actual code changes)
 - **Comment trigger**: Add `@request-claude-review` to any PR comment to force a fresh review
 - Manual trigger via workflow_dispatch to force a new review (bypasses cache)
@@ -99,6 +100,18 @@ This workflow uses a hybrid approach:
 2. A TypeScript script (`post-review.ts`) parses the JSON and posts the review via `gh` CLI
 
 This ensures all comments appear as `github-actions[bot]` using the official Anthropic action without needing a fork.
+
+**Real-Time Status Updates:**
+
+The workflow provides immediate feedback to PR authors:
+
+| Status                  | When Shown                                            | Message                                              |
+| ----------------------- | ----------------------------------------------------- | ---------------------------------------------------- |
+| 🔄 **In Progress**      | Immediately when workflow starts                      | "Claude is currently analyzing this pull request..." |
+| ✅ **No Review Needed** | When cache hit detected (rebase with no code changes) | "No new code changes since the last review"          |
+| 📋 **Review Complete**  | After Claude finishes analysis                        | Full review with verdict and inline comments         |
+
+This eliminates the "is it running?" uncertainty by posting a status comment as the very first action in the workflow, before any analysis begins. The same comment is then updated with the final review or skipped status.
 
 **Required Secrets:**
 

--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -138,7 +138,48 @@ jobs:
         with:
           fetch-depth: 0 # Full history needed for git merge-base
 
+      # Setup Node.js early so we can post status updates
+      - name: Setup Node.js (Early)
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: "22"
+
+      # Download or use local post-review script (needed for status updates)
+      - name: Setup Post Review Script (Early)
+        id: setup-script-early
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}
+          TOOLKIT_REF: ${{ inputs.toolkit_ref }}
+        run: |
+          set -euo pipefail
+
+          # Check if we're running from the ai-toolkit repository
+          if [ "$GITHUB_REPOSITORY" = "Uniswap/ai-toolkit" ]; then
+            echo "ℹ️  Running from ai-toolkit - using local post-review.ts"
+            echo "script_path=.github/scripts/post-review.ts" >> $GITHUB_OUTPUT
+          else
+            echo "ℹ️  Running from external repository - downloading post-review.ts from Uniswap/ai-toolkit"
+            echo "ℹ️  Using toolkit ref: $TOOLKIT_REF"
+
+            # Download the script from ai-toolkit repository at the specified ref
+            if ! curl -fSs -H "Authorization: token $WORKFLOW_PAT" \
+                      -H "Accept: application/vnd.github.v4.raw" \
+                      -L "https://api.github.com/repos/Uniswap/ai-toolkit/contents/.github/scripts/post-review.ts?ref=${TOOLKIT_REF}" \
+                      -o /tmp/post-review.ts 2>&1 | tee /tmp/curl-error.log; then
+              echo "❌ Failed to download post-review.ts from Uniswap/ai-toolkit@${TOOLKIT_REF}"
+              echo "   Error details:"
+              cat /tmp/curl-error.log | head -5
+              exit 1
+            fi
+
+            echo "✅ Downloaded post-review.ts from SHA: $TOOLKIT_REF"
+            echo "script_path=/tmp/post-review.ts" >> $GITHUB_OUTPUT
+          fi
+
       # Calculate patch-ID (stable hash of code changes, survives rebases)
+      # This must run BEFORE posting in-progress so we can check cache first
       - name: Calculate Patch ID
         id: patch-id
         env:
@@ -154,9 +195,65 @@ jobs:
           echo "📊 Patch-ID: ${PATCH_ID:0:12}... (first 12 chars)"
           echo "   This ID stays the same across rebases if code hasn't changed"
 
+      # Check cache BEFORE posting in-progress to preserve existing review
+      # Skip cache check entirely when force_review is enabled
+      - name: Check Review Cache
+        id: cache-check
+        if: inputs.force_review != true
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .review-cache
+          key: review-pr${{ inputs.pr_number }}-patch-${{ steps.patch-id.outputs.patch_id }}
+          lookup-only: true # Just check, don't restore
+
+      # Early exit if we've already reviewed this code (rebase detected)
+      # Never skip when force_review is enabled
+      # IMPORTANT: This runs BEFORE posting in-progress to preserve existing review content
+      - name: Skip Review if No Changes
+        if: steps.cache-check.outputs.cache-hit == 'true' && inputs.force_review != true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          POST_REVIEW_SCRIPT: ${{ steps.setup-script-early.outputs.script_path }}
+        run: |
+          echo "✅ Skipping review - no actual code changes detected"
+          echo ""
+          echo "This push appears to be a rebase or merge without new code changes."
+          echo "Patch-ID: ${{ steps.patch-id.outputs.patch_id }}"
+          echo ""
+          echo "We've already reviewed this exact code, so skipping to save API costs."
+          echo ""
+          echo "💡 To force a new review, use the manual trigger with force_review: true"
+
+          # Add status banner to existing review (preserving full content)
+          echo ""
+          echo "ℹ️  Adding 'still valid' status banner to existing review..."
+
+          REPO_OWNER=$(echo "$GITHUB_REPOSITORY" | cut -d'/' -f1)
+          REPO_NAME=$(echo "$GITHUB_REPOSITORY" | cut -d'/' -f2)
+
+          npx tsx "$POST_REVIEW_SCRIPT" \
+            --mode skipped \
+            --owner "$REPO_OWNER" \
+            --repo "$REPO_NAME" \
+            --pr-number "$PR_NUMBER"
+
+          echo "✅ Review preserved with status banner"
+          exit 0
+
+      # Log when force review is enabled
+      - name: Force Review Enabled
+        if: inputs.force_review == true
+        run: |
+          echo "🔄 Force review enabled - bypassing cache check"
+          echo "   A full review will run regardless of previous reviews for this code"
+
       # Detect trivial PRs for fast-path review
+      # Only runs if we're actually going to do a review (not cached)
       - name: Detect Trivial PR
         id: pr-size
+        if: steps.cache-check.outputs.cache-hit != 'true'
         env:
           BASE_REF: ${{ inputs.base_ref }}
         run: |
@@ -183,38 +280,33 @@ jobs:
             echo "📝 Standard PR - will use comprehensive review mode"
           fi
 
-      # Check cache to see if we've already reviewed this exact code
-      # Skip cache check entirely when force_review is enabled
-      - name: Check Review Cache
-        id: cache-check
-        if: inputs.force_review != true
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: .review-cache
-          key: review-pr${{ inputs.pr_number }}-patch-${{ steps.patch-id.outputs.patch_id }}
-          lookup-only: true # Just check, don't restore
-
-      # Log when force review is enabled
-      - name: Force Review Enabled
-        if: inputs.force_review == true
+      # Post "Review in Progress" comment ONLY if we're actually going to review
+      # This runs AFTER cache check to preserve existing review on cache hits
+      - name: Post Review In Progress
+        id: in-progress
+        if: steps.cache-check.outputs.cache-hit != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          POST_REVIEW_SCRIPT: ${{ steps.setup-script-early.outputs.script_path }}
         run: |
-          echo "🔄 Force review enabled - bypassing cache check"
-          echo "   A full review will run regardless of previous reviews for this code"
+          set -euo pipefail
 
-      # Early exit if we've already reviewed this code (rebase detected)
-      # Never skip when force_review is enabled
-      - name: Skip Review if No Changes
-        if: steps.cache-check.outputs.cache-hit == 'true' && inputs.force_review != true
-        run: |
-          echo "✅ Skipping review - no actual code changes detected"
-          echo ""
-          echo "This push appears to be a rebase or merge without new code changes."
-          echo "Patch-ID: ${{ steps.patch-id.outputs.patch_id }}"
-          echo ""
-          echo "We've already reviewed this exact code, so skipping to save API costs."
-          echo ""
-          echo "💡 To force a new review, use the manual trigger with force_review: true"
-          exit 0
+          echo "ℹ️  Posting 'review in progress' status..."
+
+          # Parse owner and repo
+          REPO_OWNER=$(echo "$GITHUB_REPOSITORY" | cut -d'/' -f1)
+          REPO_NAME=$(echo "$GITHUB_REPOSITORY" | cut -d'/' -f2)
+
+          # Post in-progress comment (creates or updates the bot's comment)
+          npx tsx "$POST_REVIEW_SCRIPT" \
+            --mode in-progress \
+            --owner "$REPO_OWNER" \
+            --repo "$REPO_NAME" \
+            --pr-number "$PR_NUMBER"
+
+          echo "✅ In-progress status posted"
 
       # Fetch existing review comments for context
       - name: Fetch Existing Review Comments
@@ -588,12 +680,7 @@ jobs:
           additional_permissions: |
             actions: read
 
-      # Setup Node.js for the post-review script
-      - name: Setup Node.js
-        if: steps.cache-check.outputs.cache-hit != 'true' && success()
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
-        with:
-          node-version: "22"
+      # Note: Node.js is already set up earlier for posting in-progress status
 
       # Extract Claude's structured output (validated JSON from --json-schema)
       - name: Extract Claude Response
@@ -633,42 +720,7 @@ jobs:
           retention-days: 7
           if-no-files-found: warn
 
-      # Download post-review script if running from external repository
-      # When running from ai-toolkit itself, use the local file
-      - name: Setup Post Review Script
-        if: steps.cache-check.outputs.cache-hit != 'true' && success()
-        id: setup-script
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}
-          # Explicit ref input - defaults to 'main', can be set to 'next' or a SHA for testing
-          TOOLKIT_REF: ${{ inputs.toolkit_ref }}
-        run: |
-          set -euo pipefail
-
-          # Check if we're running from the ai-toolkit repository
-          if [ "$GITHUB_REPOSITORY" = "Uniswap/ai-toolkit" ]; then
-            echo "ℹ️  Running from ai-toolkit - using local post-review.ts"
-            echo "script_path=.github/scripts/post-review.ts" >> $GITHUB_OUTPUT
-          else
-            echo "ℹ️  Running from external repository - downloading post-review.ts from Uniswap/ai-toolkit"
-            echo "ℹ️  Using toolkit ref: $TOOLKIT_REF"
-
-            # Download the script from ai-toolkit repository at the specified ref
-            if ! curl -fSs -H "Authorization: token $WORKFLOW_PAT" \
-                      -H "Accept: application/vnd.github.v4.raw" \
-                      -L "https://api.github.com/repos/Uniswap/ai-toolkit/contents/.github/scripts/post-review.ts?ref=${TOOLKIT_REF}" \
-                      -o /tmp/post-review.ts 2>&1 | tee /tmp/curl-error.log; then
-              echo "❌ Failed to download post-review.ts from Uniswap/ai-toolkit@${TOOLKIT_REF}"
-              echo "   Error details:"
-              cat /tmp/curl-error.log | head -5
-              exit 1
-            fi
-
-            echo "✅ Downloaded post-review.ts from SHA: $TOOLKIT_REF"
-            echo "script_path=/tmp/post-review.ts" >> $GITHUB_OUTPUT
-          fi
+      # Note: Post-review script is already downloaded/located earlier for in-progress status
 
       # Post the review using our script (all comments as github-actions[bot])
       - name: Post Review via Script
@@ -684,8 +736,8 @@ jobs:
           # Pass file path instead of content to avoid shell injection risks
           # The script reads the file directly, avoiding shell expansion of content
           REVIEW_JSON_FILE: /tmp/claude-review-response.txt
-          # Script path determined by setup-script step (local or downloaded)
-          POST_REVIEW_SCRIPT: ${{ steps.setup-script.outputs.script_path }}
+          # Script path determined by early setup step (local or downloaded)
+          POST_REVIEW_SCRIPT: ${{ steps.setup-script-early.outputs.script_path }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
- Added functionality to post immediate "review in progress" comments when a workflow starts, enhancing user experience by providing real-time feedback.
- Introduced "skipped" status comments for cases where no code changes are detected, ensuring clarity on review status.
- Updated documentation to reflect new status update features, detailing the different statuses shown during the review process.

---
<!-- claude-pr-description-start -->
## :sparkles: Claude-Generated Content

## Summary
Enhances the Claude Code Review workflow with real-time status updates that provide immediate feedback to PR authors, eliminating the "is it running?" uncertainty by posting status comments throughout the review lifecycle.
## Changes
- **New `--mode` flag**: Added `in-progress`, `skipped`, and `review` modes to the post-review script for posting different status states
- **Marker-based comment structure**: Implemented separate status and content sections with HTML markers, allowing independent updates to each section without losing review content
- **Real-time "in progress" status**: Posts an immediate status comment when the workflow starts, before any analysis begins
- **Cache-preserving "skipped" status**: When a cache hit is detected (rebase with no code changes), updates only the status banner while preserving the existing review content
- **Workflow restructuring**: Moved Node.js setup and post-review script initialization earlier in the workflow to enable status updates before the Claude analysis step
- **Cache flow optimization**: Reorganized cache check to run before posting in-progress status, ensuring existing reviews are preserved on cache hits rather than overwritten
## Technical Details
The workflow now follows this status progression:
| Status | When Shown | Message |
|--------|------------|---------|
| 🔄 **In Progress** | Immediately when workflow starts | "Claude is analyzing this pull request..." |
| ✅ **No Review Needed** | Cache hit (rebase with no code changes) | "No new code changes since the last review" |
| 📋 **Review Complete** | After Claude finishes analysis | Full review with verdict and inline comments |
The comment uses HTML markers to separate status and content:
```
<!-- claude-pr-review-bot -->
<!-- claude-pr-review-status-start -->
{status content}
<!-- claude-pr-review-status-end -->
<!-- claude-pr-review-content-start -->
{review content}
<!-- claude-pr-review-content-end -->
{footer}
```
This allows the status section to be updated independently (e.g., from "in progress" to "complete") while preserving or updating the content section as needed.
<!-- claude-pr-description-end -->