### PR TITLE
feat(uniswap-integrations): add investigate-incident skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,7 +227,7 @@ All plugins follow semantic versioning (semver). Key versioning rules:
 | development-pr-workflow    | 2.1.0   |
 | development-productivity   | 2.4.0   |
 | spec-workflow              | 2.0.1   |
-| uniswap-integrations       | 2.3.0   |
+| uniswap-integrations       | 2.4.0   |
 
 **Note:** Keep this table updated when versions change.
 

--- a/packages/plugins/uniswap-integrations/.claude-plugin/plugin.json
+++ b/packages/plugins/uniswap-integrations/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uniswap-integrations",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "External service integrations (Linear, Notion, Nx, Chrome DevTools, GitHub, Slack, Amplitude, Datadog) and deployment orchestration",
   "author": {
     "name": "Uniswap Labs",
@@ -24,6 +24,7 @@
   "skills": [
     "./skills/daily-standup",
     "./skills/github-setup",
+    "./skills/investigate-incident",
     "./skills/orchestrate-deployment",
     "./skills/refine-linear-task"
   ],

--- a/packages/plugins/uniswap-integrations/CLAUDE.md
+++ b/packages/plugins/uniswap-integrations/CLAUDE.md
@@ -10,6 +10,7 @@ This plugin provides external service integrations for Claude Code, bundling MCP
 
 - **daily-standup**: Generate daily standup reports from GitHub and Linear activity
 - **github-setup**: Configure GitHub Personal Access Token for the GitHub MCP server
+- **investigate-incident**: Investigate production incidents using Datadog logs, metrics, and traces
 - **orchestrate-deployment**: Orchestrate deployment pipelines with CI/CD configuration
 - **refine-linear-task**: Refine and enhance Linear task descriptions
 
@@ -102,6 +103,7 @@ uniswap-integrations/
 ├── skills/
 │   ├── daily-standup/
 │   ├── github-setup/
+│   ├── investigate-incident/
 │   ├── orchestrate-deployment/
 │   └── refine-linear-task/
 ├── agents/

--- a/packages/plugins/uniswap-integrations/README.md
+++ b/packages/plugins/uniswap-integrations/README.md
@@ -32,12 +32,13 @@ This plugin bundles the following MCP (Model Context Protocol) servers:
 
 ## Skills
 
-| Skill                      | Description                                                    |
-| -------------------------- | -------------------------------------------------------------- |
-| **daily-standup**          | Generate daily standup reports from GitHub and Linear activity |
-| **github-setup**           | Configure GitHub Personal Access Token for MCP server          |
-| **orchestrate-deployment** | Orchestrate deployment pipelines with CI/CD configuration      |
-| **refine-linear-task**     | Refine and enhance Linear task descriptions                    |
+| Skill                      | Description                                                              |
+| -------------------------- | ------------------------------------------------------------------------ |
+| **daily-standup**          | Generate daily standup reports from GitHub and Linear activity           |
+| **github-setup**           | Configure GitHub Personal Access Token for MCP server                    |
+| **investigate-incident**   | Investigate production incidents using Datadog logs, metrics, and traces |
+| **orchestrate-deployment** | Orchestrate deployment pipelines with CI/CD configuration                |
+| **refine-linear-task**     | Refine and enhance Linear task descriptions                              |
 
 ## Agents
 
@@ -53,6 +54,7 @@ This plugin bundles the following MCP (Model Context Protocol) servers:
 # Use skills contextually
 "Generate my daily standup"                    # triggers daily-standup skill
 "Help me deploy to staging"                    # triggers orchestrate-deployment skill
+"Investigate the high error rate on api-gateway"  # triggers investigate-incident skill
 "Refine this Linear task description"          # triggers refine-linear-task skill
 ```
 
@@ -78,7 +80,6 @@ Some MCP servers require authentication:
 #### Slack Setup
 
 1. **Obtain a Slack Bot Token**:
-
    - Visit <https://ai-toolkit-slack-oauth-backend.vercel.app/>
    - Click "Add to Slack" and authorize the app
    - Copy the Access Token (starts with `xoxp-...`)
@@ -109,7 +110,6 @@ For detailed Slack setup documentation, see: <https://www.notion.so/uniswaplabs/
 #### GitHub Setup
 
 1. **Create a Personal Access Token**:
-
    - Go to <https://github.com/settings/tokens?type=beta>
    - Click "Generate new token" (Fine-grained recommended)
    - Set permissions: Contents (R/W), Issues (R/W), Pull requests (R/W)

--- a/packages/plugins/uniswap-integrations/skills/investigate-incident/SKILL.md
+++ b/packages/plugins/uniswap-integrations/skills/investigate-incident/SKILL.md
@@ -1,0 +1,100 @@
+---
+description: Investigate production incidents using Datadog. Use when user says "what's causing this alert", "investigate production incident", "root cause analysis for production error", "debug production issue", "what caused this outage", "analyze production logs", "triage production error", "why is the service down", "production is throwing errors", or "help me understand this incident". Always use this skill when diagnosing production issues, on-call alerts, or service degradations that require querying logs, metrics, or traces.
+allowed-tools: Task(mcp__datadog__*), Read, Glob, WebSearch
+model: sonnet
+---
+
+# Incident Investigator
+
+Investigate production incidents by querying Datadog for logs, metrics, and traces, then synthesizing findings into a structured root-cause report.
+
+## When to Activate
+
+- On-call alert triggered and developer needs to understand what's happening
+- Service degradation, error spike, or latency increase detected
+- User asks "what's causing this?" or "why is X failing in production?"
+- Post-incident root cause analysis needed
+- Monitoring dashboard shows anomaly requiring investigation
+
+## Steps
+
+1. **Gather incident context** — confirm the affected service, error message or alert name, and approximate start time. If the user hasn't provided a time range, default to the last hour. Ask for any missing critical context before querying.
+
+2. **Query logs** — search Datadog logs for error patterns in the incident window. Filter by service name and `status:error`. Surface the top recurring error messages and stack traces. Note frequency and distribution over time to establish whether the issue is steady-state or spiking.
+
+3. **Check metrics and monitors** — retrieve error rate, latency (p50/p95/p99), and saturation metrics (CPU, memory, throughput) for the affected service. Check for triggered monitors around the incident start time to correlate alert onset with metric changes.
+
+4. **Pull traces** — look up traces for failing requests to identify where in the call chain the failure originates. Note slow spans, timeouts, and downstream service dependencies that may indicate the root cause location.
+
+5. **Correlate events** — search for deployment events, configuration changes, or upstream service issues in the same window. A deploy or config push immediately preceding the error onset is strong evidence of causation.
+
+6. **Generate report** — synthesize findings into a structured incident report with timeline, root cause, confidence level, and actionable remediation steps.
+
+## Output Format
+
+**Incident Summary**
+
+- What happened, when it started, and estimated user/system impact
+
+**Timeline**
+
+- Chronological events: deploys, config changes, error onset, monitor triggers
+
+**Root Cause** _(High / Medium / Low confidence)_
+
+- Primary cause with supporting evidence from logs, metrics, and traces
+
+**Evidence**
+
+- Key log snippets showing the error pattern
+- Metric anomalies (e.g., "error rate jumped from 0.1% to 12% at 14:32 UTC")
+- Relevant trace IDs for further inspection
+
+**Next Steps**
+
+- Immediate remediation actions (rollback, config change, scaling)
+- Follow-up investigation items if root cause is uncertain
+- Suggested post-mortem tasks
+
+## Parameters
+
+| Parameter  | Description                                           | Default           |
+| ---------- | ----------------------------------------------------- | ----------------- |
+| `service:` | Datadog service name to investigate                   | (prompt if blank) |
+| `since:`   | Start of incident window (ISO 8601 or relative: `1h`) | `1h ago`          |
+| `until:`   | End of incident window                                | `now`             |
+| `error:`   | Specific error message or alert name to focus on      | (optional)        |
+| `env:`     | Deployment environment (`prod`, `staging`)            | `prod`            |
+
+## Usage
+
+Quick triage from an alert:
+
+```
+"Investigate the high error rate alert on the swap-router service"
+```
+
+With explicit time range:
+
+```
+"Root cause analysis for production error since:2024-01-15T14:00:00Z until:2024-01-15T15:30:00Z service:api-gateway"
+```
+
+Post-incident analysis:
+
+```
+"What caused the outage on the pricing service around 2pm yesterday?"
+```
+
+Scoped to a specific error:
+
+```
+"Triage production error 'upstream connect error or disconnect/reset before headers' on service:routing env:prod"
+```
+
+## Notes
+
+- Requires Datadog MCP server configured in the uniswap-integrations plugin
+- If traces are unavailable, the investigation focuses on logs and metrics
+- Use `env:staging` to investigate pre-production incidents before they reach prod
+- Confidence level in the root cause reflects evidence quality — "Low" means further investigation is recommended before acting


### PR DESCRIPTION
## Summary

- Adds `investigate-incident` skill to the `uniswap-integrations` plugin
- Fills the monitoring/observability gap — no skill existed for the production incident investigation phase of the development workflow
- Leverages the Datadog MCP server (added in DEV-266) to query logs, metrics, traces, and monitors
- Bumps plugin version to v2.4.0

## Gap Being Filled

The development workflow has skills for every phase except **monitoring** — there was no way to ask Claude to investigate a production incident. This skill closes that gap by guiding developers through a structured investigation using Datadog.

## How It Was Identified

Backlog analysis from the `enhance-ai-toolkit` job. The monitoring/observability gap was marked high priority and the Datadog MCP infrastructure was already in place.

## Example Usage Scenarios

```
"Investigate the high error rate alert on the swap-router service"
```

```
"What caused the outage on the pricing service around 2pm yesterday?"
```

```
"Root cause analysis for production error since:2024-01-15T14:00:00Z until:2024-01-15T15:30:00Z service:api-gateway"
```

```
"Triage production error 'upstream connect error' on service:routing env:prod"
```

## Skill Design

The skill walks through six steps:
1. Gather incident context (service, time range, error)
2. Query Datadog logs for error patterns
3. Check metrics and triggered monitors
4. Pull traces for failing requests
5. Correlate with deployment/config events
6. Generate structured report with root cause (confidence-rated), timeline, evidence, and remediation steps

## Test Plan

- [ ] Trigger with "investigate production incident" — skill activates
- [ ] Trigger with "what's causing this alert" — skill activates
- [ ] Trigger with "root cause analysis for production error" — skill activates
- [ ] `validate-plugin.cjs` passes for `uniswap-integrations`
- [ ] `markdownlint-cli2` passes with 0 errors
- [ ] Prettier reports no changes (or reformats cleanly)
- [ ] Skill appears in `/plugin list` after installing `uniswap-integrations@next`
- [ ] Plugin version bumped to 2.4.0 in `plugin.json`

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
- Add `investigate-incident` skill to the `uniswap-integrations` plugin for structured production incident investigation via Datadog
- Fills the monitoring/observability gap in the development workflow — no skill previously existed for on-call triage or root cause analysis
- Leverages the Datadog MCP server (added in #442) to query logs, metrics, traces, and monitors
- Bump plugin version from 2.3.0 to 2.4.0
## Changes
- **New skill** `skills/investigate-incident/SKILL.md` — six-step investigation workflow: gather context, query logs, check metrics/monitors, pull traces, correlate events, generate structured report with confidence-rated root cause
- **plugin.json** — register the new skill and bump version to 2.4.0
- **CLAUDE.md** — add skill to component list and file structure tree
- **README.md** — add skill to the skills table and usage examples
## Notes
- Requires Datadog MCP server to be configured (ships with this plugin since v2.3.0)
- Skill uses `model: sonnet` and scopes tool access to `Task(mcp__datadog__*)`, `Read`, `Glob`, `WebSearch`
## Test plan
- [ ] Trigger with "investigate production incident" — skill activates
- [ ] Trigger with "what's causing this alert" — skill activates
- [ ] Trigger with "root cause analysis for production error" — skill activates
- [ ] `validate-plugin.cjs` passes for `uniswap-integrations`
- [ ] `markdownlint-cli2` passes with 0 errors
- [ ] Plugin version is 2.4.0 in `plugin.json`

</details>
<!-- claude-pr-description-end -->