### PR TITLE
docs(development-codebase-tools): tune skill diagram-excalidraw

### DIFF
--- a/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
+++ b/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-codebase-tools",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Codebase exploration, refactoring, and quality analysis",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/development-codebase-tools/skills/diagram-excalidraw/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/diagram-excalidraw/SKILL.md
@@ -8,17 +8,9 @@ model: opus
 
 Generate valid `.excalidraw` JSON files representing system architecture from codebase analysis.
 
-## When to Activate
-
-- User asks to create an architecture diagram
-- User wants to visualize system design
-- User asks for a flowchart or data flow diagram
-- User wants to document system structure visually
-- User mentions Excalidraw or diagram generation
-
 ## Quick Start
 
-Works without existing diagrams, Terraform, or specific file types. Analyzes any codebase structure.
+Works without existing diagrams, Terraform, or specific file types. Analyzes any codebase structure. If the codebase has more than ~30 distinct components, limit scope to top-level packages or services only to keep the diagram readable.
 
 ## Critical Implementation Rules
 
@@ -50,7 +42,7 @@ Works without existing diagrams, Terraform, or specific file types. Analyzes any
 
 1. **Analyze codebase structure** - Identify components, services, and relationships
 2. **Plan layout grid** - Determine rows, columns, and spacing
-3. **Generate shape elements** - Create rectangles, ellipses, text labels
+3. **Generate shape elements** - Create rectangles, ellipses, text labels; derive element IDs from component names (e.g., `api-server`, `api-server-text`) and verify all IDs are unique
 4. **Add connection arrows** - Connect components with proper edge positioning
 5. **Apply grouping** - Group related elements (namespaces, services, etc.)
 6. **Validate and write output** - Check all constraints before writing file


### PR DESCRIPTION
## Summary

- Remove redundant "When to Activate" section — it was a verbatim duplicate of the frontmatter `description` field, adding ~8 lines of token waste on every invocation
- Add scope-limiting guidance to Quick Start: when a codebase has >30 distinct components, limit to top-level packages/services to keep the diagram readable
- Expand Step 3 in the generation workflow to surface the ID naming convention (`api-server`, `api-server-text`) and remind Claude to verify uniqueness before output

## Test plan

- [ ] Skill triggers correctly on diagram-related requests
- [ ] Plugin validates: `npx nx run development-codebase-tools:validate`
- [ ] Markdownlint passes: 0 errors

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
- Remove redundant "When to Activate" section — it was a verbatim duplicate of the frontmatter `description` field, adding ~8 lines of token waste on every invocation
- Add scope-limiting guidance to Quick Start: when a codebase has >30 distinct components, limit to top-level packages/services to keep the diagram readable
- Expand Step 3 in the generation workflow to surface the ID naming convention (`api-server`, `api-server-text`) and remind Claude to verify uniqueness before output
## Test plan
- [ ] Skill triggers correctly on diagram-related requests
- [ ] Plugin validates: `npx nx run development-codebase-tools:validate`
- [ ] Markdownlint passes: 0 errors

</details>
<!-- claude-pr-description-end -->