### PR TITLE
feat(development-codebase-tools): add audit-accessibility skill

### DIFF
--- a/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
+++ b/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-codebase-tools",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "Codebase exploration, refactoring, and quality analysis",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/development-codebase-tools/CLAUDE.md
+++ b/packages/plugins/development-codebase-tools/CLAUDE.md
@@ -11,6 +11,7 @@ This plugin provides codebase exploration, refactoring, and quality analysis too
 - **analyze-code**: Multi-agent code explanation for architecture, patterns, security, and performance
 - **analyze-dead-code**: Find unused exports, unreachable modules, and dead files with confidence-ranked removal guidance
 - **analyze-tech-debt**: Identify and prioritize technical debt with remediation plans. Uses a structured 6-step execution process: scope the target, collect code signals (Glob/Grep for large files, nesting, TODO/FIXME/HACK, `any` types), examine git history (high-churn files via `git log`, chronic bug areas via `git blame`), assess test presence (test-to-source file ratio), score and prioritize items by ROI, and write a Debt Metrics Dashboard + Prioritized Roadmap. Allowed tools include `Bash(git blame:*)`.
+- **audit-accessibility**: Audit UI components for WCAG 2.1 AA compliance, identifying violations by severity with fix guidance
 - **debug-issue**: Systematic debugging workflow — accepts any error report (message, stack trace, or vague symptom), locates the origin, gathers context, invokes the debug-assistant-agent for root-cause analysis, and validates the fix
 - **diagram-excalidraw**: Generate Excalidraw architecture diagrams from codebase analysis
 - **mermaid-diagram**: Generate syntactically valid Mermaid.js diagrams (flowcharts, sequence, class, state, ER, Gantt, git)
@@ -85,6 +86,7 @@ development-codebase-tools/
 │   ├── analyze-code/
 │   ├── analyze-dead-code/
 │   ├── analyze-tech-debt/
+│   ├── audit-accessibility/
 │   ├── debug-issue/
 │   ├── diagram-excalidraw/
 │   ├── mermaid-diagram/

--- a/packages/plugins/development-codebase-tools/README.md
+++ b/packages/plugins/development-codebase-tools/README.md
@@ -14,16 +14,17 @@ claude /plugin install development-codebase-tools
 
 ## Skills
 
-| Skill                  | Description                                                                                      |
-| ---------------------- | ------------------------------------------------------------------------------------------------ |
-| **analyze-code**       | Multi-agent code explanation for architecture, patterns, security, and performance               |
-| **analyze-dead-code**  | Find unused exports, unreachable modules, and dead files with confidence-ranked removal guidance |
-| **analyze-tech-debt**  | Identify and prioritize technical debt with remediation plans                                    |
-| **debug-issue**        | Systematic debugging workflow — from vague symptom to root cause analysis and validated fix      |
-| **diagram-excalidraw** | Generate Excalidraw architecture diagrams from codebase analysis                                 |
-| **explore-codebase**   | Deep codebase exploration and understanding                                                      |
-| **refactor-code**      | Comprehensive refactoring with safety checks and pattern application                             |
-| **strengthen-types**   | Audit and harden TypeScript type safety — find `any`, unsafe casts, and missing return types     |
+| Skill                   | Description                                                                                      |
+| ----------------------- | ------------------------------------------------------------------------------------------------ |
+| **analyze-code**        | Multi-agent code explanation for architecture, patterns, security, and performance               |
+| **analyze-dead-code**   | Find unused exports, unreachable modules, and dead files with confidence-ranked removal guidance |
+| **analyze-tech-debt**   | Identify and prioritize technical debt with remediation plans                                    |
+| **audit-accessibility** | Audit UI components for WCAG 2.1 AA compliance with severity-grouped violations                  |
+| **debug-issue**         | Systematic debugging workflow — from vague symptom to root cause analysis and validated fix      |
+| **diagram-excalidraw**  | Generate Excalidraw architecture diagrams from codebase analysis                                 |
+| **explore-codebase**    | Deep codebase exploration and understanding                                                      |
+| **refactor-code**       | Comprehensive refactoring with safety checks and pattern application                             |
+| **strengthen-types**    | Audit and harden TypeScript type safety — find `any`, unsafe casts, and missing return types     |
 
 ## Agents
 
@@ -59,6 +60,8 @@ claude /plugin install development-codebase-tools
 "I'm getting a TypeError in the auth module"     # triggers debug-issue
 "This keeps crashing in production, help me fix it" # triggers debug-issue
 "Find all dead code and unused exports"          # triggers analyze-dead-code
+"Check accessibility in src/components"          # triggers audit-accessibility
+"Find WCAG violations in LoginForm.tsx"          # triggers audit-accessibility
 ```
 
 ## License

--- a/packages/plugins/development-codebase-tools/skills/audit-accessibility/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/audit-accessibility/SKILL.md
@@ -1,0 +1,144 @@
+---
+description: Audit UI components and pages for accessibility (a11y) issues. Use when user says "check accessibility", "audit a11y compliance", "find WCAG violations", "is this component accessible", "run an accessibility audit", or "check screen reader support".
+allowed-tools: Read, Grep, Glob, Bash(npx axe:*), Bash(npx pa11y:*), Bash(npx lighthouse:*), Bash(npx jest:*), Bash(node:*), Task(subagent_type:security-analyzer-agent)
+model: sonnet
+---
+
+# Accessibility Auditor
+
+Audit frontend components and pages for WCAG 2.1 AA compliance, identifying violations by severity and providing targeted fix guidance.
+
+## When to Activate
+
+- User asks to "check accessibility" or "audit a11y"
+- User wants to find WCAG violations or screen reader issues
+- User mentions ADA compliance or ARIA issues
+- Before shipping a new UI component or page
+- User asks "is this accessible?"
+
+## Quick Process
+
+1. **Detect scope**: Identify target files (JSX/TSX/HTML/Vue/Svelte)
+2. **Static analysis**: Scan code for structural a11y issues
+3. **Tool detection**: Check for available automated tools (axe, pa11y, lighthouse)
+4. **Run tools**: Execute available auditors on the target
+5. **Report**: Output violations grouped by severity with fix guidance
+
+## What Gets Checked
+
+### Structural (Static Analysis)
+
+| Category        | What to Check                                                                        |
+| --------------- | ------------------------------------------------------------------------------------ |
+| Images          | `<img>` missing `alt`; decorative images use `alt=""`                                |
+| Forms           | Every `<input>` / `<select>` / `<textarea>` has associated `<label>` or `aria-label` |
+| Headings        | Heading hierarchy is sequential (h1 → h2 → h3, no skipped levels)                    |
+| Buttons & links | Interactive elements have accessible text (not icon-only without aria-label)         |
+| Color contrast  | CSS custom properties checked; hardcoded hex values flagged for manual review        |
+| ARIA            | `role`, `aria-*` attributes used correctly; no redundant roles                       |
+| Keyboard        | `onClick` on non-interactive elements without `onKeyDown`/`onKeyPress`               |
+| Focus           | No `tabIndex > 0`; focus-visible not suppressed via `outline: 0` without replacement |
+| Language        | `<html lang="...">` present                                                          |
+| Landmarks       | Page has at least one `<main>` landmark                                              |
+
+### Automated Tools (when available)
+
+```
+axe-core  →  npx axe <url>  or  jest-axe in test files
+pa11y     →  npx pa11y <url>
+lighthouse →  npx lighthouse <url> --only-categories=accessibility --output=json
+```
+
+## Step-by-Step
+
+### Step 1: Identify Target Files
+
+Glob for `.jsx`, `.tsx`, `.html`, `.vue`, `.svelte` under `src/` or the path provided.
+If a URL is given, skip to Step 3 (tool-based audit).
+
+### Step 2: Static Code Scan
+
+For each component file:
+
+1. Read the file
+2. Check the structural categories in the table above
+3. Record each violation with file path, line number, WCAG criterion, and severity
+
+**Severity mapping:**
+
+| Severity | Examples                                                              |
+| -------- | --------------------------------------------------------------------- |
+| Critical | Missing alt text on informative image, form input with no label       |
+| Serious  | Interactive element with no accessible name, missing `lang` attribute |
+| Moderate | Skipped heading level, `onClick` without keyboard handler             |
+| Minor    | Redundant ARIA role, `tabIndex="0"` on naturally focusable element    |
+
+### Step 3: Run Automated Tools
+
+Detect installed tools via `node -e "require('axe-core')"` or `npx pa11y --version` etc.
+For each available tool, run against the target URL or build output.
+Parse JSON output and merge with static findings (deduplicate by element + criterion).
+
+### Step 4: Generate Report
+
+Output a summary then grouped violation list:
+
+```
+Accessibility Audit: <target>
+WCAG Standard: 2.1 AA
+───────────────────────────────
+Critical:   N  (must fix before release)
+Serious:    N  (fix soon)
+Moderate:   N  (fix in backlog)
+Minor:      N  (nice to have)
+───────────────────────────────
+
+[CRITICAL] src/components/Avatar.tsx:12
+  Issue: <img> missing alt attribute
+  WCAG:  1.1.1 Non-text Content
+  Fix:   Add alt="" for decorative or alt="<description>" for informative image
+
+[SERIOUS] src/pages/LoginForm.tsx:34
+  Issue: <input type="email"> has no associated label
+  WCAG:  1.3.1 Info and Relationships, 4.1.2 Name, Role, Value
+  Fix:   Add <label htmlFor="email">...</label> or aria-label attribute
+
+[MODERATE] src/components/Sidebar.tsx:88
+  Issue: onClick handler on <div> with no keyboard equivalent
+  WCAG:  2.1.1 Keyboard
+  Fix:   Use <button> element or add onKeyDown={handleKey} and role="button" tabIndex={0}
+```
+
+### Step 5: Prioritize Fixes
+
+If Critical or Serious violations exist, list the top 5 highest-impact fixes with code snippets.
+Provide a summary of effort: which violations are one-line fixes vs. require design changes.
+
+## Options
+
+| Option       | Values                                | Default  |
+| ------------ | ------------------------------------- | -------- |
+| `--standard` | wcag2a, wcag2aa, wcag21aa, wcag22aa   | wcag21aa |
+| `--target`   | path/glob or URL                      | `src/`   |
+| `--severity` | critical, serious, moderate, all      | all      |
+| `--fix`      | Attempt to auto-fix simple violations | false    |
+
+## Auto-Fix Candidates
+
+When `--fix` is passed, safely apply:
+
+- Add `alt=""` to clearly decorative images (svg icons, spacers)
+- Add `lang="en"` to `<html>` if missing
+- Replace `role="button"` on `<div onClick>` with `<button>`
+
+Never auto-fix color contrast or heading hierarchy — these require design judgment.
+
+## Examples
+
+```
+"Check accessibility in src/components"
+"Audit a11y compliance for the checkout page"
+"Find WCAG violations in LoginForm.tsx"
+"Is the dashboard accessible to screen readers?"
+"Run an accessibility audit before we ship"
+```

--- a/packages/plugins/development-codebase-tools/skills/audit-accessibility/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/audit-accessibility/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Audit UI components and pages for accessibility (a11y) issues. Use when user says "check accessibility", "audit a11y compliance", "find WCAG violations", "is this component accessible", "run an accessibility audit", or "check screen reader support".
-allowed-tools: Read, Grep, Glob, Bash(npx axe:*), Bash(npx pa11y:*), Bash(npx lighthouse:*), Bash(npx jest:*), Bash(node:*), Task(subagent_type:security-analyzer-agent)
+allowed-tools: Read, Grep, Glob, Bash(npx axe:*), Bash(npx pa11y:*), Bash(npx lighthouse:*), Bash(npx jest:*), Bash(node -e:*), Task
 model: sonnet
 ---
 
@@ -44,9 +44,9 @@ Audit frontend components and pages for WCAG 2.1 AA compliance, identifying viol
 ### Automated Tools (when available)
 
 ```
-axe-core  →  npx axe <url>  or  jest-axe in test files
-pa11y     →  npx pa11y <url>
-lighthouse →  npx lighthouse <url> --only-categories=accessibility --output=json
+@axe-core/cli  →  npx axe <url>  or  jest-axe in test files
+pa11y          →  npx pa11y <url>
+lighthouse     →  npx lighthouse <url> --only-categories=accessibility --output=json
 ```
 
 ## Step-by-Step
@@ -75,7 +75,7 @@ For each component file:
 
 ### Step 3: Run Automated Tools
 
-Detect installed tools via `node -e "require('axe-core')"` or `npx pa11y --version` etc.
+Detect installed tools via `npx axe --version`, `npx pa11y --version`, `npx lighthouse --version` etc.
 For each available tool, run against the target URL or build output.
 Parse JSON output and merge with static findings (deduplicate by element + criterion).
 

--- a/packages/plugins/development-codebase-tools/skills/audit-accessibility/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/audit-accessibility/SKILL.md
@@ -129,7 +129,7 @@ When `--fix` is passed, safely apply:
 
 - Add `alt=""` to clearly decorative images (svg icons, spacers)
 - Add `lang="en"` to `<html>` if missing
-- Replace `role="button"` on `<div onClick>` with `<button>`
+- Replace `role="button"` on `<div onClick>` with `<button type="button">` (explicit `type="button"` prevents unintended form submissions in form contexts)
 
 Never auto-fix color contrast or heading hierarchy — these require design judgment.
 


### PR DESCRIPTION
## What gap this fills

Accessibility auditing is a distinct, commonly needed workflow step that was completely absent from the toolkit. The only a11y coverage in the repo is:
- `generate-tests` skill: `--strategy accessibility` option for *writing* a11y tests
- `refine-linear-task` skill: `--focus accessibility` option for *planning* a11y work

Neither of these *audits existing UI code* for compliance violations — which is the most frequent developer need: "is this component accessible before I ship it?"

## How it was identified

Gap analysis across development workflow phases showed monitoring/quality checks were underrepresented. Accessibility auditing is a pre-release quality gate (like security scanning or IaC validation) rather than a testing strategy or planning aid.

## What the skill does

The `audit-accessibility` skill in `development-codebase-tools`:

1. **Static code analysis** — scans JSX/TSX/HTML/Vue/Svelte files for structural violations: missing `alt` text, unlabeled form inputs, skipped heading levels, `onClick` on non-interactive elements without keyboard handlers, `tabIndex > 0`, suppressed focus outlines, missing `<html lang>`, missing `<main>` landmark
2. **Automated tool integration** — detects and runs available tools (axe-core, pa11y, lighthouse `--only-categories=accessibility`) when present, merging results with static findings
3. **Severity-grouped report** — outputs violations as Critical / Serious / Moderate / Minor with WCAG 2.1 criterion references and per-violation fix guidance
4. **Optional `--fix`** — auto-applies safe one-liners (decorative `alt=""`, `<html lang="en">`, `<div onClick>` → `<button>`)

## Example usage scenarios

```
"Check accessibility in src/components"
"Audit a11y compliance for the checkout page"
"Find WCAG violations in LoginForm.tsx"
"Is the dashboard accessible to screen readers?"
"Run an accessibility audit before we ship"
```

## Test plan

- [ ] Skill triggers on "check accessibility" and "audit a11y" phrases
- [ ] Static scan detects missing `alt` on `<img>` elements
- [ ] Static scan detects unlabeled `<input>` elements
- [ ] Static scan flags `<div onClick>` without keyboard handler
- [ ] Tool detection gracefully handles missing tools (no crash)
- [ ] Report output groups violations by severity
- [ ] WCAG criterion references are accurate
- [ ] `--fix` applies safe auto-fixes without breaking valid patterns
- [ ] Validation passes: `node scripts/validate-plugin.cjs packages/plugins/development-codebase-tools`
- [ ] Markdownlint: 0 errors

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## What gap this fills
Accessibility auditing is a distinct, commonly needed workflow step that was completely absent from the toolkit. The only a11y coverage in the repo is:
- `generate-tests` skill: `--strategy accessibility` option for *writing* a11y tests
- `refine-linear-task` skill: `--focus accessibility` option for *planning* a11y work
Neither of these *audits existing UI code* for compliance violations — which is the most frequent developer need: "is this component accessible before I ship it?"
## How it was identified
Gap analysis across development workflow phases showed monitoring/quality checks were underrepresented. Accessibility auditing is a pre-release quality gate (like security scanning or IaC validation) rather than a testing strategy or planning aid.
## What the skill does
The `audit-accessibility` skill in `development-codebase-tools`:
1. **Static code analysis** — scans JSX/TSX/HTML/Vue/Svelte files for structural violations: missing `alt` text, unlabeled form inputs, skipped heading levels, `onClick` on non-interactive elements without keyboard handlers, `tabIndex > 0`, suppressed focus outlines, missing `<html lang>`, missing `<main>` landmark
2. **Automated tool integration** — detects and runs available tools (axe-core, pa11y, lighthouse `--only-categories=accessibility`) when present, merging results with static findings
3. **Severity-grouped report** — outputs violations as Critical / Serious / Moderate / Minor with WCAG 2.1 criterion references and per-violation fix guidance
4. **Optional `--fix`** — auto-applies safe one-liners (decorative `alt=""`, `<html lang="en">`, `<div onClick>` → `<button type="button">`)
## Changes
| File | Change |
|------|--------|
| `skills/audit-accessibility/SKILL.md` | New skill definition (144 lines) with static analysis checklist, automated tool integration, severity-grouped reporting, and `--fix` option |
| `.claude-plugin/plugin.json` | Register `audit-accessibility` in skills array; bump version 2.5.3 → 2.5.4 |
| `CLAUDE.md` | Add audit-accessibility to skills list and file structure tree |
| `README.md` | Add audit-accessibility to skills table and usage examples |
## Example usage scenarios
```
"Check accessibility in src/components"
"Audit a11y compliance for the checkout page"
"Find WCAG violations in LoginForm.tsx"
"Is the dashboard accessible to screen readers?"
"Run an accessibility audit before we ship"
```
## Test plan
- [ ] Skill triggers on "check accessibility" and "audit a11y" phrases
- [ ] Static scan detects missing `alt` on `<img>` elements
- [ ] Static scan detects unlabeled `<input>` elements
- [ ] Static scan flags `<div onClick>` without keyboard handler
- [ ] Tool detection gracefully handles missing tools (no crash)
- [ ] Report output groups violations by severity
- [ ] WCAG criterion references are accurate
- [ ] `--fix` applies safe auto-fixes without breaking valid patterns
- [ ] Validation passes: `node scripts/validate-plugin.cjs packages/plugins/development-codebase-tools`
- [ ] Markdownlint: 0 errors

</details>
<!-- claude-pr-description-end -->