### PR TITLE
feat(uniswap-integrations): add Datadog MCP server integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,7 +231,7 @@ All plugins follow semantic versioning (semver). Key versioning rules:
 | development-pr-workflow    | 2.1.0   |
 | development-productivity   | 2.2.0   |
 | spec-workflow              | 2.0.1   |
-| uniswap-integrations       | 2.2.0   |
+| uniswap-integrations       | 2.3.0   |
 
 **Note:** Keep this table updated when versions change.
 

--- a/packages/plugins/uniswap-integrations/.claude-plugin/plugin.json
+++ b/packages/plugins/uniswap-integrations/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "uniswap-integrations",
-  "version": "2.2.0",
-  "description": "External service integrations (Linear, Notion, Nx, Chrome DevTools, GitHub, Slack, Amplitude) and deployment orchestration",
+  "version": "2.3.0",
+  "description": "External service integrations (Linear, Notion, Nx, Chrome DevTools, GitHub, Slack, Amplitude, Datadog) and deployment orchestration",
   "author": {
     "name": "Uniswap Labs",
     "email": "ai-services@uniswap.org"
@@ -16,6 +16,8 @@
     "mcp",
     "github",
     "amplitude",
+    "datadog",
+    "monitoring",
     "analytics"
   ],
   "license": "MIT",

--- a/packages/plugins/uniswap-integrations/.mcp.json
+++ b/packages/plugins/uniswap-integrations/.mcp.json
@@ -43,6 +43,10 @@
       "type": "http",
       "url": "https://mcp.amplitude.com/mcp"
     },
+    "datadog": {
+      "type": "http",
+      "url": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
+    },
     "slack": {
       "type": "stdio",
       "command": "npx",

--- a/packages/plugins/uniswap-integrations/CLAUDE.md
+++ b/packages/plugins/uniswap-integrations/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This plugin provides external service integrations for Claude Code, bundling MCP servers for Linear, Notion, Nx, Chrome DevTools, GitHub, Slack, Amplitude, and more, plus deployment and CI/CD capabilities.
+This plugin provides external service integrations for Claude Code, bundling MCP servers for Linear, Notion, Nx, Chrome DevTools, GitHub, Slack, Amplitude, Datadog, and more, plus deployment and CI/CD capabilities.
 
 ## Plugin Components
 
@@ -32,6 +32,7 @@ This plugin provides external service integrations for Claude Code, bundling MCP
 | **figma**           | Figma design file access and collaboration       | OAuth |
 | **vercel**          | Vercel deployment management and hosting         | OAuth |
 | **amplitude**       | Amplitude analytics, experiments, and metrics    | OAuth |
+| **datadog**         | Datadog monitoring, logs, and metrics            | OAuth |
 | **slack**           | Slack workspace integration for messaging        | Token |
 
 ### Hooks (./hooks/)
@@ -44,14 +45,14 @@ This plugin provides external service integrations for Claude Code, bundling MCP
 - Agents are auto-discovered from the `agents/` directory
 - Skills invoke agents via `Task(subagent_type:agent-name)`
 - MCP servers provide external service connectivity
-- OAuth-based servers (Notion, Linear, Pulumi, Figma, Vercel, Amplitude) authenticate via `/mcp` command
+- OAuth-based servers (Notion, Linear, Pulumi, Figma, Vercel, Amplitude, Datadog) authenticate via `/mcp` command
 - Token-based servers (GitHub, Slack) require environment variable configuration
 
 ## MCP Authentication
 
 ### OAuth Servers
 
-Notion, Linear, Amplitude, and other OAuth servers use OAuth authentication. Users authenticate via the `/mcp` command which opens a browser flow. Amplitude's OAuth flow routes through Uniswap's SSO provider (SAML 2.0), so no separate API keys are needed.
+Notion, Linear, Amplitude, Datadog, and other OAuth servers use OAuth authentication. Users authenticate via the `/mcp` command which opens a browser flow. Amplitude's OAuth flow routes through Uniswap's SSO provider (SAML 2.0), so no separate API keys are needed.
 
 ### Token-Based Servers
 

--- a/packages/plugins/uniswap-integrations/README.md
+++ b/packages/plugins/uniswap-integrations/README.md
@@ -1,6 +1,6 @@
 # @uniswap/uniswap-integrations
 
-External service integrations for Claude Code - Linear, Notion, Nx, Chrome DevTools, GitHub, Pulumi, Figma, Vercel, Slack, Amplitude, and more.
+External service integrations for Claude Code - Linear, Notion, Nx, Chrome DevTools, GitHub, Pulumi, Figma, Vercel, Slack, Amplitude, Datadog, and more.
 
 ## Installation
 
@@ -27,6 +27,7 @@ This plugin bundles the following MCP (Model Context Protocol) servers:
 | **figma**           | Figma design file access and collaboration       | OAuth |
 | **vercel**          | Vercel deployment management and hosting         | OAuth |
 | **amplitude**       | Amplitude analytics, experiments, and metrics    | OAuth |
+| **datadog**         | Datadog monitoring, logs, and metrics            | OAuth |
 | **slack**           | Slack workspace integration for messaging        | Token |
 
 ## Skills
@@ -67,6 +68,7 @@ Some MCP servers require authentication:
 - **figma**: OAuth via <https://mcp.figma.com> - Run `/mcp` and follow browser flow
 - **vercel**: OAuth via <https://mcp.vercel.com> - Run `/mcp` and follow browser flow
 - **amplitude**: OAuth via <https://mcp.amplitude.com> - Run `/mcp` and follow browser flow (routes through Uniswap SSO)
+- **datadog**: OAuth via <https://mcp.datadoghq.com> - Run `/mcp` and follow browser flow
 
 ### Token-Based (Manual Setup)
 


### PR DESCRIPTION
## Summary

- Adds the official Datadog remote MCP server (`mcp.datadoghq.com`) to the uniswap-integrations plugin
- Uses remote HTTP transport with OAuth authentication, consistent with existing integrations (Notion, Linear, Amplitude, etc.)
- Updates plugin description, keywords, version (2.2.0 → 2.3.0), and all documentation (CLAUDE.md, README.md)

Resolves [DEV-266](https://linear.app/uniswap/issue/DEV-266/add-datadog-mcp-configuration-to-uniswap-integrations-plugin)

## Test plan

- [ ] Verify `claude /mcp` lists the Datadog server after plugin install
- [ ] Verify OAuth flow completes successfully via `/mcp` → Datadog
- [ ] Confirm Datadog tools (logs, metrics, monitors) are available after auth

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
- Adds the official Datadog remote MCP server (`mcp.datadoghq.com`) to the uniswap-integrations plugin
- Uses remote HTTP transport with OAuth authentication, consistent with existing integrations (Notion, Linear, Amplitude, etc.)
- Updates plugin description, keywords, version (2.2.0 → 2.3.0), and all documentation (CLAUDE.md, README.md)
- Fixes CI: removes stale tsx non-directory entry before global install to prevent `ENOTDIR` failures
Resolves [DEV-266](https://linear.app/uniswap/issue/DEV-266/add-datadog-mcp-configuration-to-uniswap-integrations-plugin)
## Changes
| File | Change |
|------|--------|
| `packages/plugins/uniswap-integrations/.mcp.json` | Add `datadog` HTTP MCP server entry pointing to `https://mcp.datadoghq.com/api/unstable/mcp-server/mcp` |
| `packages/plugins/uniswap-integrations/.claude-plugin/plugin.json` | Bump version 2.2.0 → 2.3.0; add `datadog` and `monitoring` keywords; update description |
| `packages/plugins/uniswap-integrations/CLAUDE.md` | Add Datadog to MCP server table, OAuth server list, and authentication docs |
| `packages/plugins/uniswap-integrations/README.md` | Add Datadog to MCP server table and authentication instructions |
| `CLAUDE.md` (root) | Update uniswap-integrations version in plugin version table (2.2.0 → 2.3.0) |
| `.github/workflows/_claude-docs-check.yml` | Remove stale tsx non-directory file before `npm install -g` to prevent `ENOTDIR` on Ubuntu runner images |
## Test plan
- [ ] Verify `claude /mcp` lists the Datadog server after plugin install
- [ ] Verify OAuth flow completes successfully via `/mcp` → Datadog
- [ ] Confirm Datadog tools (logs, metrics, monitors) are available after auth
- [ ] Verify `_claude-docs-check.yml` tsx install succeeds on fresh runner images

</details>
<!-- claude-pr-description-end -->