### PR TITLE
feat(workflows): add configurable max diff lines parameter to Claude code review

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -116,9 +116,9 @@ This eliminates the "is it running?" uncertainty by posting a status comment as 
 
 **Required Secrets:**
 
-| Secret              | Required | Description                                                                                                              |
-| ------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `ANTHROPIC_API_KEY` | Yes      | Anthropic API key for Claude access                                                                                      |
+| Secret              | Required | Description                                                                                                                       |
+| ------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `ANTHROPIC_API_KEY` | Yes      | Anthropic API key for Claude access                                                                                               |
 | `WORKFLOW_PAT`      | Optional | Personal Access Token with `repo` scope. Only needed for resolving review threads via GraphQL API (falls back to `GITHUB_TOKEN`). |
 
 > **Important:** The [Claude GitHub App](https://github.com/apps/claude) must be installed on your repository for these workflows to function. This is required by Anthropic's official Claude Code GitHub Action.
@@ -137,6 +137,7 @@ This eliminates the "is it running?" uncertainty by posting a status comment as 
 | `custom_prompt`      | No       | `""`                               | Custom prompt text (overrides prompt file and default)                                                                         |
 | `custom_prompt_path` | No       | `.claude/prompts/claude-pr-bot.md` | Path to custom prompt file in repository                                                                                       |
 | `timeout_minutes`    | No       | `30`                               | Job timeout in minutes                                                                                                         |
+| `max_diff_lines`     | No       | `2000`                             | Maximum diff lines before skipping Claude review (PR considered too large)                                                     |
 | `allowed_tools`      | No       | `""`                               | Comma-separated list of allowed tools for Claude                                                                               |
 | `toolkit_ref`        | No       | `main`                             | Git ref (branch, tag, or SHA) of ai-toolkit to use for the post-review script. Use `next` or a SHA to test unreleased changes. |
 
@@ -256,8 +257,8 @@ This allows users to add custom notes, disclaimers, or additional context that s
 ```markdown
 > **Note:** This PR requires manual QA testing before merge.
 
-<!-- claude-pr-description-start -->
----
+## <!-- claude-pr-description-start -->
+
 ## :sparkles: Claude-Generated Content
 
 ## Summary

--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -93,6 +93,12 @@ on:
         type: number
         default: 30
 
+      max_diff_lines:
+        description: "Maximum diff lines before skipping Claude review (PR considered too large). Default: 2000"
+        required: false
+        type: number
+        default: 2000
+
       allowed_tools:
         description: 'Comma-separated list of allowed tools for Claude (e.g., "Read,Grep,Glob"). Leave empty for default read-only set.'
         required: false
@@ -118,7 +124,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout_minutes }}
     env:
-      MAX_CLAUDE_DIFF_LINES: 2000 # any PR with a `git diff` larger than this will be considered too large for Claude review
+      MAX_CLAUDE_DIFF_LINES: ${{ inputs.max_diff_lines }} # any PR with a `git diff` larger than this will be considered too large for Claude review
     # Fixed permissions (cannot be overridden by calling workflow)
     permissions:
       id-token: write # Required for OIDC
@@ -487,7 +493,8 @@ jobs:
             --owner "$REPO_OWNER" \
             --repo "$REPO_NAME" \
             --pr-number "$PR_NUMBER" \
-            --line-count "$DIFF_LINE_COUNT"
+            --line-count "$DIFF_LINE_COUNT" \
+            --max-diff-lines "$MAX_CLAUDE_DIFF_LINES"
 
           echo "✅ 'PR too large' message posted"
           echo "⏭️  Skipping Claude review due to large diff size"
@@ -816,8 +823,9 @@ jobs:
           # Build claude_args conditionally based on provided inputs
           CLAUDE_ARGS="--model $INPUT_MODEL"
 
-          # Only add --max-turns if explicitly provided (not empty)
-          if [ -n "$INPUT_MAX_TURNS" ]; then
+          # Only add --max-turns if explicitly provided (not empty or 0)
+          # Note: GitHub Actions number inputs default to 0 when not provided
+          if [ -n "$INPUT_MAX_TURNS" ] && [ "$INPUT_MAX_TURNS" != "0" ]; then
             CLAUDE_ARGS="$CLAUDE_ARGS
             --max-turns $INPUT_MAX_TURNS"
             echo "ℹ️  Including --max-turns $INPUT_MAX_TURNS"


### PR DESCRIPTION
Enhanced the Claude code review workflow by introducing a `max_diff_lines` parameter, allowing users to specify the maximum number of diff lines before a PR is considered too large for automated review. Updated relevant scripts and documentation to reflect this new functionality, improving flexibility and user control over review thresholds.

<!-- claude-pr-description-start -->
---
## :sparkles: Claude-Generated Content

Adds a configurable `max_diff_lines` input parameter to the Claude code review workflow, allowing consumers to specify the maximum number of diff lines before a PR is considered too large for automated review. Previously this threshold was hardcoded at 2,000 lines.
---
## :sparkles: Claude-Generated Content
## Summary
Introduces a `max_diff_lines` parameter to the Claude code review reusable workflow, enabling repositories to customize the diff size threshold based on their specific needs.
## Changes
- **New workflow input `max_diff_lines`**: Added optional input parameter with default value of 2000, allowing callers to override the threshold
- **Dynamic threshold in post-review script**: Updated `STATUS_TOO_LARGE` function to accept and display the configured threshold instead of hardcoded value
- **New CLI argument `--max-diff-lines`**: Added to post-review.ts for passing the threshold from workflow to script
- **Updated documentation**: Added `max_diff_lines` parameter to the inputs table in CLAUDE.md
- **Fixed `--max-turns` handling**: Added check for `!= "0"` since GitHub Actions number inputs default to 0 when not provided
## Technical Details
The workflow now accepts `max_diff_lines` as an input:
```yaml
with:
  max_diff_lines: 3000  # Custom threshold (default: 2000)
```
This value flows through the workflow:
1. Set as `MAX_CLAUDE_DIFF_LINES` environment variable
2. Passed to post-review.ts via `--max-diff-lines` argument
3. Used in the "PR too large" message to show the actual configured threshold
<!-- claude-pr-description-end -->