### PR TITLE
fix(ci): replace unindented heredoc with echo block in update-claude-code-action workflow

### DIFF
--- a/.github/workflows/update-claude-code-action.yml
+++ b/.github/workflows/update-claude-code-action.yml
@@ -109,31 +109,31 @@ jobs:
             grep -rl "anthropics/claude-code-action@" .github/workflows/ 2>/dev/null \
             | sed 's|^|  - `|; s|$|`|'
           )
-          cat > /tmp/pr_body.md << EOF
-## Update \`anthropics/claude-code-action\` SHA
-
-This automated PR pins all usages of \`anthropics/claude-code-action\` to the latest release.
-
-| | |
-|---|---|
-| **Previous SHA(s)** | \`${CURRENT_SHAS}\` |
-| **New SHA** | [\`${LATEST:0:7}\`](https://github.com/anthropics/claude-code-action/commit/${LATEST}) |
-| **New Release** | [\`${LATEST_TAG}\`](${RELEASE_URL}) |
-| **Diff** | [Compare changes](${COMPARE_URL}) |
-
-### Files updated
-${CHANGED_FILES}
-
----
-
-### Release notes for \`${LATEST_TAG}\`
-
-$(cat /tmp/release_notes.md)
-
----
-
-> _This PR was created automatically by the [update-claude-code-action](${GITHUB_SERVER_URL_VAL}/${GITHUB_REPOSITORY_VAL}/actions/workflows/update-claude-code-action.yml) workflow._
-EOF
+          {
+            echo "## Update \`anthropics/claude-code-action\` SHA"
+            echo ""
+            echo "This automated PR pins all usages of \`anthropics/claude-code-action\` to the latest release."
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| **Previous SHA(s)** | \`${CURRENT_SHAS}\` |"
+            echo "| **New SHA** | [\`${LATEST:0:7}\`](https://github.com/anthropics/claude-code-action/commit/${LATEST}) |"
+            echo "| **New Release** | [\`${LATEST_TAG}\`](${RELEASE_URL}) |"
+            echo "| **Diff** | [Compare changes](${COMPARE_URL}) |"
+            echo ""
+            echo "### Files updated"
+            echo "${CHANGED_FILES}"
+            echo ""
+            echo "---"
+            echo ""
+            echo "### Release notes for \`${LATEST_TAG}\`"
+            echo ""
+            cat /tmp/release_notes.md
+            echo ""
+            echo "---"
+            echo ""
+            echo "> _This PR was created automatically by the [update-claude-code-action](${GITHUB_SERVER_URL_VAL}/${GITHUB_REPOSITORY_VAL}/actions/workflows/update-claude-code-action.yml) workflow._"
+          } > /tmp/pr_body.md
       - name: Update SHA in workflow files
         if: steps.check.outputs.needs_update == 'true'
         env:


### PR DESCRIPTION
## Summary

- Fixes YAML syntax error on line 115 of `update-claude-code-action.yml` that caused GitHub Actions to reject the workflow file entirely
- The heredoc (`cat << EOF`) content was unindented (column 0), breaking out of the YAML `run: |` literal block — the parser tried to interpret plain text as YAML keys
- Replaced with a `{ echo ... } > file` block that stays properly indented within the YAML literal block

Closes DEV-267

## Test plan

- [x] YAML validates locally (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [ ] Workflow file parses successfully on GitHub Actions (no "workflow file issue" error)
- [ ] Manually trigger workflow dispatch to verify PR body markdown renders correctly

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
- Fixes YAML syntax error in `update-claude-code-action.yml` that caused GitHub Actions to reject the workflow file entirely
- The heredoc (`cat << EOF`) content was unindented (column 0), breaking out of the YAML `run: |` literal block — the parser tried to interpret plain text as YAML keys
- Replaced with a `{ echo ... } > file` block that stays properly indented within the YAML literal block
Closes DEV-267
## Changes
| File | Change |
|------|--------|
| `.github/workflows/update-claude-code-action.yml` | Replace `cat > /tmp/pr_body.md << EOF` heredoc with `{ echo ... } > /tmp/pr_body.md` block to keep PR body generation properly indented within the YAML `run: \|` scalar |
## Why this approach
Heredocs in YAML literal block scalars (`run: |`) must be indented to at least the block's indentation level. The original `EOF` marker and its content started at column 0, which YAML interprets as exiting the scalar — causing every line to be parsed as top-level YAML. Using grouped `echo` statements avoids this entirely since each line can be indented normally.
## Test plan
- [x] YAML validates locally (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [ ] Workflow file parses successfully on GitHub Actions (no "workflow file issue" error)
- [ ] Manually trigger workflow dispatch to verify PR body markdown renders correctly

</details>
<!-- claude-pr-description-end -->