### PR TITLE
fix(workflows): add authentication to GitHub API calls in claude code review workflow

### DIFF
--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -195,9 +195,11 @@ jobs:
             echo "ℹ️  Running from external repository - downloading post-review.ts from Uniswap/ai-toolkit"
             echo "ℹ️  Using toolkit ref: $TOOLKIT_REF"
 
-            # Download the script from ai-toolkit repository (public repo, no auth needed)
+            # Download the script from ai-toolkit repository
+            # Note: Authentication required to avoid GitHub API rate limits on shared runner IPs
             if ! curl -fSs \
                       -H "Accept: application/vnd.github.v4.raw" \
+                      -H "Authorization: Bearer $GITHUB_TOKEN" \
                       -L "https://api.github.com/repos/Uniswap/ai-toolkit/contents/.github/scripts/post-review.ts?ref=${TOOLKIT_REF}" \
                       -o /tmp/post-review.ts 2>&1 | tee /tmp/curl-error.log; then
               echo "❌ Failed to download post-review.ts from Uniswap/ai-toolkit@${TOOLKIT_REF}"
@@ -461,6 +463,7 @@ jobs:
         if: steps.cache-check.outputs.cache-hit != 'true' && steps.diff-size.outputs.is_too_large != 'true'
         id: build-prompt
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CUSTOM_PROMPT_INPUT: ${{ inputs.custom_prompt }}
           CUSTOM_PROMPT_PATH: ${{ inputs.custom_prompt_path }}
           REPO: ${{ github.repository }}
@@ -483,13 +486,15 @@ jobs:
             echo "📝 Using custom prompt from repository: $CUSTOM_PROMPT_PATH"
             CUSTOM_PROMPT=$(cat "$CUSTOM_PROMPT_PATH")
 
-          # Priority 3: Default prompt from ai-toolkit repository (public, no auth needed)
+          # Priority 3: Default prompt from ai-toolkit repository
           else
             echo "📝 Fetching default prompt from Uniswap/ai-toolkit repository"
 
-            # Fetch default prompt via GitHub API (public repo, no auth needed)
+            # Fetch default prompt via GitHub API
+            # Note: Authentication required to avoid GitHub API rate limits on shared runner IPs
             if ! curl -fSs \
                       -H "Accept: application/vnd.github.v4.raw" \
+                      -H "Authorization: Bearer $GITHUB_TOKEN" \
                       -L "https://api.github.com/repos/Uniswap/ai-toolkit/contents/.github/prompts/default-pr-review.md?ref=${TOOLKIT_REF}" \
                       -o /tmp/default-prompt.md 2>&1 | tee /tmp/curl-error.log; then
               echo "❌ Failed to fetch default prompt from Uniswap/ai-toolkit"


### PR DESCRIPTION
Updated the claude code review workflow to include authentication headers for GitHub API calls to avoid rate limits on shared runner IPs. This change ensures successful downloads of the post-review script and default prompt from the Uniswap/ai-toolkit repository.

<!-- claude-pr-description-start -->
---
## :sparkles: Claude-Generated Content

## Summary
Adds authentication headers to GitHub API `curl` requests in the Claude code review workflow to avoid rate limiting issues when running on shared GitHub Actions runner IPs.
## Changes
- **Added `Authorization` header to post-review.ts download**: The `curl` request that downloads `post-review.ts` from `Uniswap/ai-toolkit` now includes `Authorization: Bearer $GITHUB_TOKEN` to authenticate against the GitHub API
- **Added `Authorization` header to default prompt fetch**: The `curl` request that fetches the default PR review prompt from `Uniswap/ai-toolkit` now includes authentication
- **Added `GITHUB_TOKEN` environment variable**: Exposed `GITHUB_TOKEN` in the `build-prompt` step's environment to make it available for the authenticated API call
- **Updated comments**: Clarified that authentication is required to avoid GitHub API rate limits on shared runner IPs (removed misleading "public repo, no auth needed" comments)
## Technical Details
GitHub Actions runners share IP addresses across many workflows. Unauthenticated GitHub API requests are rate-limited per IP (60 requests/hour), which can be quickly exhausted on shared runners. Authenticated requests get a much higher rate limit (5,000 requests/hour per token), making them essential for reliability.
The `GITHUB_TOKEN` is automatically provided by GitHub Actions and requires no additional configuration from consumers of this reusable workflow.
<!-- claude-pr-description-end -->