### PR TITLE
fix(addons): correct Slack MCP server npx command arguments

### DIFF
--- a/packages/ai-toolkit-nx-claude/src/generators/addons/addon-registry.ts
+++ b/packages/ai-toolkit-nx-claude/src/generators/addons/addon-registry.ts
@@ -138,7 +138,7 @@ const ADDON_REGISTRY: AddonMetadata[] = [
     mcp: {
       serverName: 'slack',
       command: 'npx',
-      args: ['-y', '@zencoderai/slack-mcp-server', '--transport', 'stdio'],
+      args: ['-y', '-p', '@zencoderai/slack-mcp-server', 'slack-mcp'],
       env: {
         SLACK_BOT_TOKEN: 'PROMPT_TO_INSERT_SLACK_BOT_TOKEN',
         SLACK_TEAM_ID: 'TKZBCKUJJ',


### PR DESCRIPTION
Modified the command arguments for the Slack MCP server in the addon registry to include the package flag and specify the server name, ensuring correct execution of the command.

<!-- claude-pr-description-start -->
---
## :sparkles: Claude-Generated Content

## Summary
Fixes the Slack MCP server command arguments in the addon registry to use the correct npx syntax for executing the `slack-mcp` binary from the `@zencoderai/slack-mcp-server` package.
## Changes
- **Updated npx arguments**: Changed from `['-y', '@zencoderai/slack-mcp-server', '--transport', 'stdio']` to `['-y', '-p', '@zencoderai/slack-mcp-server', 'slack-mcp']`
  - Added `-p` flag to specify the package explicitly
  - Replaced `--transport stdio` with the actual command name `slack-mcp` to execute
## Technical Details
The previous configuration was incorrect because:
1. Without the `-p` flag, npx tries to execute the package directly rather than using it as a dependency
2. The `--transport stdio` flag was being passed to npx rather than to the actual MCP server command
3. The correct syntax uses `-p <package>` to specify the package and then the command name (`slack-mcp`) to execute from that package
This follows the same pattern used by other MCP server configurations in the addon registry.
<!-- claude-pr-description-end -->