### PR TITLE
refactor(code-review): remove full diff from prompt to prevent argument list overflow

### DIFF
--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -370,7 +370,7 @@ jobs:
             echo "ℹ️  No existing review comments found (initial review)"
           fi
 
-      # Generate the PR diff for Claude to review
+      # Generate the PR diff of changed files for Claude to review
       # This ensures Claude reviews ONLY the PR's changes, not other commits merged to main
       - name: Generate PR Diff
         if: steps.cache-check.outputs.cache-hit != 'true'
@@ -390,13 +390,6 @@ jobs:
           CHANGED_FILES=$(git diff --name-only ${MERGE_BASE}..HEAD)
           FILE_COUNT=$(echo "$CHANGED_FILES" | grep -c . || echo "0")
           echo "📁 Files changed: $FILE_COUNT"
-
-          # Generate the full diff
-          # This is the ONLY diff Claude should review - it contains exactly the PR's changes
-          git diff ${MERGE_BASE}..HEAD > /tmp/pr-diff.txt
-
-          DIFF_SIZE=$(wc -c < /tmp/pr-diff.txt)
-          echo "📊 Diff size: $DIFF_SIZE bytes"
 
           # Save changed files list
           echo "$CHANGED_FILES" > /tmp/changed-files.txt
@@ -479,11 +472,6 @@ jobs:
           **Files changed in this PR:**
           \`\`\`
           $(cat /tmp/changed-files.txt)
-          \`\`\`
-
-          **Full PR Diff:**
-          \`\`\`diff
-          $(cat /tmp/pr-diff.txt)
           \`\`\`
 
           ---


### PR DESCRIPTION
… doesn't explode

we had a bug in the backend/ repo where it used the ai-toolkit's claude-code-review.yml action, and because the backend PR was _massive_, 10_000+ lines of bash code, bash failed with 'Argument list too long'.

To remedy that now and for future runs on huge PR's, we're going to remove the main cause of the long prompt size, which was pasting the full 'git diff' as part of the LLM prompt. The original goal of this was to ensure the claude code action just addresses changes in the PR, so by removing the full PR diff but including the changed files, claude code will still know to just review the changed code.

<!-- claude-pr-description-start -->
---
## :sparkles: Claude-Generated Content

## Summary
Removes the full git diff from the Claude code review prompt to prevent bash "Argument list too long" errors when reviewing large PRs.
## Changes
- **Removed full diff generation**: Eliminated `git diff ${MERGE_BASE}..HEAD > /tmp/pr-diff.txt` and associated size logging
- **Removed diff from prompt**: Removed the "Full PR Diff" section that embedded the entire diff in the review prompt
- **Preserved changed files list**: Kept the list of changed files so Claude still knows which files to review
- **Updated comment**: Clarified that the step generates a diff of changed files, not the full diff content
## Technical Details
The previous implementation embedded the complete `git diff` output directly in the prompt passed to Claude. For large PRs (10,000+ lines), this caused bash to fail with "Argument list too long" when the prompt exceeded shell argument limits.
By removing the embedded diff while keeping the changed files list, Claude Code can still identify which files were modified and review them directly using its file reading capabilities, without the prompt size causing shell failures.
## Testing
This change should be tested with:
- Small PRs (verify reviews still work correctly)
- Large PRs (verify no argument list overflow errors)
<!-- claude-pr-description-end -->