### PR TITLE
feat(development-codebase-tools): add analyze-test-coverage skill

### DIFF
--- a/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
+++ b/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
@@ -27,6 +27,7 @@
     "./skills/analyze-dead-code",
     "./skills/analyze-migrations",
     "./skills/analyze-tech-debt",
+    "./skills/analyze-test-coverage",
     "./skills/audit-accessibility",
     "./skills/debug-issue",
     "./skills/diagram-excalidraw",

--- a/packages/plugins/development-codebase-tools/CLAUDE.md
+++ b/packages/plugins/development-codebase-tools/CLAUDE.md
@@ -13,6 +13,7 @@ This plugin provides codebase exploration, refactoring, and quality analysis too
 - **analyze-dead-code**: Find unused exports, unreachable modules, and dead files with confidence-ranked removal guidance
 - **analyze-migrations**: Statically analyze database migration files for safety issues (locks, data loss, missing rollbacks)
 - **analyze-tech-debt**: Identify and prioritize technical debt with remediation plans. Uses a structured 6-step execution process: scope the target, collect code signals (Glob/Grep for large files, nesting, TODO/FIXME/HACK, `any` types), examine git history (high-churn files via `git log`, chronic bug areas via `git blame`), assess test presence (test-to-source file ratio), score and prioritize items by ROI, and write a Debt Metrics Dashboard + Prioritized Roadmap. Allowed tools include `Bash(git blame:*)`.
+- **analyze-test-coverage**: Measure test coverage gaps and produce a prioritized list of what to test next
 - **audit-accessibility**: Audit UI components for WCAG 2.1 AA compliance, identifying violations by severity with fix guidance
 - **debug-issue**: Systematic debugging workflow — accepts any error report (message, stack trace, or vague symptom), locates the origin, gathers context, invokes the debug-assistant-agent for root-cause analysis, and validates the fix
 - **diagram-excalidraw**: Generate Excalidraw architecture diagrams from codebase analysis
@@ -90,6 +91,7 @@ development-codebase-tools/
 │   ├── analyze-dead-code/
 │   ├── analyze-migrations/
 │   ├── analyze-tech-debt/
+│   ├── analyze-test-coverage/
 │   ├── audit-accessibility/
 │   ├── debug-issue/
 │   ├── diagram-excalidraw/

--- a/packages/plugins/development-codebase-tools/README.md
+++ b/packages/plugins/development-codebase-tools/README.md
@@ -60,7 +60,7 @@ claude /plugin install development-codebase-tools
 "How does the authentication system work?"       # triggers explore-codebase
 "Create an architecture diagram of this system"  # triggers diagram-excalidraw
 "What technical debt exists in this module?"     # triggers analyze-tech-debt
-"What's our test coverage? Where should we focus?" # triggers analyze-test-coverage
+"What's our test coverage? Where should we focus?"  # triggers analyze-test-coverage
 "Run a type safety audit on this codebase"       # triggers strengthen-types
 "I'm getting a TypeError in the auth module"     # triggers debug-issue
 "This keeps crashing in production, help me fix it" # triggers debug-issue

--- a/packages/plugins/development-codebase-tools/README.md
+++ b/packages/plugins/development-codebase-tools/README.md
@@ -14,20 +14,21 @@ claude /plugin install development-codebase-tools
 
 ## Skills
 
-| Skill                   | Description                                                                                                                 |
-| ----------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| **analyze-bundle**      | Analyze web application bundle size — heaviest modules, tree-shaking gaps, duplicate packages, code-splitting opportunities |
-| **analyze-code**        | Multi-agent code explanation for architecture, patterns, security, and performance                                          |
-| **analyze-dead-code**   | Find unused exports, unreachable modules, and dead files with confidence-ranked removal guidance                            |
-| **analyze-migrations**  | Static safety analysis of database migration files (locks, data loss, rollback gaps)                                        |
-| **analyze-tech-debt**   | Identify and prioritize technical debt with remediation plans                                                               |
-| **audit-accessibility** | Audit UI components for WCAG 2.1 AA compliance with severity-grouped violations                                             |
-| **debug-issue**         | Systematic debugging workflow — from vague symptom to root cause analysis and validated fix                                 |
-| **diagram-excalidraw**  | Generate Excalidraw architecture diagrams from codebase analysis                                                            |
-| **explore-codebase**    | Deep codebase exploration and understanding                                                                                 |
-| **mermaid-diagram**     | Generate Mermaid diagrams from codebase analysis                                                                            |
-| **refactor-code**       | Comprehensive refactoring with safety checks and pattern application                                                        |
-| **strengthen-types**    | Audit and harden TypeScript type safety — find `any`, unsafe casts, and missing return types                                |
+| Skill                     | Description                                                                                                                 |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| **analyze-bundle**        | Analyze web application bundle size — heaviest modules, tree-shaking gaps, duplicate packages, code-splitting opportunities |
+| **analyze-code**          | Multi-agent code explanation for architecture, patterns, security, and performance                                          |
+| **analyze-dead-code**     | Find unused exports, unreachable modules, and dead files with confidence-ranked removal guidance                            |
+| **analyze-migrations**    | Static safety analysis of database migration files (locks, data loss, rollback gaps)                                        |
+| **analyze-tech-debt**     | Identify and prioritize technical debt with remediation plans                                                               |
+| **analyze-test-coverage** | Measure test coverage gaps and produce a prioritized list of what to test next                                              |
+| **audit-accessibility**   | Audit UI components for WCAG 2.1 AA compliance with severity-grouped violations                                             |
+| **debug-issue**           | Systematic debugging workflow — from vague symptom to root cause analysis and validated fix                                 |
+| **diagram-excalidraw**    | Generate Excalidraw architecture diagrams from codebase analysis                                                            |
+| **explore-codebase**      | Deep codebase exploration and understanding                                                                                 |
+| **mermaid-diagram**       | Generate Mermaid diagrams from codebase analysis                                                                            |
+| **refactor-code**         | Comprehensive refactoring with safety checks and pattern application                                                        |
+| **strengthen-types**      | Audit and harden TypeScript type safety — find `any`, unsafe casts, and missing return types                                |
 
 ## Agents
 
@@ -59,6 +60,7 @@ claude /plugin install development-codebase-tools
 "How does the authentication system work?"       # triggers explore-codebase
 "Create an architecture diagram of this system"  # triggers diagram-excalidraw
 "What technical debt exists in this module?"     # triggers analyze-tech-debt
+"What's our test coverage? Where should we focus?" # triggers analyze-test-coverage
 "Run a type safety audit on this codebase"       # triggers strengthen-types
 "I'm getting a TypeError in the auth module"     # triggers debug-issue
 "This keeps crashing in production, help me fix it" # triggers debug-issue

--- a/packages/plugins/development-codebase-tools/skills/analyze-test-coverage/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/analyze-test-coverage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Analyze test coverage gaps and prioritize what to test next. Use this skill whenever the user says "analyze test coverage", "what's our test coverage", "find gaps in test coverage", "which code isn't tested", "improve test coverage", "show me a coverage report", "coverage analysis", "where are we missing tests", "what's untested", "test coverage audit", or asks about coverage percentages or uncovered files. Also trigger when the user asks which areas to focus testing efforts on, or when they want to know what the test-writer agent should work on next.
-allowed-tools: Read, Glob, Grep, Bash(npm test:*), Bash(npx vitest:*), Bash(npx jest:*), Bash(npx c8:*), Bash(python -m pytest:*), Bash(go test:*), Bash(mvn:*), Bash(gradle:*), Bash(cat:*), Bash(find:*), Task(subagent_type:test-writer-agent)
+allowed-tools: Read, Glob, Grep, Bash(npm test:*), Bash(npm run:*), Bash(npx vitest:*), Bash(npx jest:*), Bash(npx c8:*), Bash(python -m pytest:*), Bash(go test:*), Bash(mvn:*), Bash(gradle:*), Bash(./gradlew:*), Task(subagent_type:test-writer-agent)
 model: sonnet
 ---
 

--- a/packages/plugins/development-codebase-tools/skills/analyze-test-coverage/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/analyze-test-coverage/SKILL.md
@@ -1,0 +1,126 @@
+---
+description: Analyze test coverage gaps and prioritize what to test next. Use this skill whenever the user says "analyze test coverage", "what's our test coverage", "find gaps in test coverage", "which code isn't tested", "improve test coverage", "show me a coverage report", "coverage analysis", "where are we missing tests", "what's untested", "test coverage audit", or asks about coverage percentages or uncovered files. Also trigger when the user asks which areas to focus testing efforts on, or when they want to know what the test-writer agent should work on next.
+allowed-tools: Read, Glob, Grep, Bash(npm test:*), Bash(npx vitest:*), Bash(npx jest:*), Bash(npx c8:*), Bash(python -m pytest:*), Bash(go test:*), Bash(mvn:*), Bash(gradle:*), Bash(cat:*), Bash(find:*), Task(subagent_type:test-writer-agent)
+model: sonnet
+---
+
+# Test Coverage Analyzer
+
+Measure where tests are missing, identify high-impact coverage gaps, and produce a prioritized action list — so the next test-writing session targets the code that matters most.
+
+## When to Activate
+
+- User asks about test coverage or coverage percentages
+- User wants to know which code isn't tested
+- User wants to find the highest-priority testing gaps
+- User is planning a testing sprint and needs direction
+- User asks what to pass to the test-writer agent
+
+## Step 1: Detect Project Setup
+
+Scan the project to identify language, test framework, and coverage tooling:
+
+**Language / framework detection (check in order):**
+
+| Signal file                                           | Stack                  | Coverage command                                                               |
+| ----------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------ |
+| `vitest.config.*` or `vite.config.*` with test key    | TypeScript/JS + Vitest | `npx vitest run --coverage`                                                    |
+| `jest.config.*` or `"jest"` in package.json           | TypeScript/JS + Jest   | `npx jest --coverage --coverageReporters=json-summary,text`                    |
+| `pyproject.toml` with `[tool.pytest]` or `pytest.ini` | Python + pytest        | `python -m pytest --cov --cov-report=term-missing --cov-report=json`           |
+| `go.mod`                                              | Go                     | `go test ./... -coverprofile=coverage.out && go tool cover -func=coverage.out` |
+| `pom.xml`                                             | Java + Maven/JaCoCo    | `mvn test jacoco:report -q`                                                    |
+| `build.gradle`                                        | Java + Gradle          | `./gradlew test jacocoTestReport`                                              |
+
+If multiple frameworks are detected (monorepo), scan for the subpackages and handle each separately.
+
+Check for existing coverage reports before running tools — they may be fresh:
+
+- `.coverage`, `coverage.json`, `coverage-summary.json`, `lcov.info`, `coverage.out` in common locations
+
+## Step 2: Run Coverage
+
+Run the coverage command detected in Step 1. If you can't determine the command, check `package.json` scripts for a `coverage`, `test:coverage`, or `test:cov` target and run that.
+
+**Important:** Run from the directory that contains the test config, not necessarily the repo root.
+
+If the coverage run fails (compilation error, missing deps, no tests), report the failure clearly with the exact error — don't silently skip. A project with zero passing tests is itself a critical finding.
+
+## Step 3: Parse the Report
+
+Extract file-level coverage data from whichever output format was produced:
+
+- **JSON summary** (`coverage-summary.json`): Read `total` and per-file `statements`, `branches`, `functions`, `lines` percentages
+- **LCOV** (`lcov.info`): Parse `DA:` (line hit/missed) and `BRH:` (branch hit/missed) records
+- **Go text output**: Parse `func coverage: X%` per package
+- **Terminal text** (pytest `--cov-report=term-missing`): Extract file paths and uncovered line ranges from the `MISS` column
+
+Build a table of files with their line coverage %, branch coverage %, and uncovered line ranges.
+
+## Step 4: Score and Rank Coverage Gaps
+
+Don't sort by raw line count. Sort by **criticality of what's untested**:
+
+**Criticality signals (check each uncovered file/function for these):**
+
+1. **Public API surface** — exported functions, class methods, REST/GraphQL handlers, CLI entry points. These are contracts that callers depend on.
+2. **Error-handling branches** — `catch` blocks, error returns, fallback paths. Untested error paths are where production incidents hide.
+3. **Business logic density** — files in `src/`, `lib/`, `domain/`, or `core/` with conditionals and state transformations. High cyclomatic complexity + low coverage = high risk.
+4. **Data boundaries** — input parsers, validators, serializers/deserializers. Untested boundary code produces silent corruption.
+5. **Security-adjacent code** — auth, permissions, rate-limiting, token handling.
+
+**Scoring heuristic (per file):**
+
+- Start with `(100 - line_coverage) * 0.5 + (100 - branch_coverage) * 0.5` as a base gap score
+- Multiply by 2× if the file exports public symbols
+- Multiply by 1.5× if the file contains `catch`, `error`, or `fallback` handlers
+- Multiply by 1.5× if the file path matches `auth`, `security`, `permission`, `token`, `payment`
+- Sort descending by final score
+
+## Step 5: Report
+
+Output two sections:
+
+### Coverage Summary
+
+```
+Overall: statements X%, branches X%, functions X%, lines X%
+Files scanned: N  |  Files at 0% coverage: M
+```
+
+Include a small table of the 10 worst-covered files (by raw line coverage), as context.
+
+### Prioritized Gap List
+
+For the **top 10 files by criticality score**, output:
+
+```
+## 1. src/auth/token-validator.ts  (branch coverage: 34%)
+   Uncovered: lines 45-67 (error path when token is expired), line 89 (refresh failure branch)
+   Why it matters: exported validateToken() is called at every API boundary; untested expiry/refresh paths are a common incident vector
+   Suggested test: unit test for expired token, forged token, and refresh-failure scenarios
+```
+
+Adjust the "why it matters" explanation based on the criticality signals found in Step 4.
+
+If any file has **0% coverage** and is in the public API or business logic layer, call it out prominently at the top as a critical gap regardless of its ranked position.
+
+## Step 6: Optional — Delegate to Test Writer
+
+If the user asks to also generate tests (e.g., "and write the tests" or "fix the top 3"), invoke the test-writer agent for the top N files from the prioritized list:
+
+Pass the agent:
+
+- The file path
+- The uncovered lines/branches identified above
+- The "why it matters" context
+- A note to focus on the error paths and branching scenarios, not just happy-path coverage
+
+## Options
+
+| Flag                 | Description                                                     |
+| -------------------- | --------------------------------------------------------------- |
+| `--target <path>`    | Limit analysis to a subdirectory or file                        |
+| `--min-coverage <N>` | Only report files below N% (default: 80)                        |
+| `--top <N>`          | How many files to include in the prioritized list (default: 10) |
+| `--fix`              | After reporting, invoke test-writer for the top 3 gaps          |
+| `--skip-run`         | Skip running coverage tools; parse existing reports only        |


### PR DESCRIPTION
## What gap this fills

The toolkit had `generate-tests` (writes tests on demand) and `analyze-tech-debt` (mentions coverage as one metric in a broader audit), but nothing for the **"where am I missing tests?"** question. This skill fills the gap between knowing tests are needed and knowing *which specific code paths to test first*.

## How it was identified

Coverage analysis was absent from the development workflow capability map. The `test` phase had test generation but no coverage measurement. Developers planning a testing sprint need a way to run coverage tools and get a prioritized action list — not raw lcov output.

## Design decisions

- **Criticality-based ranking** — gaps are ranked by the importance of what's untested (public exports, error branches, auth/security paths), not by raw uncovered line count. A 40%-covered auth validator is higher priority than a 0%-covered test fixture.
- **Framework auto-detection** — supports Vitest, Jest, pytest, Go, Maven/JaCoCo, Gradle. Checks for existing fresh reports before re-running tools.
- **Structured output** — each gap entry includes file path, uncovered lines/branches, and a "why it matters" explanation derived from the criticality signals.
- **Optional delegation** — `--fix` flag hands the top 3 gaps to `test-writer-agent` with the uncovered context pre-loaded.

## Example usage scenarios

- "What's our test coverage? Where should we focus our sprint?"
- "Which code in `src/auth/` isn't tested?"
- "Find the highest-risk coverage gaps and write tests for the top 3"
- "Show me a coverage report for the payment module"
- "We need to hit 80% coverage — what's left to test?"

## Test plan

- [ ] Vitest project: `npx vitest run --coverage` detected and run; JSON summary parsed
- [ ] Jest project: `--coverageReporters=json-summary,text` flags used; per-file data extracted
- [ ] Python/pytest project: `--cov-report=json` output parsed; missed lines shown
- [ ] Go project: `go test -coverprofile` + `go tool cover -func` output parsed
- [ ] Monorepo: multiple subpackages detected and handled separately
- [ ] Fresh report exists: `--skip-run` equivalent behavior (reads existing file)
- [ ] Coverage run fails: error reported clearly, not silently skipped
- [ ] `--fix` flag: `test-writer-agent` invoked with uncovered context for top 3 files
- [ ] `--target <path>`: analysis scoped to subdirectory
- [ ] Validation passes: `node scripts/validate-plugin.cjs packages/plugins/development-codebase-tools`

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## What gap this fills
The toolkit had `generate-tests` (writes tests on demand) and `analyze-tech-debt` (mentions coverage as one metric in a broader audit), but nothing for the **"where am I missing tests?"** question. This skill fills the gap between knowing tests are needed and knowing *which specific code paths to test first*.
## How it was identified
Coverage analysis was absent from the development workflow capability map. The `test` phase had test generation but no coverage measurement. Developers planning a testing sprint need a way to run coverage tools and get a prioritized action list — not raw lcov output.
## Design decisions
- **Criticality-based ranking** — gaps are ranked by the importance of what's untested (public exports, error branches, auth/security paths), not by raw uncovered line count. A 40%-covered auth validator is higher priority than a 0%-covered test fixture.
- **Framework auto-detection** — supports Vitest, Jest, pytest, Go, Maven/JaCoCo, Gradle. Checks for existing fresh reports before re-running tools.
- **Structured output** — each gap entry includes file path, uncovered lines/branches, and a "why it matters" explanation derived from the criticality signals.
- **Optional delegation** — `--fix` flag hands the top 3 gaps to `test-writer-agent` with the uncovered context pre-loaded.
## Changes
| File | Change |
|------|--------|
| `packages/plugins/development-codebase-tools/skills/analyze-test-coverage/SKILL.md` | New skill definition (126 lines) with framework auto-detection, criticality-based scoring, and structured output |
| `packages/plugins/development-codebase-tools/.claude-plugin/plugin.json` | Register `analyze-test-coverage` in skills array |
| `packages/plugins/development-codebase-tools/CLAUDE.md` | Add skill to component list and file structure |
| `packages/plugins/development-codebase-tools/README.md` | Add skill to skills table and example usage section |
## What the skill does
1. **Detect** — auto-detect language, test framework, and coverage tooling (Vitest, Jest, pytest, Go, Maven/JaCoCo, Gradle); check for fresh existing reports before re-running
2. **Run** — execute the appropriate coverage command from the correct directory
3. **Parse** — extract file-level coverage data from JSON summary, LCOV, Go text output, or terminal text
4. **Score** — rank gaps by criticality of what's untested (public API surface, error branches, business logic density, data boundaries, security-adjacent code) rather than raw uncovered line count
5. **Report** — produce a coverage summary plus a prioritized gap list with file paths, uncovered lines, and "why it matters" explanations
6. **Delegate** — optional `--fix` flag hands top gaps to `test-writer-agent` with uncovered context pre-loaded
## Example usage scenarios
- "What's our test coverage? Where should we focus our sprint?"
- "Which code in `src/auth/` isn't tested?"
- "Find the highest-risk coverage gaps and write tests for the top 3"
- "Show me a coverage report for the payment module"
- "We need to hit 80% coverage — what's left to test?"
## Test plan
- [ ] Vitest project: `npx vitest run --coverage` detected and run; JSON summary parsed
- [ ] Jest project: `--coverageReporters=json-summary,text` flags used; per-file data extracted
- [ ] Python/pytest project: `--cov-report=json` output parsed; missed lines shown
- [ ] Go project: `go test -coverprofile` + `go tool cover -func` output parsed
- [ ] Monorepo: multiple subpackages detected and handled separately
- [ ] Fresh report exists: reads existing coverage file instead of re-running
- [ ] Coverage run fails: error reported clearly, not silently skipped
- [ ] `--fix` flag: `test-writer-agent` invoked with uncovered context for top 3 files
- [ ] `--target <path>`: analysis scoped to subdirectory
- [ ] Validation passes: `node scripts/validate-plugin.cjs packages/plugins/development-codebase-tools`

</details>
<!-- claude-pr-description-end -->