### PR TITLE
improve(development-codebase-tools): tune analyze-tech-debt skill with concrete execution steps

### DIFF
--- a/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
+++ b/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-codebase-tools",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "Codebase exploration, refactoring, and quality analysis",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/development-codebase-tools/CLAUDE.md
+++ b/packages/plugins/development-codebase-tools/CLAUDE.md
@@ -10,7 +10,7 @@ This plugin provides codebase exploration, refactoring, and quality analysis too
 
 - **analyze-code**: Multi-agent code explanation for architecture, patterns, security, and performance
 - **analyze-dead-code**: Find unused exports, unreachable modules, and dead files with confidence-ranked removal guidance
-- **analyze-tech-debt**: Identify and prioritize technical debt with remediation plans
+- **analyze-tech-debt**: Identify and prioritize technical debt with remediation plans. Uses a structured 6-step execution process: scope the target, collect code signals (Glob/Grep for large files, nesting, TODO/FIXME/HACK, `any` types), examine git history (high-churn files via `git log`, chronic bug areas via `git blame`), assess test presence (test-to-source file ratio), score and prioritize items by ROI, and write a Debt Metrics Dashboard + Prioritized Roadmap. Allowed tools include `Bash(git blame:*)`.
 - **debug-issue**: Systematic debugging workflow — accepts any error report (message, stack trace, or vague symptom), locates the origin, gathers context, invokes the debug-assistant-agent for root-cause analysis, and validates the fix
 - **diagram-excalidraw**: Generate Excalidraw architecture diagrams from codebase analysis
 - **mermaid-diagram**: Generate syntactically valid Mermaid.js diagrams (flowcharts, sequence, class, state, ER, Gantt, git)

--- a/packages/plugins/development-codebase-tools/skills/analyze-tech-debt/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/analyze-tech-debt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Analyze and prioritize technical debt with remediation plans. Use when user says "analyze the technical debt in this codebase", "what's the code quality like in this module", "identify what's slowing down our development", "assess the maintenance burden of this legacy code", "create a plan to pay down our tech debt", or "where should we focus our cleanup efforts".
-allowed-tools: Read, Glob, Grep, Bash(git log:*), Bash(git diff:*), Task, WebSearch
+allowed-tools: Read, Glob, Grep, Bash(git log:*), Bash(git diff:*), Bash(git blame:*), Task, WebSearch
 model: opus
 ---
 
@@ -15,6 +15,15 @@ Identify, quantify, and prioritize technical debt with ROI-based remediation pla
 - Understanding what's slowing development
 - Legacy code evaluation
 - Maintenance burden analysis
+
+## Execution Process
+
+1. **Scope the target** — Identify which packages, modules, or files to analyze. If no scope is given, use the entire repository.
+2. **Collect code signals** — Use `Glob` and `Grep` to find: files over 500 lines, deeply nested code (≥4 levels of indentation), `TODO`/`FIXME`/`HACK` comments, and `any` types in TypeScript files.
+3. **Examine git history** — Run `git log --since="6 months ago" --format="%H %s" --stat` to identify high-churn files. Run `git log --oneline --grep="fix\|bug\|hotfix" -- <path>` on suspect files to spot chronic bug areas.
+4. **Assess test coverage** — Use `Glob("**/*.test.*")` and `Glob("**/*.spec.*")` to find test files. Cross-reference with source files to identify untested modules. Estimate coverage as (test file count / source file count) × 100.
+5. **Score and prioritize each item** — Assign impact (hours/month lost), effort (hours to fix), and risk (critical/high/medium/low). Compute ROI = (monthly_impact × 12) / effort.
+6. **Write the report** — Output a Debt Metrics Dashboard followed by a Prioritized Roadmap. Categorize items as Quick Wins (high ROI, <4h effort), Medium-Term, or Long-Term.
 
 ## Debt Categories
 
@@ -55,22 +64,29 @@ Calculates real cost:
 ### Debt Metrics Dashboard
 
 ```yaml
-cyclomatic_complexity:
-  current: 15.2
-  target: 10.0
-code_duplication:
-  percentage: 23%
-  target: 5%
-test_coverage:
-  unit: 45%
+high_churn_files:
+  - path: src/auth/login.ts
+    commits_6mo: 47
+files_over_500_lines:
+  count: 12
+  worst: src/legacy/processor.ts (1842 lines)
+todo_fixme_count:
+  total: 83
+  hotspots: [src/payments/, src/legacy/]
+test_coverage_estimate:
+  ratio: 45%
   target: 80%
 ```
 
 ### Prioritized Roadmap
 
-- **Quick Wins**: High value, low effort (Week 1-2)
-- **Medium-Term**: Features, refactors (Month 1-3)
-- **Long-Term**: Architecture changes (Quarter 2-4)
+- **Quick Wins**: High ROI, <4h effort (Week 1–2)
+- **Medium-Term**: Refactors and feature-level changes (Month 1–3)
+- **Long-Term**: Architecture changes (Quarter 2–4)
+
+### Per-Item Format
+
+Each item includes: location, description, estimated effort, monthly velocity savings, ROI %, and recommended fix.
 
 ### ROI Calculations
 
@@ -81,11 +97,11 @@ Each item includes:
 - ROI percentage
 - Payback period
 
-## Prevention Strategy
+## Examples
 
-Includes quality gates:
-
-- Pre-commit hooks
-- CI pipeline checks
-- Code review requirements
-- Debt budget tracking
+```
+"Analyze the technical debt in the auth module"
+"What's slowing down development in packages/legacy?"
+"Create a cleanup roadmap for next quarter"
+"Where should we focus refactoring efforts this sprint?"
+```

--- a/packages/plugins/development-codebase-tools/skills/analyze-tech-debt/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/analyze-tech-debt/SKILL.md
@@ -21,7 +21,7 @@ Identify, quantify, and prioritize technical debt with ROI-based remediation pla
 1. **Scope the target** — Identify which packages, modules, or files to analyze. If no scope is given, use the entire repository.
 2. **Collect code signals** — Use `Glob` and `Grep` to find: files over 500 lines, deeply nested code (≥4 levels of indentation), `TODO`/`FIXME`/`HACK` comments, and `any` types in TypeScript files.
 3. **Examine git history** — Run `git log --since="6 months ago" --format="%H %s" --stat` to identify high-churn files. Run `git log --oneline --grep="fix\|bug\|hotfix" -- <path>` on suspect files to spot chronic bug areas.
-4. **Assess test coverage** — Use `Glob("**/*.test.*")` and `Glob("**/*.spec.*")` to find test files. Cross-reference with source files to identify untested modules. Estimate coverage as (test file count / source file count) × 100.
+4. **Assess test presence** — Use `Glob("**/*.test.*")` and `Glob("**/*.spec.*")` to find test files. Cross-reference with source files to identify untested modules. Compute the test-to-source file ratio (test file count / source file count) as a proxy for testing density — not a statement of line coverage.
 5. **Score and prioritize each item** — Assign impact (hours/month lost), effort (hours to fix), and risk (critical/high/medium/low). Compute ROI = (monthly_impact × 12) / effort.
 6. **Write the report** — Output a Debt Metrics Dashboard followed by a Prioritized Roadmap. Categorize items as Quick Wins (high ROI, <4h effort), Medium-Term, or Long-Term.
 
@@ -73,9 +73,9 @@ files_over_500_lines:
 todo_fixme_count:
   total: 83
   hotspots: [src/payments/, src/legacy/]
-test_coverage_estimate:
+test_to_source_ratio:
   ratio: 45%
-  target: 80%
+  note: proxy for testing density, not line coverage
 ```
 
 ### Prioritized Roadmap


### PR DESCRIPTION
## Summary

- Adds a concrete 6-step **Execution Process** section that tells Claude exactly which tools to run (`Glob`, `Grep`, `git log`, `git blame`) and how to interpret results
- Replaces the vague example YAML dashboard with instructional field names derived from what the tools actually produce
- Removes the **Prevention Strategy** section (out of scope for an analysis skill)
- Adds an **Examples** section with concrete user trigger phrases
- Adds `Bash(git blame:*)` to `allowed-tools` for high-churn file investigation

## Motivation

The original skill described *what* to output but not *how* to gather the data. Without step-by-step guidance, Claude defaults to general reasoning rather than running the specific git and code-signal queries that produce accurate debt metrics.

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
- Adds a concrete 6-step **Execution Process** section that tells Claude exactly which tools to run (`Glob`, `Grep`, `git log`, `git blame`) and how to interpret results
- Replaces the vague example YAML dashboard with instructional field names derived from what the tools actually produce
- Removes the **Prevention Strategy** section (out of scope for an analysis skill) and replaces it with an **Examples** section with concrete user trigger phrases
- Adds `Bash(git blame:*)` to `allowed-tools` for high-churn file investigation
## Motivation
The original skill described *what* to output but not *how* to gather the data. Without step-by-step guidance, Claude defaults to general reasoning rather than running the specific git and code-signal queries that produce accurate debt metrics.
## Changes
| File | Change |
|------|--------|
| `packages/plugins/development-codebase-tools/skills/analyze-tech-debt/SKILL.md` | Add 6-step Execution Process; replace example YAML dashboard with tool-derived fields; replace Prevention Strategy with Examples section; add `Bash(git blame:*)` to allowed-tools |
| `packages/plugins/development-codebase-tools/.claude-plugin/plugin.json` | Bump version 2.5.2 → 2.5.3 (patch: skill content improvement, no new components) |
| `packages/plugins/development-codebase-tools/CLAUDE.md` | Update analyze-tech-debt description to reflect the new 6-step execution process |
## Test plan
- [ ] Verify SKILL.md renders correctly in markdown preview
- [ ] Trigger skill with "analyze the technical debt in this codebase" and confirm Claude follows the 6-step execution process
- [ ] Confirm `git blame` commands are permitted by the allowed-tools list
- [ ] Confirm plugin validation passes: `node scripts/validate-plugin.cjs packages/plugins/development-codebase-tools`

</details>
<!-- claude-pr-description-end -->