### PR TITLE
feat(development-codebase-tools): add skill analyze-dead-code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,7 +226,7 @@ All plugins follow semantic versioning (semver). Key versioning rules:
 | Plugin                     | Version |
 | -------------------------- | ------- |
 | claude-setup               | 1.0.4   |
-| development-codebase-tools | 2.2.0   |
+| development-codebase-tools | 2.5.0   |
 | development-planning       | 2.0.1   |
 | development-pr-workflow    | 2.1.0   |
 | development-productivity   | 2.4.0   |

--- a/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
+++ b/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-codebase-tools",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "description": "Codebase exploration, refactoring, and quality analysis",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
+++ b/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-codebase-tools",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Codebase exploration, refactoring, and quality analysis",
   "author": {
     "name": "Uniswap Labs",
@@ -23,6 +23,7 @@
   ],
   "skills": [
     "./skills/analyze-code",
+    "./skills/analyze-dead-code",
     "./skills/analyze-tech-debt",
     "./skills/debug-issue",
     "./skills/diagram-excalidraw",

--- a/packages/plugins/development-codebase-tools/CLAUDE.md
+++ b/packages/plugins/development-codebase-tools/CLAUDE.md
@@ -9,6 +9,7 @@ This plugin provides codebase exploration, refactoring, and quality analysis too
 ### Skills (./skills/)
 
 - **analyze-code**: Multi-agent code explanation for architecture, patterns, security, and performance
+- **analyze-dead-code**: Find unused exports, unreachable modules, and dead files with confidence-ranked removal guidance
 - **analyze-tech-debt**: Identify and prioritize technical debt with remediation plans
 - **debug-issue**: Systematic debugging workflow — accepts any error report (message, stack trace, or vague symptom), locates the origin, gathers context, invokes the debug-assistant-agent for root-cause analysis, and validates the fix
 - **diagram-excalidraw**: Generate Excalidraw architecture diagrams from codebase analysis
@@ -82,6 +83,7 @@ development-codebase-tools/
 │   └── plugin.json
 ├── skills/
 │   ├── analyze-code/
+│   ├── analyze-dead-code/
 │   ├── analyze-tech-debt/
 │   ├── debug-issue/
 │   ├── diagram-excalidraw/

--- a/packages/plugins/development-codebase-tools/README.md
+++ b/packages/plugins/development-codebase-tools/README.md
@@ -14,15 +14,16 @@ claude /plugin install development-codebase-tools
 
 ## Skills
 
-| Skill                  | Description                                                                                  |
-| ---------------------- | -------------------------------------------------------------------------------------------- |
-| **analyze-code**       | Multi-agent code explanation for architecture, patterns, security, and performance           |
-| **analyze-tech-debt**  | Identify and prioritize technical debt with remediation plans                                |
-| **debug-issue**        | Systematic debugging workflow — from vague symptom to root cause analysis and validated fix  |
-| **diagram-excalidraw** | Generate Excalidraw architecture diagrams from codebase analysis                             |
-| **explore-codebase**   | Deep codebase exploration and understanding                                                  |
-| **refactor-code**      | Comprehensive refactoring with safety checks and pattern application                         |
-| **strengthen-types**   | Audit and harden TypeScript type safety — find `any`, unsafe casts, and missing return types |
+| Skill                  | Description                                                                                      |
+| ---------------------- | ------------------------------------------------------------------------------------------------ |
+| **analyze-code**       | Multi-agent code explanation for architecture, patterns, security, and performance               |
+| **analyze-dead-code**  | Find unused exports, unreachable modules, and dead files with confidence-ranked removal guidance |
+| **analyze-tech-debt**  | Identify and prioritize technical debt with remediation plans                                    |
+| **debug-issue**        | Systematic debugging workflow — from vague symptom to root cause analysis and validated fix      |
+| **diagram-excalidraw** | Generate Excalidraw architecture diagrams from codebase analysis                                 |
+| **explore-codebase**   | Deep codebase exploration and understanding                                                      |
+| **refactor-code**      | Comprehensive refactoring with safety checks and pattern application                             |
+| **strengthen-types**   | Audit and harden TypeScript type safety — find `any`, unsafe casts, and missing return types     |
 
 ## Agents
 
@@ -57,6 +58,7 @@ claude /plugin install development-codebase-tools
 "Run a type safety audit on this codebase"       # triggers strengthen-types
 "I'm getting a TypeError in the auth module"     # triggers debug-issue
 "This keeps crashing in production, help me fix it" # triggers debug-issue
+"Find all dead code and unused exports"          # triggers analyze-dead-code
 ```
 
 ## License

--- a/packages/plugins/development-codebase-tools/skills/analyze-dead-code/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/analyze-dead-code/SKILL.md
@@ -1,0 +1,204 @@
+---
+description: Find and remove dead code — unused exports, unreachable modules, and stale files. Always use this skill whenever the user says "find dead code", "remove unused code", "clean up unused exports", "what code can we delete", "detect unreachable code", "what files are no longer used", "prune dead code", "unused exports cleanup", "find unused variables or functions", "what's safe to delete", "trim the codebase", "find unused imports", "identify unused dependencies", "dead code audit", or asks which symbols, files, or packages can be safely removed. Also trigger when the user is preparing a major refactor or cleanup sprint and wants to reduce surface area first.
+allowed-tools: Read, Glob, Grep, Bash(npx knip:*), Bash(npx ts-prune:*), Bash(npx depcheck:*), Bash(python -m vulture:*), Bash(go build:*), Bash(deadcode:*), Bash(npm run:*), Bash(find:*), Bash(git log:*)
+model: sonnet
+---
+
+# Dead Code Analyzer
+
+Find unused exports, unreachable modules, and dead files across your codebase — so cleanup is targeted and confident, not a guessing game.
+
+## When to Activate
+
+- User wants to know what code can be safely deleted
+- Pre-refactoring cleanup to reduce surface area before making changes
+- Post-feature-removal to find leftover artifacts
+- Bundle size or maintenance burden is growing and unused code may be responsible
+- Preparing a cleanup sprint and need to prioritize what to remove
+
+## Step 1: Detect Stack and Choose Scanner
+
+Scan the project to determine language and which dead code tool to use:
+
+| Signal file                                   | Stack      | Preferred scanner                         |
+| --------------------------------------------- | ---------- | ----------------------------------------- |
+| `tsconfig.json` or `*.ts` files               | TypeScript | `knip` (preferred), `ts-prune` (fallback) |
+| `package.json` without TypeScript             | JavaScript | `knip`                                    |
+| `pyproject.toml`, `setup.py`, or `*.py` files | Python     | `vulture`                                 |
+| `go.mod`                                      | Go         | `deadcode` or `go vet`                    |
+
+Check for existing scanner config files (`knip.json`, `knip.config.ts`, `.knip.json`) — if found, use them as-is so project customizations are respected.
+
+Verify the preferred tool is available before running:
+
+```
+npx knip --version   # TypeScript/JavaScript
+python -m vulture --version  # Python
+deadcode -version    # Go
+```
+
+If no scanner is available and installing isn't appropriate, fall back to static grep analysis (Step 2b below).
+
+## Step 2: Run the Scanner
+
+### 2a: With a Scanner
+
+**knip** (preferred for TypeScript/JavaScript):
+
+```bash
+npx knip --reporter json 2>/dev/null
+```
+
+If JSON output fails or produces errors, run without `--reporter json` and parse text output.
+
+**ts-prune** (TypeScript fallback):
+
+```bash
+npx ts-prune 2>/dev/null
+```
+
+Ignore lines containing `(used in module)` — those are internal usages. Only report symbols not referenced outside their declaring file.
+
+**vulture** (Python):
+
+```bash
+python -m vulture . --min-confidence 80 2>/dev/null
+```
+
+**deadcode / go vet** (Go):
+
+```bash
+deadcode -test ./... 2>/dev/null || go build ./... 2>&1 | grep "declared and not used"
+```
+
+### 2b: Static Grep Fallback
+
+When no scanner is available, use grep to find exported symbols that are never imported:
+
+- For TypeScript/JavaScript: search for `export (const|function|class|type|interface)` declarations in `src/`, `lib/`, `packages/` directories, then grep for each name across the rest of the codebase to check if it's imported anywhere.
+- Limit the search to files in main source directories to reduce noise from test fixtures and generated files.
+
+This approach has higher false positive rates than dedicated tools — annotate findings with `[review before removing]` accordingly.
+
+## Step 3: Classify Findings
+
+Group scanner output into three categories. Understanding the category helps developers decide how aggressively to act.
+
+**Unused exports** — Symbols declared with `export` that are never imported anywhere in the project. These are the highest-confidence removals: the symbol was intended for reuse but nothing consumes it.
+
+**Unused files** — Entire source files not reachable from any entry point. Before flagging as dead, verify the entry points the scanner used (check `package.json#main`, `package.json#exports`, `tsconfig.json#include`, and framework conventions like Next.js pages or Vite entry points). Entry-point misconfiguration is a common source of false positives here.
+
+**Unused dependencies** — Packages listed in `package.json#dependencies` or `devDependencies` with no references in source. Run `npx depcheck` to surface these if not already included in the main scanner's output.
+
+For each finding, check git recency to inform confidence. A file last touched 18 months ago with zero recent activity is a stronger removal candidate than one touched last week:
+
+```bash
+git log --oneline -3 -- <file-path>
+```
+
+## Step 4: Filter False Positives
+
+Dead code detectors flag things that are legitimately "unused by static analysis" but are used at runtime. Before reporting, screen each finding for these patterns and downgrade confidence when found:
+
+- **Dynamic imports**: `require(variable)`, `import(expression)` — the scanner can't trace the runtime path
+- **Barrel re-exports**: `index.ts` files that re-export symbols for external package consumers
+- **Test helpers and fixtures**: modules used by test runners but not imported as code
+- **Type-only exports**: TypeScript `interface` / `type` used by downstream packages via `.d.ts` files
+- **Framework conventions**: Next.js page components, Vite plugins, Express middleware — consumed by name convention rather than import
+- **CLI binaries**: scripts registered in `package.json#bin`
+
+Mark findings that match any of these with `[review before removing]` in the report. Mark findings with none of these signals as `[safe to remove]`.
+
+## Step 5: Report
+
+Output a structured report in two sections.
+
+### Dead Code Summary
+
+```
+Unused exports:     N symbols across M files
+Unused files:       P files
+Unused packages:    R packages
+Estimated removable lines: ~S lines
+```
+
+### Findings by Confidence
+
+List findings sorted by confidence level (high first), then by cleanup value (largest files and most symbols first within each level):
+
+```
+## High confidence (safe to remove)
+
+### src/utils/legacyFormatter.ts — entire file unused
+   Last commit: 2024-03-15 (14 months ago)
+   Exported symbols: formatLegacyDate, parseLegacyTimestamp, LEGACY_FORMATS
+   Action: Delete file; remove any imports in src/index.ts
+
+### src/api/v1Routes.ts — 4 of 6 exports unused
+   Unused: handleV1Swap, buildV1Quote, V1_ROUTE_MAP, routeV1Request
+   Used:   formatV1Error, V1_ERROR_CODES (keep these)
+   Action: Remove the 4 unused exports; keep the file
+
+## Review before removing (potential false positives)
+
+### src/types/externalContract.ts — all exports unused internally
+   Reason: re-export barrel; may be consumed by external packages via package.json#exports
+   Action: Confirm with package maintainer before removing
+```
+
+If any file has been fully unused for 6+ months and sits in a core source directory, call it out prominently — it's the highest-value cleanup target regardless of its ranked position.
+
+### Unused Dependencies
+
+```
+Remove from dependencies:    lodash, uuid, moment
+Remove from devDependencies: @types/moment, ts-jest
+Command: npm uninstall lodash uuid moment @types/moment ts-jest
+```
+
+## Step 6: Optional — Generate Removal Plan
+
+If the user asks to also generate a cleanup plan ("and remove them", "give me a plan", "how do I clean this up"), produce an ordered removal sequence that minimizes the chance of introducing breakage:
+
+1. Remove unused `devDependencies` first — no runtime impact
+2. Uninstall unused `dependencies` after confirming no dynamic `require()` calls reference them
+3. Delete fully-unused files starting with leaf modules (files that no other file imports)
+4. Remove unused exports from files that have a mix of used and unused symbols
+
+Output the sequence as a numbered checklist the developer can execute one step at a time. Each step should take less than 5 minutes — don't bundle too much into one step.
+
+## Options
+
+| Flag              | Description                                                          |
+| ----------------- | -------------------------------------------------------------------- |
+| `--target <path>` | Limit scan to a subdirectory or package                              |
+| `--tool <name>`   | Force a specific scanner (`knip`, `ts-prune`, `vulture`, `deadcode`) |
+| `--include-deps`  | Also scan `package.json` dependencies (runs `depcheck`)              |
+| `--skip-git`      | Skip git-log recency checks                                          |
+| `--fix`           | After reporting, generate a prioritized removal plan                 |
+
+## Usage Examples
+
+Full codebase scan:
+
+```
+"Find all dead code in this project"
+```
+
+Scoped to a subdirectory:
+
+```
+"What unused exports are in the packages/core directory?"
+```
+
+With cleanup plan:
+
+```
+"Audit dead code and give me a removal plan I can follow"
+```
+
+Pre-refactor sweep:
+
+```
+"I'm about to refactor the auth module — what unused code should I remove first?"
+```


### PR DESCRIPTION
## What gap this fills

Every mature codebase accumulates dead code: exported symbols no one imports, whole files unreachable from any entry point, and npm packages listed in `package.json` that nothing actually uses. The existing `analyze-tech-debt` skill surfaces this broadly as part of wider debt analysis, but there's no focused, actionable skill that:

- Runs the right static scanner for the project's language stack
- Classifies findings by type (unused exports / unused files / unused dependencies)
- Filters false positives before the developer sees them (dynamic imports, barrel re-exports, framework conventions)
- Labels each finding with a confidence level so developers know whether to act immediately or verify first

## How it was identified

Capability map analysis revealed that the development lifecycle has tools for exploring, planning, implementing, testing, reviewing, and analyzing security/performance/debt, but nothing specifically targeting dead code removal as a first-class workflow. Dead code cleanup is a common pre-refactor step and a frequent maintenance request, and it deserves its own structured skill.

## What this adds

**`analyze-dead-code`** in `development-codebase-tools` (v2.3.0):

- **Stack detection** — reads `tsconfig.json`, `package.json`, `pyproject.toml`, `go.mod` to pick the right scanner
- **Scanner integration** — knip (preferred for TS/JS), ts-prune (fallback), vulture (Python), deadcode/go vet (Go), plus a static grep fallback when no tool is available
- **Three finding categories** — unused exports, unused files, unused package dependencies
- **False positive filtering** — screens for dynamic imports, barrel re-exports, framework conventions (Next.js pages, Vite plugins), CLI binaries, and type-only exports before reporting
- **Git recency enrichment** — annotates findings with last-commit date so staleness informs removal priority
- **Confidence-ranked report** — `[safe to remove]` vs `[review before removing]` with per-finding action steps
- **Optional removal plan** — ordered sequence for `--fix` that minimizes breakage risk (devDeps first, then leaf files, then mixed-export files)

## Example usage scenarios

```
"Find all dead code in this project"
"What unused exports are in packages/core?"
"Audit dead code and give me a removal plan I can follow"
"I'm about to refactor the auth module — what unused code should I remove first?"
```

## Test plan

- [ ] Trigger phrases from description activate the skill in a TypeScript project
- [ ] Skill correctly detects knip availability and runs it; falls back to ts-prune when knip is absent
- [ ] Findings are classified into the three categories (exports, files, dependencies)
- [ ] A barrel `index.ts` file appears in the "review before removing" section, not "safe to remove"
- [ ] A file last committed 18+ months ago appears before one last committed last week in the ranked output
- [ ] `--fix` flag produces an ordered removal checklist
- [ ] Skill runs without errors on a Python project (vulture) and a Go project (deadcode)
- [ ] Plugin validates with `node scripts/validate-plugin.cjs packages/plugins/development-codebase-tools`

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
- Adds `analyze-dead-code` skill to the `development-codebase-tools` plugin (v2.4.1 → v2.5.0)
- Fills a gap: no existing skill targets dead code removal as a first-class workflow — `analyze-tech-debt` surfaces it broadly but doesn't run scanners, classify findings, or filter false positives
- Particularly valuable as a pre-refactor step to reduce surface area before making changes
## What the skill does
1. **Stack detection** — reads `tsconfig.json`, `package.json`, `pyproject.toml`, `go.mod` to pick the right scanner
2. **Scanner integration** — knip (preferred for TS/JS), ts-prune (fallback), vulture (Python), deadcode/go vet (Go), plus a static grep fallback when no tool is available
3. **Three finding categories** — unused exports, unused files, unused package dependencies
4. **False positive filtering** — screens for dynamic imports, barrel re-exports, framework conventions (Next.js pages, Vite plugins), CLI binaries, and type-only exports before reporting
5. **Git recency enrichment** — annotates findings with last-commit date so staleness informs removal priority
6. **Confidence-ranked report** — `[safe to remove]` vs `[review before removing]` with per-finding action steps
7. **Optional removal plan** — ordered sequence for `--fix` that minimizes breakage risk (devDeps first, then leaf files, then mixed-export files)
## Changes
| File | Change |
|------|--------|
| `packages/plugins/development-codebase-tools/skills/analyze-dead-code/SKILL.md` | New 204-line skill with stack detection, scanner integration, false positive filtering, confidence-ranked reporting, and optional removal plan generation |
| `packages/plugins/development-codebase-tools/.claude-plugin/plugin.json` | Register `analyze-dead-code` in skills array; bump version 2.4.1 → 2.5.0 |
| `packages/plugins/development-codebase-tools/CLAUDE.md` | Add skill to component list and file structure |
| `packages/plugins/development-codebase-tools/README.md` | Add skill to skills table and usage examples |
| `CLAUDE.md` | Update plugin version table (2.2.0 → 2.5.0) |
## Example usage scenarios
```
"Find all dead code in this project"
"What unused exports are in packages/core?"
"Audit dead code and give me a removal plan I can follow"
"I'm about to refactor the auth module — what unused code should I remove first?"
```
## Test plan
- [ ] Trigger phrases from description activate the skill in a TypeScript project
- [ ] Skill correctly detects knip availability and runs it; falls back to ts-prune when knip is absent
- [ ] Findings are classified into the three categories (exports, files, dependencies)
- [ ] A barrel `index.ts` file appears in the "review before removing" section, not "safe to remove"
- [ ] A file last committed 18+ months ago appears before one last committed last week in the ranked output
- [ ] `--fix` flag produces an ordered removal checklist
- [ ] Skill runs without errors on a Python project (vulture) and a Go project (deadcode)
- [ ] Plugin validates with `node scripts/validate-plugin.cjs packages/plugins/development-codebase-tools`

</details>
<!-- claude-pr-description-end -->