### PR TITLE
feat(development-planning): add manage-release skill

### DIFF
--- a/packages/plugins/development-planning/.claude-plugin/plugin.json
+++ b/packages/plugins/development-planning/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-planning",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Implementation planning, execution, and PR creation workflows with multi-agent collaboration",
   "author": {
     "name": "Uniswap Labs",
@@ -13,6 +13,7 @@
     "./skills/create-pr",
     "./skills/execute-plan",
     "./skills/generate-commit-message",
+    "./skills/manage-release",
     "./skills/plan-implementation",
     "./skills/plan-swarm",
     "./skills/review-plan"

--- a/packages/plugins/development-planning/CLAUDE.md
+++ b/packages/plugins/development-planning/CLAUDE.md
@@ -11,6 +11,7 @@ This plugin provides the complete implementation lifecycle for Claude Code: plan
 - **create-pr**: Creates Graphite PRs with auto-generated conventional commit messages
 - **execute-plan**: Executes plans step-by-step with progress tracking; supports **single PR mode** (default) and **Graphite stack mode** for creating one PR per logical chunk
 - **generate-commit-message**: Generates well-structured git commit messages
+- **manage-release**: Coordinates a full software release — determines next version via conventional commits, updates package files, generates a changelog entry, creates a release branch, commits, and opens a release PR
 - **plan-implementation**: Creates comprehensive implementation plans with step-by-step breakdowns
 - **plan-swarm**: Multi-agent collaborative plan refinement through expert discussion
 - **review-plan**: Reviews plans for completeness, feasibility, and alignment with codebase patterns
@@ -72,6 +73,7 @@ development-planning/
 │   │   ├── SKILL.md
 │   │   └── execution-guide.md
 │   ├── generate-commit-message/
+│   ├── manage-release/
 │   ├── plan-implementation/
 │   ├── plan-swarm/
 │   └── review-plan/

--- a/packages/plugins/development-planning/README.md
+++ b/packages/plugins/development-planning/README.md
@@ -16,14 +16,15 @@ claude /plugin install development-planning
 
 This plugin provides the following skills:
 
-| Skill                       | Description                                          |
-| --------------------------- | ---------------------------------------------------- |
-| **create-pr**               | Create Graphite PRs with conventional commits        |
-| **execute-plan**            | Execute implementation plans step-by-step            |
-| **generate-commit-message** | Generate well-structured git commit messages         |
-| **plan-implementation**     | Create implementation plans for features and changes |
-| **plan-swarm**              | Refine plans through multi-agent expert discussion   |
-| **review-plan**             | Review plans for completeness and feasibility        |
+| Skill                       | Description                                                     |
+| --------------------------- | --------------------------------------------------------------- |
+| **create-pr**               | Create Graphite PRs with conventional commits                   |
+| **execute-plan**            | Execute implementation plans step-by-step                       |
+| **generate-commit-message** | Generate well-structured git commit messages                    |
+| **manage-release**          | Coordinate a full release: version bump, changelog, tag, and PR |
+| **plan-implementation**     | Create implementation plans for features and changes            |
+| **plan-swarm**              | Refine plans through multi-agent expert discussion              |
+| **review-plan**             | Review plans for completeness and feasibility                   |
 
 ## Agents
 

--- a/packages/plugins/development-planning/skills/manage-release/SKILL.md
+++ b/packages/plugins/development-planning/skills/manage-release/SKILL.md
@@ -1,0 +1,185 @@
+---
+description: Coordinate a full software release. Use when user says "release version 1.2.0", "cut a release", "bump the version and release", "prepare a release for this milestone", "tag and release the latest changes", "what version should we release next?", or "create a release PR".
+allowed-tools: Bash(git log:*), Bash(git tag:*), Bash(git describe:*), Bash(git diff:*), Bash(git commit:*), Bash(git push:*), Bash(git checkout:*), Bash(git branch:*), Bash(grep:*), Bash(sed:*), Bash(cat:*), Bash(gh pr:*), Bash(gh release:*), Read, Write, Edit, Glob
+model: sonnet
+---
+
+# Release Manager
+
+Coordinate a complete software release: determine the next version, update package files, generate a changelog, commit, tag, and open a release PR.
+
+## When to Activate
+
+- User wants to cut a new release
+- User asks "what version should we release?"
+- User wants to bump the version and create a release PR
+- User is preparing a release for a milestone or sprint
+- User wants to tag and publish the latest changes
+- User says "release", "cut a release", "bump version", or "ship this"
+
+## Inputs
+
+Parse from the user's request:
+
+- **version**: Explicit version to release (e.g. `1.2.0`). If not provided, auto-determine from commits.
+- **type**: Force a release type (`major` | `minor` | `patch`). Overrides auto-detection.
+- **tag-prefix**: Prefix for git tags (e.g. `v`). Default: `v` if existing tags use it, else none.
+- **base**: Branch to open the release PR against. Default: `main`.
+- **dry-run**: Print what would happen without making changes. Default: false.
+
+## Process
+
+### Step 1: Understand the current state
+
+```bash
+# Find the most recent tag
+git describe --tags --abbrev=0 2>/dev/null || echo "no tags"
+
+# List recent tags
+git tag --sort=-version:refname | head -10
+
+# Count commits since last tag
+git log $(git describe --tags --abbrev=0 2>/dev/null)..HEAD --oneline 2>/dev/null | wc -l
+
+# Show the commits since last tag
+git log $(git describe --tags --abbrev=0 2>/dev/null)..HEAD --oneline 2>/dev/null
+```
+
+If there are no commits since the last tag, tell the user there is nothing to release and stop.
+
+### Step 2: Determine the next version
+
+If the user specified an explicit version, use it. Otherwise, analyze commits since the last tag using conventional commit format:
+
+| Commit type                                        | Version bump |
+| -------------------------------------------------- | ------------ |
+| `feat!`, `fix!`, `BREAKING CHANGE` in footer       | **major**    |
+| `feat`                                             | **minor**    |
+| `fix`, `perf`, `refactor`, `docs`, `test`, `chore` | **patch**    |
+
+Rules:
+
+- If no recognizable conventional commits found, default to **patch**
+- If current version is `0.x.y`, a `feat` bumps **minor**, a breaking change bumps **minor** too (per semver pre-1.0 conventions — tell the user this is happening)
+- Show the proposed version and ask for confirmation before proceeding (unless `--dry-run` is false and user already provided the version)
+
+### Step 3: Detect package files to update
+
+Look for files that contain the version string and need updating:
+
+```bash
+# package.json at root or in packages/
+# plugin.json in .claude-plugin/ directories
+# Any VERSION or version files
+git ls-files | grep -E "(package\.json|plugin\.json|VERSION)$" | head -20
+```
+
+For each file:
+
+1. Check if it contains `"version":` (JSON) or a bare version string
+2. Confirm it's a file that should be bumped (not `node_modules`, not lock files)
+3. For monorepos — only update packages whose contents changed since the last tag
+
+Show the user the list of files that will be updated.
+
+### Step 4: Checkout a release branch
+
+```bash
+git checkout -b release/v<VERSION>
+```
+
+### Step 5: Update version in package files
+
+For each identified package file, update the version field:
+
+```bash
+# For package.json — use a targeted sed (not npm version, to avoid side effects)
+sed -i '' "s/\"version\": \"<CURRENT>\"/\"version\": \"<NEXT>\"/" path/to/package.json
+
+# For plugin.json — same pattern
+sed -i '' "s/\"version\": \"<CURRENT>\"/\"version\": \"<NEXT>\"/" path/to/.claude-plugin/plugin.json
+```
+
+After each edit, re-read the file to verify the replacement was correct.
+
+### Step 6: Generate the changelog
+
+If a `CHANGELOG.md` exists or the user wants one:
+
+1. Generate the changelog entry for the new version by running `git log` with the same range used for version detection
+2. Format as a conventional changelog entry (see `generate-changelog` skill for format)
+3. Prepend the new entry to `CHANGELOG.md`, preserving any existing content
+
+If `CHANGELOG.md` does not exist, create it with the new entry.
+
+### Step 7: Commit the release changes
+
+```bash
+git add <all updated package files> CHANGELOG.md
+git commit -m "chore(release): bump version to <VERSION>"
+```
+
+### Step 8: Create and push the release branch
+
+```bash
+git push -u origin release/v<VERSION>
+```
+
+### Step 9: Create the release PR
+
+```bash
+gh pr create \
+  --base <BASE_BRANCH> \
+  --title "chore(release): v<VERSION>" \
+  --body "..."
+```
+
+PR body should include:
+
+- Version being released (`## Release v<VERSION>`)
+- The changelog entry for this version (from Step 6)
+- List of files updated with version bumps
+- Checklist:
+  - [ ] Version bumped in all package files
+  - [ ] CHANGELOG.md updated
+  - [ ] No unintended files staged
+
+### Step 10: Summarize
+
+Report back to the user:
+
+- New version: `v<VERSION>`
+- Release branch: `release/v<VERSION>`
+- PR link
+- Files updated
+- Next steps (merge PR, then tag + publish if not automated)
+
+## Dry Run Mode
+
+If `--dry-run` is set:
+
+- Show what version would be bumped to and why
+- Show which files would be updated
+- Show the changelog that would be generated
+- Do NOT create any branches, commits, or PRs
+
+## Safety Rules
+
+- Never commit directly to `main` or `main`-equivalent branches — always use a release branch
+- Never force-push
+- Never delete or modify existing release tags
+- If any file update fails to verify correctly, stop and report the failure before proceeding
+- If the user says "just tag it" without a PR, offer both options but default to the PR workflow for traceability
+
+## Examples
+
+```text
+"Release the next version"
+"Cut a patch release"
+"Bump to version 2.1.0 and create a release PR"
+"What version should we ship next?"
+"Prepare a minor release for this sprint"
+"manage-release --version 1.5.0 --base main"
+"manage-release --type minor --dry-run"
+"Tag and release latest changes"
+```


### PR DESCRIPTION
## What gap this fills

The `development-planning` plugin had no release management tooling. Developers needed to manually determine the next semver, bump versions across all package files, generate a changelog entry, and create a release PR. This skill coordinates the entire release workflow in one command.

## How it was identified

During gap analysis, the **release lifecycle** phase was absent — no structured workflow for version determination, version bumping, changelog generation, or release branch creation. This is a common bottleneck in every release cycle.

## Example usage scenarios

- `"release the next version"` — auto-detect next semver from conventional commits and release
- `"cut a patch release"` — force a patch bump
- `"bump to version 2.1.0 and create a release PR"` — explicit version
- `"manage-release --type minor --dry-run"` — preview what would happen
- `"what version should we ship next?"` — semver analysis only
- `"tag and release latest changes"` — detect and release automatically

## Changes

- Adds `packages/plugins/development-planning/skills/manage-release/SKILL.md`
- Updates `plugin.json` (version `2.0.1` → `2.1.0`, skill registered)
- Updates `CLAUDE.md` and `README.md` with new skill documentation

## Test plan

- [ ] Skill triggers on "release the next version", "cut a release", "bump the version and release"
- [ ] Auto-detects next semver from conventional commits (feat → minor, fix → patch, BREAKING → major)
- [ ] Handles pre-1.0 semver correctly (no major bumps)
- [ ] Detects and lists package files to update (package.json, plugin.json)
- [ ] Creates release branch and commits version bumps correctly
- [ ] Generates CHANGELOG entry and prepends to CHANGELOG.md
- [ ] Creates PR targeting base branch
- [ ] `--dry-run` shows plan without making changes
- [ ] Respects `--version` override and `--type` override
- [ ] Plugin validates: `node scripts/validate-plugin.cjs packages/plugins/development-planning`
- [ ] Markdown lints clean

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
- Adds a new `manage-release` skill to the `development-planning` plugin that coordinates the full release workflow: version determination from conventional commits, package file updates, changelog generation, release branch creation, and PR opening
- Bumps plugin version from 2.0.1 → 2.1.0 (new skill = minor bump)
- Updates plugin CLAUDE.md and README.md with the new skill documentation
## Changes
| File | Change |
|------|--------|
| `packages/plugins/development-planning/skills/manage-release/SKILL.md` | New skill with 10-step release workflow, dry-run support, semver auto-detection from conventional commits, and safety guardrails |
| `packages/plugins/development-planning/.claude-plugin/plugin.json` | Bump version 2.0.1 → 2.1.0; register `manage-release` in skills array |
| `packages/plugins/development-planning/CLAUDE.md` | Add manage-release to skills list and file structure tree |
| `packages/plugins/development-planning/README.md` | Add manage-release row to skills table |
## Context
The development-planning plugin had no release management tooling. This skill fills that gap by coordinating the entire release lifecycle — from analyzing conventional commits to determine the next semver, through version bumping across package files, changelog generation, and release PR creation — in a single command.
## Test plan
- [ ] Skill triggers on "release the next version", "cut a release", "bump the version and release"
- [ ] Auto-detects next semver from conventional commits (feat → minor, fix → patch, BREAKING → major)
- [ ] Handles pre-1.0 semver correctly (no major bumps)
- [ ] Detects package files to update (package.json, plugin.json)
- [ ] Creates release branch and commits version bumps correctly
- [ ] Generates CHANGELOG entry and prepends to CHANGELOG.md
- [ ] Creates PR targeting base branch
- [ ] `--dry-run` shows plan without making changes
- [ ] Plugin validates: `node scripts/validate-plugin.cjs packages/plugins/development-planning`
- [ ] Markdown lints clean

</details>
<!-- claude-pr-description-end -->