### PR TITLE
refactor(development-planning): tune commit-message-generator agent metadata

### DIFF
--- a/packages/plugins/development-planning/.claude-plugin/plugin.json
+++ b/packages/plugins/development-planning/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-planning",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Implementation planning, execution, and PR creation workflows with multi-agent collaboration",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/development-planning/agents/commit-message-generator.md
+++ b/packages/plugins/development-planning/agents/commit-message-generator.md
@@ -1,7 +1,8 @@
 ---
 name: commit-message-generator-agent
-description: Generate well-structured git commit messages that clearly communicate the WHAT and WHY of code changes. Your messages should help future developers (including the author) understand the purpose and context of the commit.
+description: Generate a conventional git commit message from pre-collected git diff and commit history strings. Invoked by the generate-commit-message skill and execute-plan agent with staged_changes, commit_history, and optional scope already gathered — no file system access needed.
 model: sonnet
+allowed-tools:
 ---
 
 # commit-message-generator Agent


### PR DESCRIPTION
## Summary

- Rewrites the frontmatter `description` from a mission statement to an orchestrator trigger phrase that names the pre-collected inputs (`staged_changes`, `commit_history`, `scope`) and callers (generate-commit-message skill, execute-plan agent)
- Adds `allowed-tools:` with no tools listed — all inputs arrive as string parameters so the agent requires no file system or shell access (least-privilege principle)

## Test plan

- [ ] Plugin validates: `npx nx run development-planning:validate`
- [ ] Markdownlint passes on modified file
- [ ] No functional behavior change — description and allowed-tools are metadata only

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
- Rewrites the frontmatter `description` from a generic mission statement to an orchestrator trigger phrase that names the pre-collected inputs (`staged_changes`, `commit_history`, `scope`) and callers (`generate-commit-message` skill, `execute-plan` agent)
- Adds `allowed-tools:` with no tools listed — all inputs arrive as string parameters so the agent requires no file system or shell access (least-privilege principle)
- Bumps plugin version 2.0.2 → 2.0.3
## Changes
| File | Change |
|------|--------|
| `packages/plugins/development-planning/agents/commit-message-generator.md` | Rewrite `description` for accurate orchestrator routing; add empty `allowed-tools` to enforce least-privilege |
| `packages/plugins/development-planning/.claude-plugin/plugin.json` | Patch version bump 2.0.2 → 2.0.3 |
## Notes
- No functional behavior change — `description` and `allowed-tools` are metadata only
- Follows the same agent-tuning pattern as recent PRs (`refactorer`, `code-explainer`, `context-loader`, `code-generator`, `pattern-learner`, `debug-assistant`)

</details>
<!-- claude-pr-description-end -->