### PR TITLE
refactor(development-codebase-tools): tune analyze-code skill with concrete execution steps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,7 +226,7 @@ All plugins follow semantic versioning (semver). Key versioning rules:
 | Plugin                     | Version |
 | -------------------------- | ------- |
 | claude-setup               | 1.0.4   |
-| development-codebase-tools | 2.2.0   |
+| development-codebase-tools | 2.5.0   |
 | development-planning       | 2.0.1   |
 | development-pr-workflow    | 2.1.0   |
 | development-productivity   | 2.4.0   |

--- a/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
+++ b/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-codebase-tools",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Codebase exploration, refactoring, and quality analysis",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
+++ b/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-codebase-tools",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "description": "Codebase exploration, refactoring, and quality analysis",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/development-codebase-tools/skills/analyze-code/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/analyze-code/SKILL.md
@@ -25,7 +25,7 @@ Provide comprehensive code explanation through multi-agent analysis for architec
 
    - `overview`: spawn **code-explainer-agent** only; pass the file path and its contents
    - `deep`: spawn **code-explainer-agent** + **security-analyzer-agent** + **performance-analyzer-agent** in parallel
-   - `architectural`: spawn all four agents in parallel, loading system-level context via **context-loader-agent** first
+   - `architectural`: run **context-loader-agent** first to gather system-level context, then spawn **code-explainer-agent** + **security-analyzer-agent** + **performance-analyzer-agent** in parallel with that context
 
 5. **Synthesize results** — Combine agent outputs into a single structured report. Integrate and deduplicate findings; do not dump raw agent output.
 

--- a/packages/plugins/development-codebase-tools/skills/analyze-code/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/analyze-code/SKILL.md
@@ -1,28 +1,35 @@
 ---
 description: Comprehensive code explanation and analysis. Use when user says "explain this file to me", "what does this code do", "analyze the security of this module", "review the performance of this function", or "help me understand this architecture".
 allowed-tools: Read, Grep, Glob, Bash(git show:*), Bash(git ls-files:*), Task(subagent_type:code-explainer-agent), Task(subagent_type:security-analyzer-agent), Task(subagent_type:performance-analyzer-agent), Task(subagent_type:context-loader-agent)
-model: sonnet
+model: opus
 ---
 
 # Code Analyzer
 
 Provide comprehensive code explanation through multi-agent analysis for architecture, patterns, security, and performance insights.
 
-## When to Activate
+## Execution Steps
 
-- User asks "what does this code do?"
-- User wants code explained
-- User asks about security or performance
-- User wants to understand patterns in code
-- Before making changes to unfamiliar code
+1. **Identify the target** — Extract the file path or module name from the user's request. If no target is specified, ask: "Which file or module would you like me to analyze?"
 
-## Quick Process
+2. **Verify the target exists** — Use `Read` or `Glob` to confirm the file exists. If it doesn't, report and stop: "Could not find `<path>`. Please check the path and try again."
 
-1. **Structure Analysis**: Understand architecture and patterns
-2. **Dependency Mapping**: Trace imports and dependencies
-3. **Risk Assessment**: Identify vulnerabilities and issues
-4. **Performance Analysis**: Evaluate complexity
-5. **Pattern Recognition**: Identify design patterns
+3. **Infer analysis depth** from the user's request:
+
+   - `overview` — request uses words like "quick", "summary", "briefly", "what does this do"
+   - `deep` — request mentions "security", "performance", "vulnerabilities", "thorough", "deep", "comprehensive"
+   - `architectural` — request mentions "architecture", "system", "how does this fit", "overall design"
+   - Default to `deep` when depth is ambiguous
+
+4. **Dispatch agents** based on depth:
+
+   - `overview`: spawn **code-explainer-agent** only; pass the file path and its contents
+   - `deep`: spawn **code-explainer-agent** + **security-analyzer-agent** + **performance-analyzer-agent** in parallel
+   - `architectural`: spawn all four agents in parallel, loading system-level context via **context-loader-agent** first
+
+5. **Synthesize results** — Combine agent outputs into a single structured report. Integrate and deduplicate findings; do not dump raw agent output.
+
+6. **Handle agent failures** — If an agent errors or returns empty output, note it in the report ("Security analysis unavailable") and continue with remaining results.
 
 ## Analysis Depth
 


### PR DESCRIPTION
## Summary

- **model**: `sonnet` → `opus` — multi-agent orchestration requires stronger synthesis than sonnet provides
- **Replaced** vague "Quick Process" steps (category names, not instructions) and redundant "When to Activate" section with a concrete 6-step execution procedure
- **Added** depth inference rules: explicit keyword mappings for `overview` / `deep` / `architectural` so Claude picks the right agent set without guessing
- **Added** error handling guidance for missing files and failed agent responses

## What was wrong

The original "Quick Process" listed category names ("Structure Analysis", "Dependency Mapping") that told Claude *what* to analyze but not *how* to start or *which agents* to dispatch. The "When to Activate" section was a verbatim repeat of the description. A fresh Claude instance with this skill had no concrete execution path.

## Test plan

- [ ] Verify "explain this file to me" triggers code-explainer-agent only (overview depth)
- [ ] Verify "analyze the security of this module" triggers all three deep agents
- [ ] Verify missing-file case produces the expected error message

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
- **Model upgrade**: `sonnet` → `opus` — multi-agent orchestration requires stronger synthesis than Sonnet provides
- **Replaced** vague "Quick Process" steps (category names like "Structure Analysis", "Dependency Mapping") and redundant "When to Activate" section with a concrete 6-step execution procedure
- **Added** depth inference rules: explicit keyword mappings for `overview` / `deep` / `architectural` so Claude picks the right agent set without guessing
- **Added** error handling guidance for missing files and failed agent responses
## What was wrong
The original "Quick Process" listed category names that told Claude *what* to analyze but not *how* to start or *which agents* to dispatch. The "When to Activate" section was a verbatim repeat of the description frontmatter. A fresh Claude instance with this skill had no concrete execution path — it would guess at agent orchestration instead of following a deterministic procedure.
## Changes
| File | Change |
|------|--------|
| `packages/plugins/development-codebase-tools/skills/analyze-code/SKILL.md` | Replace model `sonnet` → `opus`; replace vague category list with 6 concrete execution steps; add depth inference rules and agent dispatch matrix; add error handling for missing targets and failed agents |
| `packages/plugins/development-codebase-tools/.claude-plugin/plugin.json` | Bump version 2.4.1 → 2.5.0 (minor — new behavioral guidance added to skill) |
| `CLAUDE.md` | Update plugin version table: development-codebase-tools 2.2.0 → 2.5.0 |
## Test plan
- [ ] Verify "explain this file to me" triggers code-explainer-agent only (overview depth)
- [ ] Verify "analyze the security of this module" triggers all three deep agents
- [ ] Verify missing-file case produces the expected error message

</details>
<!-- claude-pr-description-end -->