### PR TITLE
feat(code-review): add diff size limit check to prevent prompt overflow

### DIFF
--- a/.github/scripts/post-review.ts
+++ b/.github/scripts/post-review.ts
@@ -14,6 +14,7 @@
  * - in-progress: Posts a "review in progress" placeholder comment
  * - skipped: Preserves existing review content with a "still valid" status banner (cache hit)
  *            If no substantial review exists, posts a fallback "no review needed" message
+ * - too-large: Posts a message indicating the PR diff is too large for Claude review
  *
  * @usage
  *   # Full review mode (default)
@@ -35,6 +36,14 @@
  *     --owner "Uniswap" \
  *     --repo "ai-toolkit" \
  *     --pr-number 123
+ *
+ *   # Too large mode (PR diff exceeds threshold)
+ *   npx tsx .github/scripts/post-review.ts \
+ *     --mode too-large \
+ *     --owner "Uniswap" \
+ *     --repo "ai-toolkit" \
+ *     --pr-number 123 \
+ *     --line-count 2534
  *
  * @environment
  *   GITHUB_TOKEN - GitHub token for API authentication (required)
@@ -335,6 +344,15 @@ const STATUS_SKIPPED = `## 🤖 Claude Code Review
 >
 > <sub>💡 To force a fresh review, add a comment containing \`@request-claude-review\`.</sub>`;
 
+/** Function to generate status message when PR is too large for review */
+function STATUS_TOO_LARGE(lineCount: number): string {
+  return `## 🤖 Claude Code Review
+
+> ⚠️ **PR too large for automated review** — This pull request contains ${lineCount.toLocaleString()} lines of diff, which exceeds the 2,000 line threshold for Claude Code Review.
+>
+> <sub>💡 Consider breaking this PR into smaller, more focused changes for better reviewability.</sub>`;
+}
+
 /** Status shown when review fails */
 const STATUS_FAILED = `## 🤖 Claude Code Review
 
@@ -351,6 +369,16 @@ const CONTENT_PLACEHOLDER = `*Waiting for review to complete...*`;
 
 /** Content shown when no review exists and cache hit (first PR with no changes) */
 const CONTENT_NO_REVIEW_NEEDED = `This PR has no code changes that require review.`;
+
+/** Content shown when PR is too large for Claude review */
+const CONTENT_TOO_LARGE = `Claude Code Review has been skipped for this PR because the diff is too large. Large PRs are harder to review thoroughly and increase the risk of bugs slipping through.
+
+**Recommendations:**
+- Break this PR into smaller, focused changes
+- Each PR should ideally address a single concern or feature
+- Smaller PRs are easier to review, test, and merge safely
+
+Once you've split this into smaller PRs, Claude will be able to provide detailed automated reviews for each one.`;
 
 // =============================================================================
 // Comment Structure Helpers
@@ -1152,7 +1180,8 @@ async function main(): Promise<void> {
       'pr-number': { type: 'string' },
       'review-json': { type: 'string' },
       'dry-run': { type: 'boolean', default: false },
-      mode: { type: 'string', default: 'review' }, // 'review' | 'in-progress' | 'skipped'
+      mode: { type: 'string', default: 'review' }, // 'review' | 'in-progress' | 'skipped' | 'too-large'
+      'line-count': { type: 'string' },
     },
     strict: true,
   });
@@ -1161,7 +1190,8 @@ async function main(): Promise<void> {
   const repo = values.repo;
   const prNumber = parseInt(values['pr-number'] || '', 10);
   const dryRun = values['dry-run'];
-  const mode = values.mode as 'review' | 'in-progress' | 'skipped';
+  const mode = values.mode as 'review' | 'in-progress' | 'skipped' | 'too-large';
+  const lineCount = values['line-count'] ? parseInt(values['line-count'], 10) : undefined;
 
   // Validate required inputs
   if (!owner || !repo || isNaN(prNumber)) {
@@ -1219,6 +1249,36 @@ async function main(): Promise<void> {
       process.exit(0);
     } catch (error) {
       logError(`Failed to post skipped comment: ${(error as Error).message}`);
+      process.exit(1);
+    }
+  }
+
+  // Handle too-large mode - post message that PR is too large for review
+  if (mode === 'too-large') {
+    log(`Running in too-large mode for ${owner}/${repo}#${prNumber}`);
+
+    if (lineCount === undefined || isNaN(lineCount)) {
+      logError('Missing or invalid --line-count argument for too-large mode');
+      process.exit(1);
+    }
+
+    if (dryRun) {
+      log(`DRY RUN - Would post too-large message (${lineCount} lines)`);
+      console.log(buildReviewComment(STATUS_TOO_LARGE(lineCount), CONTENT_TOO_LARGE));
+      process.exit(0);
+    }
+
+    try {
+      const result = upsertReviewComment(owner, repo, prNumber, {
+        status: STATUS_TOO_LARGE(lineCount),
+        content: CONTENT_TOO_LARGE,
+      });
+      log(`Too-large message posted: ${result.html_url}`);
+      console.log(`comment_url=${result.html_url}`);
+      console.log(`comment_id=${result.id}`);
+      process.exit(0);
+    } catch (error) {
+      logError(`Failed to post too-large message: ${(error as Error).message}`);
       process.exit(1);
     }
   }

--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -117,7 +117,8 @@ jobs:
   claude-review:
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout_minutes }}
-
+    env:
+      MAX_CLAUDE_DIFF_LINES: 2000 # any PR with a `git diff` larger than this will be considered too large for Claude review
     # Fixed permissions (cannot be overridden by calling workflow)
     permissions:
       id-token: write # Required for OIDC
@@ -370,7 +371,7 @@ jobs:
             echo "ℹ️  No existing review comments found (initial review)"
           fi
 
-      # Generate the PR diff of changed files for Claude to review
+      # Generate the PR diff for Claude to review
       # This ensures Claude reviews ONLY the PR's changes, not other commits merged to main
       - name: Generate PR Diff
         if: steps.cache-check.outputs.cache-hit != 'true'
@@ -391,14 +392,73 @@ jobs:
           FILE_COUNT=$(echo "$CHANGED_FILES" | grep -c . || echo "0")
           echo "📁 Files changed: $FILE_COUNT"
 
+          # Generate the full diff
+          # This is the ONLY diff Claude should review - it contains exactly the PR's changes
+          git diff ${MERGE_BASE}..HEAD > /tmp/pr-diff.txt
+
+          DIFF_SIZE=$(wc -c < /tmp/pr-diff.txt)
+          echo "📊 Diff size: $DIFF_SIZE bytes"
+
           # Save changed files list
           echo "$CHANGED_FILES" > /tmp/changed-files.txt
 
           echo "✅ PR diff generated successfully"
 
+      # Check if PR diff is too large for Claude review
+      - name: Check PR Diff Size
+        id: diff-size
+        if: steps.cache-check.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+
+          # Count lines in the diff
+          DIFF_LINES=$(wc -l < /tmp/pr-diff.txt)
+          echo "📊 Diff line count: $DIFF_LINES"
+
+          # Check if diff is too large for Claude review
+          if [ "$DIFF_LINES" -gt "$MAX_CLAUDE_DIFF_LINES" ]; then
+            echo "is_too_large=true" >> $GITHUB_OUTPUT
+            echo "⚠️  PR diff is too large for Claude review (> $MAX_CLAUDE_DIFF_LINES lines)"
+          else
+            echo "is_too_large=false" >> $GITHUB_OUTPUT
+            echo "✅ PR diff size is acceptable for Claude review"
+          fi
+
+          echo "line_count=$DIFF_LINES" >> $GITHUB_OUTPUT
+
+      # Post "PR too large" message and exit if diff exceeds threshold
+      - name: Post PR Too Large Message
+        if: steps.cache-check.outputs.cache-hit != 'true' && steps.diff-size.outputs.is_too_large == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          POST_REVIEW_SCRIPT: ${{ steps.setup-script-early.outputs.script_path }}
+          DIFF_LINE_COUNT: ${{ steps.diff-size.outputs.line_count }}
+        run: |
+          set -euo pipefail
+
+          echo "ℹ️  Posting 'PR too large' message..."
+
+          # Parse owner and repo
+          REPO_OWNER=$(echo "$GITHUB_REPOSITORY" | cut -d'/' -f1)
+          REPO_NAME=$(echo "$GITHUB_REPOSITORY" | cut -d'/' -f2)
+
+          # Post message that PR is too large for Claude review
+          npx tsx "$POST_REVIEW_SCRIPT" \
+            --mode too-large \
+            --owner "$REPO_OWNER" \
+            --repo "$REPO_NAME" \
+            --pr-number "$PR_NUMBER" \
+            --line-count "$DIFF_LINE_COUNT"
+
+          echo "✅ 'PR too large' message posted"
+          echo "⏭️  Skipping Claude review due to large diff size"
+          exit 0
+
       # Build final prompt with custom content
       - name: Build Review Prompt
-        if: steps.cache-check.outputs.cache-hit != 'true'
+        if: steps.cache-check.outputs.cache-hit != 'true' && steps.diff-size.outputs.is_too_large != 'true'
         id: build-prompt
         env:
           CUSTOM_PROMPT_INPUT: ${{ inputs.custom_prompt }}
@@ -472,6 +532,11 @@ jobs:
           **Files changed in this PR:**
           \`\`\`
           $(cat /tmp/changed-files.txt)
+          \`\`\`
+
+          **Full PR Diff:**
+          \`\`\`diff
+          $(cat /tmp/pr-diff.txt)
           \`\`\`
 
           ---
@@ -615,7 +680,7 @@ jobs:
 
       # Build Claude arguments - READ-ONLY tools only (no GitHub write tools)
       - name: Build Claude Arguments
-        if: steps.cache-check.outputs.cache-hit != 'true'
+        if: steps.cache-check.outputs.cache-hit != 'true' && steps.diff-size.outputs.is_too_large != 'true'
         id: build-args
         env:
           INPUT_ALLOWED_TOOLS: ${{ inputs.allowed_tools }}
@@ -736,7 +801,7 @@ jobs:
 
       # Run Claude Code Action to perform the review (analysis only, outputs JSON)
       - name: Run Claude Code Review
-        if: steps.cache-check.outputs.cache-hit != 'true'
+        if: steps.cache-check.outputs.cache-hit != 'true' && steps.diff-size.outputs.is_too_large != 'true'
         id: claude
         uses: anthropics/claude-code-action@a7e4c51380c42dd89b127f5e5f9be7b54020bc6b # v1.0.21
         with:
@@ -755,7 +820,7 @@ jobs:
 
       # Extract Claude's structured output (validated JSON from --json-schema)
       - name: Extract Claude Response
-        if: steps.cache-check.outputs.cache-hit != 'true' && success()
+        if: steps.cache-check.outputs.cache-hit != 'true' && steps.diff-size.outputs.is_too_large != 'true' && success()
         id: extract-response
         env:
           STRUCTURED_OUTPUT: ${{ steps.claude.outputs.structured_output }}
@@ -783,7 +848,7 @@ jobs:
 
       # Upload Claude execution output as artifact for debugging
       - name: Upload Claude Execution Output
-        if: steps.cache-check.outputs.cache-hit != 'true' && always()
+        if: steps.cache-check.outputs.cache-hit != 'true' && steps.diff-size.outputs.is_too_large != 'true' && always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: claude-execution-output-pr${{ inputs.pr_number }}
@@ -795,7 +860,7 @@ jobs:
 
       # Post the review using our script (all comments as github-actions[bot])
       - name: Post Review via Script
-        if: steps.cache-check.outputs.cache-hit != 'true' && success()
+        if: steps.cache-check.outputs.cache-hit != 'true' && steps.diff-size.outputs.is_too_large != 'true' && success()
         id: post-review
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -845,7 +910,7 @@ jobs:
 
       # Fallback: Post review summary as PR comment if script fails
       - name: Fallback Review Comment
-        if: steps.cache-check.outputs.cache-hit != 'true' && failure()
+        if: steps.cache-check.outputs.cache-hit != 'true' && steps.diff-size.outputs.is_too_large != 'true' && failure()
         env:
           PR_NUMBER: ${{ inputs.pr_number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -905,7 +970,7 @@ jobs:
 
       # Post error comment if Claude completely fails (no output at all)
       - name: Post Review Error Comment
-        if: steps.cache-check.outputs.cache-hit != 'true' && failure() && steps.claude.conclusion == 'failure'
+        if: steps.cache-check.outputs.cache-hit != 'true' && steps.diff-size.outputs.is_too_large != 'true' && failure() && steps.claude.conclusion == 'failure'
         env:
           PR_NUMBER: ${{ inputs.pr_number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -957,7 +1022,7 @@ jobs:
 
       # Save successful review to cache
       - name: Save Review Cache Marker
-        if: steps.cache-check.outputs.cache-hit != 'true' && success()
+        if: steps.cache-check.outputs.cache-hit != 'true' && steps.diff-size.outputs.is_too_large != 'true' && success()
         run: |
           mkdir -p .review-cache
           echo "${{ steps.patch-id.outputs.patch_id }}" > .review-cache/patch-id
@@ -965,7 +1030,7 @@ jobs:
 
       # Persist cache for future rebase detection
       - name: Cache Review State
-        if: steps.cache-check.outputs.cache-hit != 'true' && success()
+        if: steps.cache-check.outputs.cache-hit != 'true' && steps.diff-size.outputs.is_too_large != 'true' && success()
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .review-cache


### PR DESCRIPTION
This commit introduces a 2,000-line threshold for PR diffs in the Claude Code Review workflow to prevent prompt overflow issues. When a PR exceeds this limit, the workflow now posts a helpful message explaining why the automated review was skipped and recommends breaking the PR into smaller, more focused changes. This addresses the underlying problem that the previous revert was attempting to solve, while maintaining the full diff context for PRs that fall within reasonable size limits.

The implementation adds a diff size check step after PR diff generation, early-exits with a "too large" message when the threshold is exceeded, and conditionally skips all downstream review steps (Claude invocation, response extraction, posting results) when the diff is oversized. The post-review script was extended with a new "too-large" mode to generate the appropriate user-facing messaging with line count details.

Revert "refactor: remove full diff from claude code review workflow so prompt doesn't explode (#259)"

This reverts commit 410fba9800bd6364dc5796cdeade2c1548a543c8.

<!-- claude-pr-description-start -->
---
## :sparkles: Claude-Generated Content

## Summary
Introduces a 2,000-line threshold for PR diffs in the Claude Code Review workflow to prevent prompt overflow issues. When a PR exceeds this limit, the workflow posts a helpful message explaining why the automated review was skipped and recommends breaking the PR into smaller changes.
This PR reverts the previous approach (removing full diff entirely) and instead implements a size-based gating mechanism that preserves full diff context for reasonably-sized PRs.
## Changes
- **New `too-large` mode in post-review script**: Added a new mode to `post-review.ts` that generates user-friendly messaging when PR diff exceeds the threshold, including the actual line count and recommendations for splitting the PR
- **Diff size check step**: Added `Check PR Diff Size` step that counts diff lines and sets `is_too_large` output when threshold is exceeded
- **Early exit for oversized PRs**: Added `Post PR Too Large Message` step that posts the too-large comment and exits before invoking Claude
- **Conditional step execution**: Updated all downstream steps (Build Review Prompt, Build Claude Arguments, Run Claude Code Review, Extract Claude Response, Post Review, cache operations) to skip when `steps.diff-size.outputs.is_too_large == 'true'`
- **Restored full diff in prompt**: Re-added the "Full PR Diff" section to the review prompt for PRs within the size limit
- **Environment variable for threshold**: Added `MAX_CLAUDE_DIFF_LINES: 2000` as a job-level environment variable for easy configuration
## Technical Details
The workflow now follows this flow for large PRs:
1. Generate PR diff as before
2. Count lines in diff file (`wc -l < /tmp/pr-diff.txt`)
3. If lines > 2,000: post "too large" message and exit
4. If lines ≤ 2,000: proceed with full Claude review including the complete diff
This approach:
- Prevents bash "Argument list too long" errors for massive PRs
- Maintains full diff context for normal-sized PRs (better review quality)
- Provides actionable feedback to PR authors about sizing best practices
- Uses a configurable threshold that can be adjusted if needed
## Reverts
This reverts commit 410fba9800bd6364dc5796cdeade2c1548a543c8 which removed the full diff entirely, replacing it with a more nuanced size-based approach.
<!-- claude-pr-description-end -->