### PR TITLE
feat(development-codebase-tools): add profile-performance skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,7 +226,7 @@ All plugins follow semantic versioning (semver). Key versioning rules:
 | Plugin                     | Version |
 | -------------------------- | ------- |
 | claude-setup               | 1.0.4   |
-| development-codebase-tools | 2.5.5   |
+| development-codebase-tools | 2.6.0   |
 | development-planning       | 2.0.1   |
 | development-pr-workflow    | 2.1.0   |
 | development-productivity   | 2.4.0   |

--- a/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
+++ b/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-codebase-tools",
-  "version": "2.5.7",
+  "version": "2.6.0",
   "description": "Codebase exploration, refactoring, and quality analysis",
   "author": {
     "name": "Uniswap Labs",
@@ -23,11 +23,14 @@
   ],
   "skills": [
     "./skills/analyze-code",
+    "./skills/analyze-dead-code",
     "./skills/analyze-tech-debt",
+    "./skills/audit-accessibility",
     "./skills/debug-issue",
     "./skills/diagram-excalidraw",
     "./skills/explore-codebase",
     "./skills/mermaid-diagram",
+    "./skills/profile-performance",
     "./skills/refactor-code",
     "./skills/strengthen-types"
   ]

--- a/packages/plugins/development-codebase-tools/CLAUDE.md
+++ b/packages/plugins/development-codebase-tools/CLAUDE.md
@@ -16,6 +16,7 @@ This plugin provides codebase exploration, refactoring, and quality analysis too
 - **diagram-excalidraw**: Generate Excalidraw architecture diagrams from codebase analysis
 - **mermaid-diagram**: Generate syntactically valid Mermaid.js diagrams (flowcharts, sequence, class, state, ER, Gantt, git)
 - **explore-codebase**: Deep codebase exploration with architectural understanding
+- **profile-performance**: Profile and analyze application performance to identify bottlenecks via static analysis and profiling tools
 - **refactor-code**: Comprehensive refactoring with safety checks and pattern application
 - **strengthen-types**: Audit and harden TypeScript type safety — find `any`, unsafe casts, non-null assertions, and missing return types with severity-ranked findings and concrete fixes
 
@@ -91,6 +92,7 @@ development-codebase-tools/
 │   ├── diagram-excalidraw/
 │   ├── mermaid-diagram/
 │   ├── explore-codebase/
+│   ├── profile-performance/
 │   ├── refactor-code/
 │   └── strengthen-types/
 ├── agents/

--- a/packages/plugins/development-codebase-tools/README.md
+++ b/packages/plugins/development-codebase-tools/README.md
@@ -23,6 +23,7 @@ claude /plugin install development-codebase-tools
 | **debug-issue**         | Systematic debugging workflow — from vague symptom to root cause analysis and validated fix      |
 | **diagram-excalidraw**  | Generate Excalidraw architecture diagrams from codebase analysis                                 |
 | **explore-codebase**    | Deep codebase exploration and understanding                                                      |
+| **profile-performance** | Profile and analyze application performance to identify bottlenecks                              |
 | **refactor-code**       | Comprehensive refactoring with safety checks and pattern application                             |
 | **strengthen-types**    | Audit and harden TypeScript type safety — find `any`, unsafe casts, and missing return types     |
 
@@ -62,6 +63,8 @@ claude /plugin install development-codebase-tools
 "Find all dead code and unused exports"          # triggers analyze-dead-code
 "Check accessibility in src/components"          # triggers audit-accessibility
 "Find WCAG violations in LoginForm.tsx"          # triggers audit-accessibility
+"Why is this endpoint slow?"                     # triggers profile-performance
+"Find performance bottlenecks in this service"   # triggers profile-performance
 ```
 
 ## License

--- a/packages/plugins/development-codebase-tools/skills/profile-performance/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/profile-performance/SKILL.md
@@ -1,0 +1,222 @@
+---
+description: Profile and analyze application performance to identify bottlenecks. Use when user says "profile performance", "find performance bottlenecks", "why is this slow", "optimize runtime performance", "identify CPU hotspots", "analyze memory usage", "benchmark this code", or "performance profiling".
+allowed-tools: Read, Glob, Grep, Bash(node:*), Bash(npx:*), Bash(python:*), Bash(python3:*), Bash(pip:*), Bash(go:*), Bash(cargo:*), Bash(hyperfine:*), Task(subagent_type:performance-analyzer)
+model: sonnet
+---
+
+# Performance Profiler
+
+Profile application performance through static analysis and tool-assisted measurement to identify bottlenecks with actionable optimization guidance.
+
+## When to Activate
+
+- User reports slowness or latency issues
+- User asks to "profile", "benchmark", or "optimize" performance
+- User wants to find CPU hotspots or memory leaks
+- Before/after a performance-sensitive change
+- User asks "why is this slow?" about code or a feature
+
+## Quick Process
+
+1. **Detect stack**: Identify language, framework, and runtime from project files
+2. **Static scan**: Find performance anti-patterns without running the code
+3. **Tool detection**: Check for available profilers and benchmarking tools
+4. **Profile**: Run available tools on the target (with user confirmation for long-running operations)
+5. **Report**: Output findings grouped by severity with specific fix guidance
+
+## Step 1: Stack Detection
+
+Glob for `package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`, `Gemfile`, `pom.xml`, `build.gradle`.
+Read the detected files to identify:
+
+- **Language**: JavaScript/TypeScript, Python, Go, Rust, Ruby, Java/Kotlin
+- **Framework**: React, Next.js, Express, FastAPI, Django, Gin, Actix, etc.
+- **Runtime characteristics**: Node.js (event loop), Python (GIL), Go (goroutines), etc.
+
+## Step 2: Static Analysis
+
+Scan source files for language-specific performance anti-patterns.
+
+### JavaScript / TypeScript
+
+| Anti-Pattern                        | Detection                                                      | Severity |
+| ----------------------------------- | -------------------------------------------------------------- | -------- |
+| Nested loops over large arrays      | `for` inside `for` with array operands > O(n²) risk            | High     |
+| Array operations in render loops    | `.map`, `.filter`, `.find` called inside JSX without memoize   | High     |
+| Missing React.memo / useMemo        | Components/computations recreated on every parent render       | Medium   |
+| `await` inside `for` loop           | Sequential async when parallelizable with `Promise.all`        | High     |
+| Unindexed object lookups in loops   | `Array.includes` or `Array.find` in hot loops (prefer Set/Map) | Medium   |
+| Synchronous `fs` calls in handlers  | `readFileSync`, `writeFileSync` in request handlers            | High     |
+| Missing debounce on frequent events | `onInput`, `onScroll`, `onResize` without debounce/throttle    | Medium   |
+| Large bundle imports                | `import _ from 'lodash'` vs `import pick from 'lodash/pick'`   | Medium   |
+| Memory leaks in effects             | `useEffect` with subscriptions missing cleanup return          | High     |
+| Excessive re-renders                | State updates inside render, missing dependency arrays         | Medium   |
+
+```bash
+# Example grep patterns for static detection
+grep -rn "for.*of.*\n.*for\|\.map.*\.map" src/
+grep -rn "readFileSync\|writeFileSync" src/
+grep -rn "await.*for\b" src/ --include="*.ts" --include="*.js"
+```
+
+### Python
+
+| Anti-Pattern                       | Detection                                               | Severity |
+| ---------------------------------- | ------------------------------------------------------- | -------- |
+| Nested loops over lists            | `for` inside `for` — prefer numpy/vectorized ops        | High     |
+| String concatenation in loops      | `str +=` inside loop — use `''.join(list)`              | Medium   |
+| `global` or `nonlocal` in hot path | Global variable lookups are slower than local           | Low      |
+| Missing `__slots__`                | Classes with many instances benefit from `__slots__`    | Low      |
+| Repeated attribute lookups         | `obj.method()` in loop — cache as local variable        | Medium   |
+| Synchronous I/O in async context   | Blocking calls in `async def` without `run_in_executor` | High     |
+| N+1 ORM queries                    | `.filter()` inside loop instead of select_related       | High     |
+
+### Go
+
+| Anti-Pattern                  | Detection                                          | Severity |
+| ----------------------------- | -------------------------------------------------- | -------- |
+| Lock contention in hot paths  | `sync.Mutex.Lock()` in high-throughput loops       | High     |
+| Goroutine leaks               | Goroutines started without done channel or context | High     |
+| Excessive allocations         | `append` without pre-allocated slice capacity      | Medium   |
+| String/[]byte conversions     | Repeated `string(bytes)` in loops                  | Medium   |
+| Interface boxing in hot paths | Passing concrete types as `interface{}` repeatedly | Low      |
+
+### Cross-Language: Database / API Patterns
+
+| Anti-Pattern                | Detection                                                        | Severity |
+| --------------------------- | ---------------------------------------------------------------- | -------- |
+| N+1 queries                 | DB query inside a loop; ORM `.load()` in iteration               | Critical |
+| Missing pagination          | Unbounded `SELECT *` / list API calls without `LIMIT`            | High     |
+| Unindexed query filters     | `WHERE` on columns not in schema indexes (check migration files) | High     |
+| Waterfall API requests      | Sequential `fetch`/`axios` calls that could be parallelized      | Medium   |
+| Large payload serialization | Serializing full objects when only a few fields are needed       | Medium   |
+
+## Step 3: Tool Detection
+
+Check for available profiling and benchmarking tools:
+
+```bash
+# Node.js / JavaScript
+npx clinic --version 2>/dev/null && echo "clinic.js available"
+npx 0x --version 2>/dev/null && echo "0x available"
+node --prof --version 2>/dev/null && echo "node --prof available"
+
+# Python
+python3 -c "import cProfile" 2>/dev/null && echo "cProfile available"
+python3 -m py_spy --version 2>/dev/null && echo "py-spy available"
+
+# Go
+which pprof 2>/dev/null && echo "pprof available"
+go test -bench . -benchtime=1x . 2>/dev/null && echo "go bench available"
+
+# Universal benchmarking
+hyperfine --version 2>/dev/null && echo "hyperfine available"
+```
+
+## Step 4: Profile (Optional)
+
+> Only run profiling tools after confirming with the user — they may have side effects or require a running server.
+
+### Node.js — clinic.js (preferred)
+
+```bash
+npx clinic doctor -- node server.js
+# or for flame graphs:
+npx clinic flame -- node server.js
+```
+
+Parse the generated report directory and summarize:
+
+- Top CPU consumers (functions and file paths)
+- Event loop delay spikes
+- Memory growth patterns
+
+### Node.js — V8 built-in profiler
+
+```bash
+node --prof app.js
+node --prof-process isolate-*.log > profile.txt
+```
+
+Read `profile.txt` and extract the top 10 functions by tick count.
+
+### Python — cProfile
+
+```bash
+python3 -m cProfile -o profile.out -s cumulative script.py
+python3 -c "import pstats; p = pstats.Stats('profile.out'); p.sort_stats('cumulative'); p.print_stats(20)"
+```
+
+Report top 20 functions by cumulative time.
+
+### Go — pprof
+
+```bash
+go test -bench . -cpuprofile=cpu.prof ./...
+go tool pprof -top cpu.prof
+```
+
+Extract top 10 CPU-consuming functions.
+
+### Universal — hyperfine
+
+```bash
+hyperfine --warmup 3 'command-under-test'
+```
+
+Use for before/after benchmarking of CLI commands or scripts.
+
+## Step 5: Report
+
+Output findings grouped by severity.
+
+### Critical (fix immediately)
+
+N+1 query patterns, unbounded queries, blocking I/O in async handlers.
+
+### High (fix this sprint)
+
+Sequential async that should be parallel, nested loops over large data, goroutine leaks, memory leaks.
+
+### Medium (schedule for cleanup)
+
+Missing memoization, unoptimized imports, string concatenation in loops.
+
+### Low (low-hanging fruit when touching the code)
+
+Local variable caching, `__slots__`, minor allocation improvements.
+
+---
+
+For each finding output:
+
+```
+[SEVERITY] <Anti-Pattern Name>
+File: <path>:<line>
+Issue: <one-line description>
+Fix:
+  <concrete code change or command>
+Expected impact: <e.g., "reduces render time by ~30%", "eliminates N+1 query">
+```
+
+### Summary Table
+
+```
+Performance Profile Summary
+───────────────────────────
+Critical: N  High: N  Medium: N  Low: N
+
+Top 3 recommendations:
+1. [Critical] Fix N+1 query in UserService.getAll() → add .include('posts')
+2. [High] Parallelize 4 sequential API calls in checkout flow → Promise.all(...)
+3. [Medium] Memoize ProductList component → React.memo() wrapper
+```
+
+## Guidelines
+
+- Always prefer static analysis findings over running profilers — safer and faster
+- If no profiler is available, note what to install and how to interpret results
+- For React apps, check if React DevTools Profiler has existing recordings before running tools
+- Quantify impact where possible: "this loop runs O(n²) on the users array (currently 50k rows)"
+- When a profiler requires a running server, provide the exact command and what to do next
+- Never run load tests (k6, Artillery) automatically — only suggest them with the exact command

--- a/packages/plugins/development-codebase-tools/skills/profile-performance/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/profile-performance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Profile and analyze application performance to identify bottlenecks. Use when user says "profile performance", "find performance bottlenecks", "why is this slow", "optimize runtime performance", "identify CPU hotspots", "analyze memory usage", "benchmark this code", or "performance profiling".
-allowed-tools: Read, Glob, Grep, Bash(node:*), Bash(npx:*), Bash(python:*), Bash(python3:*), Bash(pip:*), Bash(go:*), Bash(cargo:*), Bash(hyperfine:*), Task(subagent_type:performance-analyzer)
+allowed-tools: Read, Glob, Grep, Bash(node:*), Bash(npx:*), Bash(python:*), Bash(python3:*), Bash(pip:*), Bash(go:*), Bash(cargo:*), Bash(hyperfine:*), Task(subagent_type:performance-analyzer-agent)
 model: sonnet
 ---
 
@@ -107,7 +107,7 @@ python3 -m py_spy --version 2>/dev/null && echo "py-spy available"
 
 # Go
 which pprof 2>/dev/null && echo "pprof available"
-go test -bench . -benchtime=1x . 2>/dev/null && echo "go bench available"
+go version 2>/dev/null && echo "go bench available"
 
 # Universal benchmarking
 hyperfine --version 2>/dev/null && echo "hyperfine available"


### PR DESCRIPTION
## What gap this fills

The `development-codebase-tools` plugin has a `performance-analyzer` agent for ad-hoc analysis, but no structured skill that walks developers through identifying and measuring performance bottlenecks. The gap: when a user says "why is this slow?", they need a systematic workflow — not an open-ended agent conversation.

## How it was identified

Identified via the `enhance-ai-toolkit` job gap analysis. The backlog item `gap-perf` noted: *"performance-analyzer agent covers ad-hoc analysis; gap is structured skill for orchestrating load tests and profiling workflows."*

## What the skill does

`profile-performance` is a 5-step skill that:

1. **Detects the tech stack** — reads `package.json`, `go.mod`, `pyproject.toml`, etc. to identify language, framework, and runtime
2. **Static analysis** — scans for performance anti-patterns specific to the detected stack (JS/TS, Python, Go, and cross-language DB/API patterns)
3. **Tool detection** — checks for available profilers (`clinic.js`, `0x`, `cProfile`, `py-spy`, `pprof`, `hyperfine`) without running them
4. **Profile (optional)** — runs detected tools with user confirmation; provides stack-specific commands and how to interpret output
5. **Report** — outputs findings grouped by severity (Critical → Low) with file+line references and concrete fix guidance

The static analysis covers:
- JS/TS: N+1 renders, `await` in loops, missing `React.memo`, synchronous fs calls, memory leaks in effects, large bundle imports
- Python: nested loops, string concatenation, N+1 ORM queries, blocking I/O in async context
- Go: goroutine leaks, lock contention, excessive allocations
- Cross-language: N+1 DB queries, missing pagination, unindexed query filters, waterfall API requests

## Example usage scenarios

- "Why is my Express API endpoint slow?" → triggers static scan of route handlers and DB call patterns
- "Profile this React component" → detects renders, memoization gaps, effect leaks
- "Find performance bottlenecks before this release" → full static scan across stack
- "Benchmark this CLI command" → detects hyperfine and runs before/after comparison

## Test plan

- [ ] Trigger phrase "find performance bottlenecks" activates the skill
- [ ] Trigger phrase "why is this slow?" activates the skill
- [ ] Trigger phrase "profile performance" activates the skill
- [ ] Static analysis runs without requiring a running server
- [ ] Tool detection step lists available tools correctly
- [ ] Profiling step prompts for confirmation before running
- [ ] Report output groups findings by severity with file+line references
- [ ] Plugin validation passes (`node scripts/validate-plugin.cjs packages/plugins/development-codebase-tools`)
- [ ] Markdownlint passes (0 errors)

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## What gap this fills
The `development-codebase-tools` plugin has a `performance-analyzer` agent for ad-hoc analysis, but no structured skill that walks developers through identifying and measuring performance bottlenecks. When a user says "why is this slow?", they need a systematic workflow — not an open-ended agent conversation.
## How it was identified
Identified via the `enhance-ai-toolkit` job gap analysis. The backlog item `gap-perf` noted: *"performance-analyzer agent covers ad-hoc analysis; gap is structured skill for orchestrating load tests and profiling workflows."*
## What the skill does
`profile-performance` is a 5-step skill that:
1. **Detects the tech stack** — reads `package.json`, `go.mod`, `pyproject.toml`, etc. to identify language, framework, and runtime
2. **Static analysis** — scans for performance anti-patterns specific to the detected stack (JS/TS, Python, Go, and cross-language DB/API patterns)
3. **Tool detection** — checks for available profilers (`clinic.js`, `0x`, `cProfile`, `py-spy`, `pprof`, `hyperfine`) without running them
4. **Profile (optional)** — runs detected tools with user confirmation; provides stack-specific commands and how to interpret output
5. **Report** — outputs findings grouped by severity (Critical > Low) with file+line references and concrete fix guidance
The static analysis covers:
- **JS/TS**: N+1 renders, `await` in loops, missing `React.memo`, synchronous fs calls, memory leaks in effects, large bundle imports
- **Python**: nested loops, string concatenation, N+1 ORM queries, blocking I/O in async context
- **Go**: goroutine leaks, lock contention, excessive allocations
- **Cross-language**: N+1 DB queries, missing pagination, unindexed query filters, waterfall API requests
## Changes
| File | Change |
|------|--------|
| `skills/profile-performance/SKILL.md` | New 222-line skill with stack detection, static analysis tables, profiler tool detection, optional profiling with user confirmation, and severity-grouped report format |
| `.claude-plugin/plugin.json` | Add `./skills/profile-performance` to skills array; also registers `analyze-dead-code` and `audit-accessibility`; bump version to 2.6.0 |
| `CLAUDE.md` | Add profile-performance to skill list and file structure tree |
| `README.md` | Add profile-performance to skills table and usage examples |
| Root `CLAUDE.md` | Update development-codebase-tools version in plugin version table to 2.6.0 |
## Example usage scenarios
- "Why is my Express API endpoint slow?" — triggers static scan of route handlers and DB call patterns
- "Profile this React component" — detects renders, memoization gaps, effect leaks
- "Find performance bottlenecks before this release" — full static scan across stack
- "Benchmark this CLI command" — detects hyperfine and runs before/after comparison
## Test plan
- [ ] Trigger phrase "find performance bottlenecks" activates the skill
- [ ] Trigger phrase "why is this slow?" activates the skill
- [ ] Trigger phrase "profile performance" activates the skill
- [ ] Static analysis runs without requiring a running server
- [ ] Tool detection step lists available tools correctly
- [ ] Profiling step prompts for confirmation before running
- [ ] Report output groups findings by severity with file+line references
- [ ] Plugin validation passes (`node scripts/validate-plugin.cjs packages/plugins/development-codebase-tools`)
- [ ] Markdownlint passes (0 errors)

</details>
<!-- claude-pr-description-end -->