### PR TITLE
improve(development-codebase-tools): tune skill explore-codebase

### DIFF
--- a/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
+++ b/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-codebase-tools",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Codebase exploration, refactoring, and quality analysis",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/development-codebase-tools/skills/explore-codebase/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/explore-codebase/SKILL.md
@@ -19,11 +19,9 @@ Build comprehensive understanding of codebase areas before implementation or to 
 
 ## Quick Process
 
-1. **Identify the topic** from user's natural language
-2. **Map relevant files** using Glob and Grep
-3. **Trace dependencies** and integration points
-4. **Identify patterns** and conventions
-5. **Document findings** for implementation work
+1. **Parse the request** — extract `topic`, `files` (optional), and `focus` (optional) from the user's message
+2. **Delegate** — invoke context-loader-agent with the extracted parameters
+3. **Present findings** — format the agent output using the Output Format section below
 
 ## Input Parsing
 
@@ -35,7 +33,13 @@ Extract from user's request:
 
 ## Delegation
 
-Invoke the **context-loader-agent** agent with extracted parameters for comprehensive analysis.
+Invoke **context-loader-agent** and pass the extracted parameters:
+
+- `topic`: the main area to explore
+- `files`: specific files mentioned (omit if none)
+- `focus`: the aspect to emphasize (omit if not specified)
+
+The agent handles file discovery, dependency tracing, pattern identification, and analysis.
 
 ## Output Format
 
@@ -48,6 +52,16 @@ Return structured analysis:
 - **Data Flow**: How data moves through the system
 - **Gotchas**: Non-obvious behaviors and pitfalls
 - **Implementation Notes**: Key considerations for new work
+
+## Examples
+
+```
+"How does the authentication flow work?"
+"Where is the API rate limiting implemented?"
+"Show me how data flows from the UI to the database"
+"Explain the plugin architecture before I add a new one"
+"Trace a request from the controller to the database"
+```
 
 ## Workflow Integration
 


### PR DESCRIPTION
## Summary

- **Quick Process rewrite**: The original 5 steps described what the `context-loader-agent` does internally, not what the skill's orchestration flow is. Replaced with a 3-step process that accurately reflects the skill's role: parse request → delegate to agent → present findings.
- **Delegation section expanded**: Added explicit parameter-passing guidance (`topic`, `files`, `focus`) so implementors know what to send to the agent, rather than the vague "with extracted parameters".
- **Examples section added**: Added 5 concrete trigger phrases consistent with the description field, matching the pattern used by sibling skills like `analyze-code`.

## Test plan

- [ ] Verify `markdownlint-cli2` reports 0 errors on the modified file
- [ ] Verify `npx nx run development-codebase-tools:validate` passes
- [ ] Manually invoke the skill with "how does the authentication flow work?" and confirm it correctly parses topic and delegates to context-loader-agent

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Rewrites the `explore-codebase` skill prompt to accurately reflect its orchestration role and provide clearer delegation guidance for implementors.
## Changes
- **Replaced Quick Process**: Swapped the 5-step process (which described `context-loader-agent` internals) with a 3-step flow matching the skill's actual responsibility: parse request → delegate to agent → present findings
- **Expanded Delegation section**: Added explicit parameter-passing guidance (`topic`, `files`, `focus`) so the handoff to `context-loader-agent` is unambiguous
- **Added Examples section**: Included 5 concrete trigger phrases consistent with the skill description, matching the pattern used by sibling skills like `analyze-code`
- **Version bump**: Plugin version bumped from 2.2.0 → 2.2.1 (patch — prompt-only change, no functional changes)
## Notes
- Single skill file change (`packages/plugins/development-codebase-tools/skills/explore-codebase/SKILL.md`)
- No functional changes to the agent itself — only the skill prompt was updated

</details>
<!-- claude-pr-description-end -->