### PR TITLE
feat(development-codebase-tools): add validate-iac skill

### DIFF
--- a/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
+++ b/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-codebase-tools",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Codebase exploration, refactoring, and quality analysis",
   "author": {
     "name": "Uniswap Labs",
@@ -27,6 +27,7 @@
     "./skills/diagram-excalidraw",
     "./skills/explore-codebase",
     "./skills/mermaid-diagram",
-    "./skills/refactor-code"
+    "./skills/refactor-code",
+    "./skills/validate-iac"
   ]
 }

--- a/packages/plugins/development-codebase-tools/CLAUDE.md
+++ b/packages/plugins/development-codebase-tools/CLAUDE.md
@@ -14,6 +14,7 @@ This plugin provides codebase exploration, refactoring, and quality analysis too
 - **mermaid-diagram**: Generate syntactically valid Mermaid.js diagrams (flowcharts, sequence, class, state, ER, Gantt, git)
 - **explore-codebase**: Deep codebase exploration with architectural understanding
 - **refactor-code**: Comprehensive refactoring with safety checks and pattern application
+- **validate-iac**: Validate and security-scan Infrastructure as Code (Terraform, CDK, Helm, CloudFormation, Pulumi)
 
 ### Agents (./agents/)
 

--- a/packages/plugins/development-codebase-tools/README.md
+++ b/packages/plugins/development-codebase-tools/README.md
@@ -20,7 +20,9 @@ claude /plugin install development-codebase-tools
 | **analyze-tech-debt**  | Identify and prioritize technical debt with remediation plans                      |
 | **diagram-excalidraw** | Generate Excalidraw architecture diagrams from codebase analysis                   |
 | **explore-codebase**   | Deep codebase exploration and understanding                                        |
+| **mermaid-diagram**    | Generate syntactically valid Mermaid.js diagrams (flowcharts, sequence, class, ER) |
 | **refactor-code**      | Comprehensive refactoring with safety checks and pattern application               |
+| **validate-iac**       | Validate and security-scan IaC configs (Terraform, CDK, Helm, CloudFormation)      |
 
 ## Agents
 
@@ -52,6 +54,8 @@ claude /plugin install development-codebase-tools
 "How does the authentication system work?"       # triggers explore-codebase
 "Create an architecture diagram of this system"  # triggers diagram-excalidraw
 "What technical debt exists in this module?"     # triggers analyze-tech-debt
+"Check my Terraform for security issues"         # triggers validate-iac
+"Lint my Helm charts before deploy"              # triggers validate-iac
 ```
 
 ## License

--- a/packages/plugins/development-codebase-tools/skills/validate-iac/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/validate-iac/SKILL.md
@@ -1,0 +1,160 @@
+---
+description: Validate and lint Infrastructure as Code (IaC) configurations. Use when user says "check my Terraform for issues", "lint my IaC configs", "validate my infrastructure code", "scan my Terraform for security misconfigurations", "run checkov on my infrastructure", "are there any problems with my Helm charts", "validate my CDK stack", or "check my CloudFormation templates".
+allowed-tools: Read, Glob, Grep, Bash(terraform:*), Bash(tflint:*), Bash(checkov:*), Bash(trivy:*), Bash(helm:*), Bash(which:*), Bash(find:*), Bash(ls:*)
+model: sonnet
+---
+
+# IaC Validator
+
+Detect, validate, and security-scan Infrastructure as Code configurations across Terraform, CDK, Helm, CloudFormation, Pulumi, and Bicep.
+
+## When to Activate
+
+- User asks to validate, lint, or check IaC files
+- User mentions Terraform, CDK, Helm, CloudFormation, Pulumi, or Bicep
+- User wants to find security misconfigurations before deploying
+- Pre-deploy review of infrastructure changes
+- CI/CD integration check for IaC quality gates
+
+## Step 1: Detect IaC Types
+
+Scan the repository to identify which IaC frameworks are in use:
+
+```
+IaC Type         | Indicator Files
+-----------------|----------------------------------
+Terraform        | **/*.tf, **/*.tfvars
+AWS CDK          | cdk.json, cdk.out/
+CloudFormation   | **/*template*.yaml, **/*cloudformation*.yaml, **/*.cfn.yaml
+Helm             | Chart.yaml, **/templates/*.yaml
+Pulumi           | Pulumi.yaml, Pulumi.*.yaml
+Bicep            | **/*.bicep
+Kubernetes       | **/*deployment*.yaml, **/*service*.yaml (with apiVersion)
+Dockerfile       | Dockerfile, **/Dockerfile.*
+```
+
+Use `Glob` and `Grep` to find indicator files. Report what IaC types were detected before proceeding.
+
+## Step 2: Check Available Validators
+
+Run `which <tool>` to confirm which validators are installed:
+
+| Tool        | Covers                                          | Install                  |
+| ----------- | ----------------------------------------------- | ------------------------ |
+| `terraform` | Terraform syntax + provider validation          | `brew install terraform` |
+| `tflint`    | Terraform best practices + cloud provider rules | `brew install tflint`    |
+| `checkov`   | Terraform, CFN, CDK, K8s, Helm, Dockerfile, GHA | `pip install checkov`    |
+| `trivy`     | Terraform, CFN, K8s, Helm, Dockerfile           | `brew install trivy`     |
+| `helm`      | Helm chart structure + template rendering       | `brew install helm`      |
+
+Only run validators that are available. Report which validators will run before executing them.
+
+## Step 3: Run Validators
+
+Execute each available validator against the detected IaC files. Use output flags to get machine-readable results where possible.
+
+### Terraform
+
+```bash
+# Syntax validation (requires terraform init first if .terraform/ absent)
+terraform validate -json
+
+# Format check
+terraform fmt -check -recursive -diff
+
+# tflint (run from each directory containing .tf files)
+tflint --format=json
+```
+
+**Note:** If `.terraform/` is absent and `terraform init` hasn't been run, skip `terraform validate` and note this in the report. Run `terraform fmt` and `tflint` without init.
+
+### Checkov (universal — covers most IaC types)
+
+```bash
+# Run from repo root; checkov auto-detects IaC type
+checkov -d . --output json --quiet
+```
+
+Checkov is the highest-signal validator — prioritize its output. If checkov is unavailable, fall back to trivy.
+
+### Trivy Config
+
+```bash
+trivy config . --format json --exit-code 0
+```
+
+### Helm
+
+```bash
+# For each Chart.yaml directory found
+helm lint <chart-dir> --strict
+```
+
+## Step 4: Parse and Categorize Findings
+
+Aggregate all findings across validators. Deduplicate findings that reference the same file/line across tools. Map to severity:
+
+| Severity     | Criteria                                                                                    |
+| ------------ | ------------------------------------------------------------------------------------------- |
+| **CRITICAL** | Remote code execution, exposed credentials, world-accessible storage, no encryption at rest |
+| **HIGH**     | Missing auth, overly permissive IAM, unencrypted data in transit, no logging                |
+| **MEDIUM**   | Missing resource tags, deprecated resources, weak encryption, open egress                   |
+| **LOW**      | Style violations, naming conventions, missing descriptions                                  |
+| **INFO**     | Format issues, best practice suggestions                                                    |
+
+## Step 5: Report Findings
+
+Output a structured report:
+
+### Summary
+
+```
+IaC Validator Report
+====================
+Detected: [list of IaC types]
+Validators run: [list of tools]
+Total findings: N (X critical, Y high, Z medium, W low)
+```
+
+### Findings (grouped by severity, then file)
+
+For each finding:
+
+```
+[SEVERITY] CHECK_ID
+File: path/to/file.tf:line
+Resource: resource_type.resource_name
+Issue: Short description of the problem
+Fix: Concrete remediation step
+```
+
+### What Passed
+
+List checks that passed to confirm coverage was complete (not just failures).
+
+## Step 6: Remediation Guidance
+
+For the top 3 highest-severity findings, provide:
+
+1. **Root cause**: Why this is a security/compliance risk
+2. **Concrete fix**: Exact code change to make (show before/after diff)
+3. **Verification**: How to confirm the fix resolves the finding
+
+If all findings are LOW or INFO, note that the infrastructure configuration is in good shape and list remaining polish items.
+
+## Success Criteria
+
+- All detected IaC types were analyzed
+- At least one validator ran successfully
+- All CRITICAL and HIGH findings are surfaced with remediation steps
+- Report is actionable: each finding tells the user exactly what to change
+
+## Common Issues
+
+**`terraform validate` fails with "Backend not configured"**: Run with `-no-color` and note the module requires `terraform init`. Checkov/tflint still run without init.
+
+**`checkov` returns exit code 1 on findings**: This is expected — it doesn't indicate a tool error. Parse the JSON output regardless of exit code.
+
+**No IaC files found**: Report this clearly and suggest checking if the user is in the right directory.
+
+**All validators missing**: Report which tools to install and provide install commands for the user's detected OS (macOS: `brew install`, Linux: package manager or binary).


### PR DESCRIPTION
## Summary

- Adds a new `validate-iac` skill to `development-codebase-tools` that detects and validates Infrastructure as Code configurations
- Covers Terraform, AWS CDK, CloudFormation, Helm, Pulumi, Bicep, and Kubernetes manifests
- Runs available validators (`terraform validate`, `tflint`, `checkov`, `trivy config`, `helm lint`) and produces a structured severity-grouped report

## What gap this fills

No existing skill or agent in the plugin ecosystem addressed IaC validation or security misconfiguration detection. The `infrastructure-agent` in `uniswap-integrations` is Uniswap-specific and focused on CI/CD orchestration, not IaC config analysis. This skill fills that gap for any team using cloud infrastructure as code.

## How it was identified

Capability map audit across all development lifecycle phases: explore, plan, implement, test, review, deploy, monitor, maintain. IaC validation was absent from the deploy/maintain phase — a real gap given how commonly teams use Terraform, CDK, and Helm.

## Example usage scenarios

- `"Check my Terraform for security issues"` — runs checkov + tflint against .tf files, reports CIS benchmark violations
- `"Lint my Helm charts before deploy"` — runs `helm lint --strict` on each detected Chart.yaml
- `"Validate my infrastructure code"` — auto-detects IaC type, runs all available validators, returns prioritized findings
- `"Scan my CDK stack for misconfigurations"` — runs checkov against CDK-synthesized CloudFormation output
- `"Are there any problems with my CloudFormation templates?"` — runs checkov + trivy config against CFN YAML files

## Test plan

- [ ] Trigger on `"check my Terraform for issues"` → skill activates, detects `.tf` files, attempts terraform/tflint/checkov
- [ ] Trigger on `"lint my Helm charts"` → skill detects Chart.yaml, runs helm lint
- [ ] No IaC files present → skill reports clearly, suggests checking directory
- [ ] No validators installed → skill lists install commands for each missing tool
- [ ] All validators pass → skill reports clean state + lists what was checked
- [ ] Checkov finds CRITICAL findings → report surfaces them with before/after fix examples
- [ ] Plugin validation passes: `node scripts/validate-plugin.cjs packages/plugins/development-codebase-tools`
- [ ] Markdownlint passes: 0 errors on SKILL.md, CLAUDE.md, README.md

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
- Adds a new `validate-iac` skill to `development-codebase-tools` that detects and validates Infrastructure as Code configurations
- Covers Terraform, AWS CDK, CloudFormation, Helm, Pulumi, Bicep, and Kubernetes manifests
- Runs available validators (`terraform validate`, `tflint`, `checkov`, `trivy config`, `helm lint`) and produces a structured severity-grouped report
- Bumps plugin version from 2.1.1 → 2.2.0
## What gap this fills
No existing skill or agent in the plugin ecosystem addressed IaC validation or security misconfiguration detection. The `infrastructure-agent` in `uniswap-integrations` is Uniswap-specific and focused on CI/CD orchestration, not IaC config analysis. This skill fills that gap for any team using cloud infrastructure as code.
## How it was identified
Capability map audit across all development lifecycle phases: explore, plan, implement, test, review, deploy, monitor, maintain. IaC validation was absent from the deploy/maintain phase — a real gap given how commonly teams use Terraform, CDK, and Helm.
## Changes
| File | Change |
|------|--------|
| `skills/validate-iac/SKILL.md` | New skill with 6-step workflow: detect IaC types → check validators → run validators → parse findings → report → remediation guidance |
| `.claude-plugin/plugin.json` | Add `./skills/validate-iac` to skills array; bump version 2.1.1 → 2.2.0 |
| `CLAUDE.md` | Add validate-iac to skills list |
| `README.md` | Add validate-iac and mermaid-diagram to skills table; add example trigger phrases |
## Example usage scenarios
- `"Check my Terraform for security issues"` — runs checkov + tflint against .tf files, reports CIS benchmark violations
- `"Lint my Helm charts before deploy"` — runs `helm lint --strict` on each detected Chart.yaml
- `"Validate my infrastructure code"` — auto-detects IaC type, runs all available validators, returns prioritized findings
- `"Scan my CDK stack for misconfigurations"` — runs checkov against CDK-synthesized CloudFormation output
- `"Are there any problems with my CloudFormation templates?"` — runs checkov + trivy config against CFN YAML files
## Test plan
- [ ] Trigger on `"check my Terraform for issues"` → skill activates, detects `.tf` files, attempts terraform/tflint/checkov
- [ ] Trigger on `"lint my Helm charts"` → skill detects Chart.yaml, runs helm lint
- [ ] No IaC files present → skill reports clearly, suggests checking directory
- [ ] No validators installed → skill lists install commands for each missing tool
- [ ] All validators pass → skill reports clean state + lists what was checked
- [ ] Checkov finds CRITICAL findings → report surfaces them with before/after fix examples
- [ ] Plugin validation passes: `node scripts/validate-plugin.cjs packages/plugins/development-codebase-tools`
- [ ] Markdownlint passes: 0 errors on SKILL.md, CLAUDE.md, README.md

</details>
<!-- claude-pr-description-end -->