### PR TITLE
improve(development-codebase-tools): tune agent-orchestrator agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,7 +226,7 @@ All plugins follow semantic versioning (semver). Key versioning rules:
 | Plugin                     | Version |
 | -------------------------- | ------- |
 | claude-setup               | 1.0.4   |
-| development-codebase-tools | 2.5.0   |
+| development-codebase-tools | 2.5.5   |
 | development-planning       | 2.0.1   |
 | development-pr-workflow    | 2.1.0   |
 | development-productivity   | 2.4.0   |

--- a/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
+++ b/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-codebase-tools",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "description": "Codebase exploration, refactoring, and quality analysis",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/development-codebase-tools/CLAUDE.md
+++ b/packages/plugins/development-codebase-tools/CLAUDE.md
@@ -21,7 +21,7 @@ This plugin provides codebase exploration, refactoring, and quality analysis too
 
 ### Agents (./agents/)
 
-- **agent-orchestrator-agent**: Centralized agent orchestration and capability matching
+- **agent-orchestrator-agent**: Coordinates multiple AI agents for complex multi-step tasks; decomposes tasks into atomic units, matches each to the right specialist, and executes in parallel where possible
 - **code-explainer-agent**: Explains what code does, how it's structured, and why it's designed that way; delegates security/performance concerns to specialist agents
 - **code-generator-agent**: Generates production-ready code following patterns (delegates to test-writer-agent for tests)
 - **context-loader-agent**: Read-only reconnaissance agent that discovers, reads, and summarizes a codebase area so other agents can implement or debug it correctly

--- a/packages/plugins/development-codebase-tools/README.md
+++ b/packages/plugins/development-codebase-tools/README.md
@@ -28,18 +28,18 @@ claude /plugin install development-codebase-tools
 
 ## Agents
 
-| Agent                          | Description                                                                                                                                |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| **agent-orchestrator-agent**   | Centralized agent orchestration and capability matching                                                                                    |
-| **code-explainer-agent**       | Explains what code does, how it's structured, and why it's designed that way; delegates security/performance concerns to specialist agents |
-| **code-generator-agent**       | Generates production-ready code (delegates to test-writer-agent for tests)                                                                 |
-| **context-loader-agent**       | Advanced context management with summarization and cross-agent sharing                                                                     |
-| **debug-assistant-agent**      | Advanced debugging with root cause analysis                                                                                                |
-| **pattern-learner-agent**      | Learns and applies codebase patterns                                                                                                       |
-| **performance-analyzer-agent** | Analyzes performance bottlenecks and optimization opportunities                                                                            |
-| **refactorer-agent**           | Performs safe, incremental refactoring operations                                                                                          |
-| **security-analyzer-agent**    | Identifies security vulnerabilities and recommends fixes                                                                                   |
-| **style-enforcer-agent**       | Enforces code style and conventions                                                                                                        |
+| Agent                          | Description                                                                                                                                 |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| **agent-orchestrator-agent**   | Coordinates multiple AI agents for complex multi-step tasks; decomposes tasks, matches specialists, and executes in parallel where possible |
+| **code-explainer-agent**       | Explains what code does, how it's structured, and why it's designed that way; delegates security/performance concerns to specialist agents  |
+| **code-generator-agent**       | Generates production-ready code (delegates to test-writer-agent for tests)                                                                  |
+| **context-loader-agent**       | Advanced context management with summarization and cross-agent sharing                                                                      |
+| **debug-assistant-agent**      | Advanced debugging with root cause analysis                                                                                                 |
+| **pattern-learner-agent**      | Learns and applies codebase patterns                                                                                                        |
+| **performance-analyzer-agent** | Analyzes performance bottlenecks and optimization opportunities                                                                             |
+| **refactorer-agent**           | Performs safe, incremental refactoring operations                                                                                           |
+| **security-analyzer-agent**    | Identifies security vulnerabilities and recommends fixes                                                                                    |
+| **style-enforcer-agent**       | Enforces code style and conventions                                                                                                         |
 
 ## Hooks
 

--- a/packages/plugins/development-codebase-tools/agents/agent-orchestrator.md
+++ b/packages/plugins/development-codebase-tools/agents/agent-orchestrator.md
@@ -1,6 +1,7 @@
 ---
 name: agent-orchestrator-agent
-description: Intelligent orchestrator that coordinates other AI agents for complex software development workflows, matching tasks to specialists based on capabilities
+description: Use this agent when you need to coordinate multiple AI agents on a complex multi-step software development task. Trigger phrases include "implement this plan", "coordinate agents to", "orchestrate", "break this task into subtasks", "run agents in parallel". Decomposes tasks into atomic units, matches each to the right specialist agent, executes in parallel where possible, and aggregates results.
+model: claude-opus-4-6
 tools: *
 ---
 
@@ -156,9 +157,9 @@ When you receive a task:
 ### Step 3: Deep Capability Analysis
 
 - For each decomposed task, identify candidate agents
-- Use agent-capability-analyst for detailed scoring
+- If agent-capability-analyst is available, use it for detailed scoring
+- Otherwise, score candidates based on their description and implied capabilities
 - Build a complete capability matrix
-- Consider meta-agent recommendations
 - Track confidence levels for each match
 
 ### Step 4: Optimized Agent Selection
@@ -166,7 +167,6 @@ When you receive a task:
 - Match agents to tasks based on capability scores
 - Consider task dependencies in selection
 - Plan for parallel execution where possible
-- Select meta-agents for system improvement
 - Document reasoning for each selection
 
 ### Step 5: Context-Aware Prompt Crafting
@@ -241,7 +241,7 @@ Always provide:
 
 - Parallel Branches: [Number of parallel execution paths]
 - Sequential Chains: [Critical path dependencies]
-- Estimated Completion: [Parallel vs sequential time comparison]
+- Execution Strategy: [Parallel vs sequential approach and rationale]
 
 ## Agent Discovery & Selection
 


### PR DESCRIPTION
## Summary

- Add `model: claude-opus-4-6` — orchestrators coordinating complex multi-agent workflows need the most capable model
- Rewrite `description` with concrete trigger phrases (`"implement this plan"`, `"orchestrate"`, `"run agents in parallel"`) for reliable orchestrator selection
- Soften `agent-capability-analyst` dependency to conditional (`if available`) — agent may not be loaded in every context
- Replace `Estimated Completion` in output template with `Execution Strategy` — avoids time estimates per project conventions
- Remove `Select meta-agents for system improvement` from Step 4 — meta-agent coordination is already covered in its own section

## Test plan

- [x] `npx nx run development-codebase-tools:validate` passes
- [x] `markdownlint-cli2` reports 0 errors on modified file
- [x] All pre-commit hooks pass: format, lint, lint-markdown, test, typecheck, update-package-lock

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
- Add `model: claude-opus-4-6` — orchestrators coordinating complex multi-agent workflows need the most capable model
- Rewrite `description` with concrete trigger phrases (`"implement this plan"`, `"orchestrate"`, `"run agents in parallel"`) for reliable orchestrator selection
- Soften `agent-capability-analyst` dependency to conditional (`if available`) — agent may not be loaded in every context
- Replace `Estimated Completion` in output template with `Execution Strategy` — avoids time estimates per project conventions
- Remove `Select meta-agents for system improvement` from Step 4 — meta-agent coordination is already covered in its own section
## Changes
| File | Change |
|------|--------|
| `packages/plugins/development-codebase-tools/agents/agent-orchestrator.md` | Add `model: claude-opus-4-6` frontmatter; rewrite `description` with explicit trigger phrases; make `agent-capability-analyst` usage conditional; replace `Estimated Completion` with `Execution Strategy`; remove redundant meta-agent selection line |
| `packages/plugins/development-codebase-tools/.claude-plugin/plugin.json` | Bump version 2.5.4 → 2.5.5 |
| `packages/plugins/development-codebase-tools/CLAUDE.md` | Update agent-orchestrator-agent description to match new wording |
| `packages/plugins/development-codebase-tools/README.md` | Update agent-orchestrator-agent description in agents table |
| `CLAUDE.md` (root) | Update development-codebase-tools version in plugin version table (2.5.0 → 2.5.5) |
## Notes
- No functional behavior change — `description`, `model`, and prompt adjustments are metadata/prompt-only
- Follows the same agent-tuning pattern as recent PRs (`refactorer`, `code-explainer`, `context-loader`, `code-generator`, `pattern-learner`, `debug-assistant`, `style-enforcer`, `security-analyzer`)
## Test plan
- [x] `npx nx run development-codebase-tools:validate` passes
- [x] `markdownlint-cli2` reports 0 errors on modified file
- [x] All pre-commit hooks pass: format, lint, lint-markdown, test, typecheck, update-package-lock

</details>
<!-- claude-pr-description-end -->