### PR TITLE
feat(development-codebase-tools): add validate-api-contract skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,7 +226,7 @@ All plugins follow semantic versioning (semver). Key versioning rules:
 | Plugin                     | Version |
 | -------------------------- | ------- |
 | claude-setup               | 1.0.4   |
-| development-codebase-tools | 2.1.1   |
+| development-codebase-tools | 2.2.0   |
 | development-planning       | 2.0.1   |
 | development-pr-workflow    | 2.1.0   |
 | development-productivity   | 2.2.0   |

--- a/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
+++ b/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-codebase-tools",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Codebase exploration, refactoring, and quality analysis",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
+++ b/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
@@ -27,6 +27,7 @@
     "./skills/diagram-excalidraw",
     "./skills/explore-codebase",
     "./skills/mermaid-diagram",
-    "./skills/refactor-code"
+    "./skills/refactor-code",
+    "./skills/validate-api-contract"
   ]
 }

--- a/packages/plugins/development-codebase-tools/CLAUDE.md
+++ b/packages/plugins/development-codebase-tools/CLAUDE.md
@@ -14,6 +14,7 @@ This plugin provides codebase exploration, refactoring, and quality analysis too
 - **mermaid-diagram**: Generate syntactically valid Mermaid.js diagrams (flowcharts, sequence, class, state, ER, Gantt, git)
 - **explore-codebase**: Deep codebase exploration with architectural understanding
 - **refactor-code**: Comprehensive refactoring with safety checks and pattern application
+- **validate-api-contract**: Detect breaking vs non-breaking changes in REST (OpenAPI/Swagger), GraphQL, and gRPC API definitions
 
 ### Agents (./agents/)
 
@@ -84,7 +85,8 @@ development-codebase-tools/
 │   ├── diagram-excalidraw/
 │   ├── mermaid-diagram/
 │   ├── explore-codebase/
-│   └── refactor-code/
+│   ├── refactor-code/
+│   └── validate-api-contract/
 ├── agents/
 │   ├── agent-orchestrator.md
 │   ├── code-explainer.md

--- a/packages/plugins/development-codebase-tools/README.md
+++ b/packages/plugins/development-codebase-tools/README.md
@@ -16,11 +16,12 @@ claude /plugin install development-codebase-tools
 
 | Skill                  | Description                                                                        |
 | ---------------------- | ---------------------------------------------------------------------------------- |
-| **analyze-code**       | Multi-agent code explanation for architecture, patterns, security, and performance |
-| **analyze-tech-debt**  | Identify and prioritize technical debt with remediation plans                      |
-| **diagram-excalidraw** | Generate Excalidraw architecture diagrams from codebase analysis                   |
-| **explore-codebase**   | Deep codebase exploration and understanding                                        |
-| **refactor-code**      | Comprehensive refactoring with safety checks and pattern application               |
+| **analyze-code**            | Multi-agent code explanation for architecture, patterns, security, and performance        |
+| **analyze-tech-debt**       | Identify and prioritize technical debt with remediation plans                             |
+| **diagram-excalidraw**      | Generate Excalidraw architecture diagrams from codebase analysis                          |
+| **explore-codebase**        | Deep codebase exploration and understanding                                               |
+| **refactor-code**           | Comprehensive refactoring with safety checks and pattern application                      |
+| **validate-api-contract**   | Detect breaking vs non-breaking changes in REST (OpenAPI/Swagger), GraphQL, and gRPC APIs |
 
 ## Agents
 
@@ -52,6 +53,8 @@ claude /plugin install development-codebase-tools
 "How does the authentication system work?"       # triggers explore-codebase
 "Create an architecture diagram of this system"  # triggers diagram-excalidraw
 "What technical debt exists in this module?"     # triggers analyze-tech-debt
+"Did I break any APIs in this branch?"           # triggers validate-api-contract
+"Check for breaking changes before I open this PR" # triggers validate-api-contract
 ```
 
 ## License

--- a/packages/plugins/development-codebase-tools/skills/validate-api-contract/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/validate-api-contract/SKILL.md
@@ -40,7 +40,7 @@ Determine the comparison baseline:
 3. **Staged only**: If user says "staged changes", use `git diff --cached`
 
 ```bash
-git diff <baseline>..HEAD -- <api-files>
+git diff <baseline>...HEAD -- <api-files>
 ```
 
 If the diff is empty (no API file changes), report "No API contract files changed" and exit cleanly.

--- a/packages/plugins/development-codebase-tools/skills/validate-api-contract/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/validate-api-contract/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Detect breaking changes in API contracts across REST (OpenAPI/Swagger), GraphQL schemas, and gRPC proto files. Use when user says "check for breaking API changes", "validate the API contract", "did I break any APIs?", "review my OpenAPI diff", "check if this GraphQL schema change is safe", or "are there any backwards-incompatible changes in this PR?".
-allowed-tools: Read, Glob, Grep, Bash(git diff:*), Bash(git log:*), Bash(git show:*), Bash(git stash:*), Bash(find:*), Bash(cat:*)
+allowed-tools: Read, Glob, Grep, Bash(git diff:*), Bash(git log:*), Bash(git show:*)
 model: sonnet
 ---
 
@@ -20,14 +20,9 @@ Detect and classify breaking versus non-breaking changes across REST (OpenAPI/Sw
 
 Scan the repository for API contract files:
 
-```bash
-# OpenAPI / Swagger
-find . -name "*.yaml" -o -name "*.yml" -o -name "*.json" | xargs grep -l "openapi:\|swagger:" 2>/dev/null
-# GraphQL schemas
-find . -name "*.graphql" -o -name "*.gql" 2>/dev/null
-# gRPC proto files
-find . -name "*.proto" 2>/dev/null
-```
+- **OpenAPI / Swagger**: Use `Glob("**/*.{yaml,yml,json}")` then `Grep` for `openapi:` or `swagger:` (YAML-style) or `"openapi"` / `"swagger"` (JSON-style keys) to identify matching files
+- **GraphQL schemas**: Use `Glob("**/*.{graphql,gql}")`
+- **gRPC proto files**: Use `Glob("**/*.proto")`
 
 If no API definition files are found, look for:
 

--- a/packages/plugins/development-codebase-tools/skills/validate-api-contract/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/validate-api-contract/SKILL.md
@@ -1,0 +1,185 @@
+---
+description: Detect breaking changes in API contracts across REST (OpenAPI/Swagger), GraphQL schemas, and gRPC proto files. Use when user says "check for breaking API changes", "validate the API contract", "did I break any APIs?", "review my OpenAPI diff", "check if this GraphQL schema change is safe", or "are there any backwards-incompatible changes in this PR?".
+allowed-tools: Read, Glob, Grep, Bash(git diff:*), Bash(git log:*), Bash(git show:*), Bash(git stash:*), Bash(find:*), Bash(cat:*)
+model: sonnet
+---
+
+# API Contract Validator
+
+Detect and classify breaking versus non-breaking changes across REST (OpenAPI/Swagger), GraphQL, and gRPC API definitions.
+
+## When to Activate
+
+- User asks about breaking API changes
+- User wants to validate an API contract before merging
+- User asks if their changes are backwards-compatible
+- Preparing for a major/minor version bump
+- Pre-release API review
+
+## Step 1: Discover API Definitions
+
+Scan the repository for API contract files:
+
+```bash
+# OpenAPI / Swagger
+find . -name "*.yaml" -o -name "*.yml" -o -name "*.json" | xargs grep -l "openapi:\|swagger:" 2>/dev/null
+# GraphQL schemas
+find . -name "*.graphql" -o -name "*.gql" 2>/dev/null
+# gRPC proto files
+find . -name "*.proto" 2>/dev/null
+```
+
+If no API definition files are found, look for:
+
+- Inline route definitions in source code (Express, Fastify, Hono, NestJS decorators)
+- TypeScript types exported from an API surface (`api/`, `routes/`, `controllers/`)
+
+Report which API type(s) were detected and which files will be analyzed.
+
+## Step 2: Establish Baseline
+
+Determine the comparison baseline:
+
+1. **Explicit**: If user specified a branch or commit (`main`, `HEAD~1`, a SHA), use it
+2. **Default**: Use `git diff origin/main...HEAD` for the current branch against the integration branch
+3. **Staged only**: If user says "staged changes", use `git diff --cached`
+
+```bash
+git diff <baseline>..HEAD -- <api-files>
+```
+
+If the diff is empty (no API file changes), report "No API contract files changed" and exit cleanly.
+
+## Step 3: Parse Changes by API Type
+
+### REST / OpenAPI
+
+For each changed `.yaml`/`.yml`/`.json` OpenAPI file, classify hunks from the diff:
+
+**Breaking changes** (require major version bump):
+
+- Removed endpoint (path + method deleted)
+- Removed required request field or query parameter
+- Added new required request field (no default)
+- Changed field type in request or response (e.g., `string` → `integer`)
+- Narrowed enum: removed an accepted value from a request field
+- Changed authentication scheme (e.g., Bearer → API key)
+- Removed response field that consumers relied on
+- Changed HTTP method for an existing path
+- Removed API version prefix
+
+**Non-breaking changes** (minor/patch):
+
+- Added optional request field
+- Added new endpoint
+- Added new response field
+- Broadened enum: added a new accepted value
+- Relaxed validation constraint (e.g., increased `maxLength`)
+- Added deprecation notice
+- Documentation / description update
+
+### GraphQL
+
+For each changed `.graphql`/`.gql` file:
+
+**Breaking changes**:
+
+- Removed type, field, or enum value
+- Changed field type to incompatible type (e.g., `String` → `Int`)
+- Made optional field required (added `!`)
+- Removed argument
+- Changed argument type to incompatible type
+
+**Non-breaking changes**:
+
+- Added new type, field, or enum value
+- Made required field optional (removed `!`)
+- Added optional argument with default
+- Added deprecation directive
+
+### gRPC / Protobuf
+
+For each changed `.proto` file:
+
+**Breaking changes**:
+
+- Removed a field number
+- Changed field type to incompatible type
+- Changed field name (if using JSON mapping)
+- Removed a message, enum, or service
+- Changed field from `optional` to `required`
+- Removed an RPC method
+
+**Non-breaking changes**:
+
+- Added new field (new field number)
+- Added new message, enum, or service
+- Adding `optional` to required field
+
+## Step 4: Report
+
+Output a structured report:
+
+```
+## API Contract Validation Report
+
+**Baseline**: <branch or commit>
+**Files analyzed**: <count> (<list>)
+
+### 🔴 Breaking Changes (<count>)
+
+| File | Location | Change | Impact |
+|------|----------|--------|--------|
+| openapi.yaml | DELETE /users/{id} | Endpoint removed | Clients calling this endpoint will receive 404 |
+| schema.graphql | User.email field | Type String → Int | All clients querying email field will fail |
+
+### 🟡 Deprecations (<count>)
+
+| File | Location | Note |
+|------|----------|------|
+| openapi.yaml | GET /v1/users | Marked deprecated; use /v2/users |
+
+### 🟢 Non-Breaking Changes (<count>)
+
+| File | Location | Change |
+|------|----------|--------|
+| openapi.yaml | POST /users | Added optional `timezone` field |
+
+### Recommended Version Bump
+
+- **Major** (breaking changes detected) / **Minor** (additions only) / **Patch** (docs/deprecations only)
+
+### Suggested Next Steps
+
+- [ ] Update API version if breaking changes are present
+- [ ] Notify consumers of breaking changes before merging
+- [ ] Add migration guide for removed/changed fields
+```
+
+## Handling Inline API Definitions
+
+If no standalone definition files exist and APIs are defined inline in code:
+
+1. Identify the framework (Express, NestJS, FastAPI, etc.) from `package.json` or imports
+2. Use `git diff` on route/controller files
+3. Extract route signatures, method handlers, and TypeScript types from the diff
+4. Apply the same breaking/non-breaking classification heuristics
+
+Note that inline analysis is less precise than schema-file analysis. Flag this in the report.
+
+## Edge Cases
+
+- **No API files changed**: Report cleanly and exit — do not hallucinate changes
+- **Binary or generated files**: Skip minified/compiled files; analyze source schemas only
+- **Multiple API versions**: Group findings by version prefix
+- **Monorepo**: Analyze all packages, label each finding with its package path
+
+## Examples
+
+```
+"Did I break any APIs in this branch?"
+"Check for breaking changes before I open this PR"
+"Validate the API contract against main"
+"Is my GraphQL schema change backwards-compatible?"
+"Review my OpenAPI diff for breaking changes"
+```


### PR DESCRIPTION
## What gap this fills

Adds a **validate-api-contract** skill to `development-codebase-tools` that detects breaking vs non-breaking changes across REST (OpenAPI/Swagger), GraphQL schemas, and gRPC proto files.

Before this skill, developers had no automated way to check whether their changes broke API contracts before opening a PR. This fills the **API & Integration Development** gap identified in the enhancement backlog.

## How it was identified

Identified during codebase capability mapping — the toolkit had strong coverage for code exploration, refactoring, and PR workflows but no skill for API safety analysis. Added to the backlog as `gap-api-dev` and prioritized based on its universality (REST/GraphQL/gRPC covers the vast majority of API surfaces used across Uniswap services).

## What the skill does

1. **Discovery** — Scans for OpenAPI/Swagger YAML/JSON, GraphQL `.graphql`/`.gql`, and gRPC `.proto` files. Falls back to inline route analysis (Express, NestJS, FastAPI) if no schema files exist.

2. **Baseline** — Uses `git diff origin/main...HEAD` by default; accepts an explicit branch, commit SHA, or `--cached` for staged-only review.

3. **Classification** — Applies API-type-specific rules:
   - REST: removed endpoints, required field changes, type changes, auth scheme changes
   - GraphQL: removed types/fields, `!` additions, argument removal
   - gRPC: removed field numbers, changed types, removed services

4. **Report** — Outputs a structured table of breaking changes, deprecations, and non-breaking additions with a recommended semver bump (major / minor / patch).

## Example trigger phrases

```
"Did I break any APIs in this branch?"
"Check for breaking changes before I open this PR"
"Validate the API contract against main"
"Is my GraphQL schema change backwards-compatible?"
"Review my OpenAPI diff for breaking changes"
```

## Test plan

- [ ] Trigger skill with `"did I break any APIs?"` on a branch with an OpenAPI YAML change
- [ ] Trigger skill with `"validate the API contract"` on a branch with a GraphQL schema change
- [ ] Verify clean exit when no API files were changed
- [ ] Verify monorepo support (findings labelled by package path)
- [ ] Validate plugin: `node scripts/validate-plugin.cjs packages/plugins/development-codebase-tools` → passes
- [ ] Markdown lint: `markdownlint-cli2 "packages/plugins/development-codebase-tools/**/*.md"` → 0 errors

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
- Adds a **validate-api-contract** skill to `development-codebase-tools` that detects breaking vs non-breaking changes across REST (OpenAPI/Swagger), GraphQL schemas, and gRPC proto files
- Fills the API & Integration Development gap — developers had no automated way to check whether changes broke API contracts before opening a PR
## How it works
1. **Discovery** — Scans for OpenAPI/Swagger YAML/JSON, GraphQL `.graphql`/`.gql`, and gRPC `.proto` files; falls back to inline route analysis (Express, NestJS, FastAPI) if no schema files exist
2. **Baseline** — Uses `git diff origin/main...HEAD` by default; accepts explicit branch, commit SHA, or `--cached` for staged-only review
3. **Classification** — Applies API-type-specific breaking change rules:
   - REST: removed endpoints, required field changes, type changes, auth scheme changes
   - GraphQL: removed types/fields, `!` additions, argument removal
   - gRPC: removed field numbers, changed types, removed services
4. **Report** — Outputs a structured table of breaking changes, deprecations, and non-breaking additions with a recommended semver bump
## Changes
| File | Change |
|------|--------|
| `skills/validate-api-contract/SKILL.md` | New skill with discovery, baseline, classification, and reporting steps |
| `.claude-plugin/plugin.json` | Add `./skills/validate-api-contract` to skills array; bump version 2.1.1 → 2.2.0 |
| `CLAUDE.md` | Update development-codebase-tools version in plugin version table (2.1.1 → 2.2.0) |
| `CLAUDE.md` (plugin) | Add validate-api-contract to skills list and file structure |
| `README.md` | Add validate-api-contract to skills table and example triggers |
## Example trigger phrases
```text
"Did I break any APIs in this branch?"
"Check for breaking changes before I open this PR"
"Validate the API contract against main"
"Is my GraphQL schema change backwards-compatible?"
"Review my OpenAPI diff for breaking changes"
```
## Test plan
- [ ] Trigger skill with `"did I break any APIs?"` on a branch with an OpenAPI YAML change
- [ ] Trigger skill with `"validate the API contract"` on a branch with a GraphQL schema change
- [ ] Verify clean exit when no API files were changed
- [ ] Verify monorepo support (findings labelled by package path)
- [ ] Validate plugin: `node scripts/validate-plugin.cjs packages/plugins/development-codebase-tools` passes
- [ ] Markdown lint: `markdownlint-cli2 "packages/plugins/development-codebase-tools/**/*.md"` passes

</details>
<!-- claude-pr-description-end -->