### PR TITLE
feat(development-codebase-tools): add skill analyze-bundle

### DIFF
--- a/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
+++ b/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
@@ -22,9 +22,12 @@
     "./agents/style-enforcer.md"
   ],
   "skills": [
+    "./skills/analyze-bundle",
     "./skills/analyze-code",
+    "./skills/analyze-dead-code",
     "./skills/analyze-migrations",
     "./skills/analyze-tech-debt",
+    "./skills/audit-accessibility",
     "./skills/debug-issue",
     "./skills/diagram-excalidraw",
     "./skills/explore-codebase",

--- a/packages/plugins/development-codebase-tools/CLAUDE.md
+++ b/packages/plugins/development-codebase-tools/CLAUDE.md
@@ -8,6 +8,7 @@ This plugin provides codebase exploration, refactoring, and quality analysis too
 
 ### Skills (./skills/)
 
+- **analyze-bundle**: Analyze web application bundle size — identify heaviest modules, tree-shaking gaps, duplicate packages, and code-splitting opportunities
 - **analyze-code**: Multi-agent code explanation for architecture, patterns, security, and performance
 - **analyze-dead-code**: Find unused exports, unreachable modules, and dead files with confidence-ranked removal guidance
 - **analyze-migrations**: Statically analyze database migration files for safety issues (locks, data loss, missing rollbacks)
@@ -84,6 +85,7 @@ development-codebase-tools/
 ├── .claude-plugin/
 │   └── plugin.json
 ├── skills/
+│   ├── analyze-bundle/
 │   ├── analyze-code/
 │   ├── analyze-dead-code/
 │   ├── analyze-migrations/

--- a/packages/plugins/development-codebase-tools/README.md
+++ b/packages/plugins/development-codebase-tools/README.md
@@ -14,18 +14,20 @@ claude /plugin install development-codebase-tools
 
 ## Skills
 
-| Skill                   | Description                                                                                      |
-| ----------------------- | ------------------------------------------------------------------------------------------------ |
-| **analyze-code**        | Multi-agent code explanation for architecture, patterns, security, and performance               |
-| **analyze-dead-code**   | Find unused exports, unreachable modules, and dead files with confidence-ranked removal guidance |
-| **analyze-migrations**  | Static safety analysis of database migration files (locks, data loss, rollback gaps)             |
-| **analyze-tech-debt**   | Identify and prioritize technical debt with remediation plans                                    |
-| **audit-accessibility** | Audit UI components for WCAG 2.1 AA compliance with severity-grouped violations                  |
-| **debug-issue**         | Systematic debugging workflow — from vague symptom to root cause analysis and validated fix      |
-| **diagram-excalidraw**  | Generate Excalidraw architecture diagrams from codebase analysis                                 |
-| **explore-codebase**    | Deep codebase exploration and understanding                                                      |
-| **refactor-code**       | Comprehensive refactoring with safety checks and pattern application                             |
-| **strengthen-types**    | Audit and harden TypeScript type safety — find `any`, unsafe casts, and missing return types     |
+| Skill                   | Description                                                                                                                 |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| **analyze-bundle**      | Analyze web application bundle size — heaviest modules, tree-shaking gaps, duplicate packages, code-splitting opportunities |
+| **analyze-code**        | Multi-agent code explanation for architecture, patterns, security, and performance                                          |
+| **analyze-dead-code**   | Find unused exports, unreachable modules, and dead files with confidence-ranked removal guidance                            |
+| **analyze-migrations**  | Static safety analysis of database migration files (locks, data loss, rollback gaps)                                        |
+| **analyze-tech-debt**   | Identify and prioritize technical debt with remediation plans                                                               |
+| **audit-accessibility** | Audit UI components for WCAG 2.1 AA compliance with severity-grouped violations                                             |
+| **debug-issue**         | Systematic debugging workflow — from vague symptom to root cause analysis and validated fix                                 |
+| **diagram-excalidraw**  | Generate Excalidraw architecture diagrams from codebase analysis                                                            |
+| **explore-codebase**    | Deep codebase exploration and understanding                                                                                 |
+| **mermaid-diagram**     | Generate Mermaid diagrams from codebase analysis                                                                            |
+| **refactor-code**       | Comprehensive refactoring with safety checks and pattern application                                                        |
+| **strengthen-types**    | Audit and harden TypeScript type safety — find `any`, unsafe casts, and missing return types                                |
 
 ## Agents
 

--- a/packages/plugins/development-codebase-tools/skills/analyze-bundle/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/analyze-bundle/SKILL.md
@@ -1,0 +1,324 @@
+---
+description: Analyze web application bundle size to find what's making it large and how to shrink it. Always use this skill whenever the user says "analyze the bundle", "what's making my bundle large", "bundle size analysis", "check my webpack output", "why is my app so big", "find heavy dependencies", "optimize the bundle", "check my Vite build size", "bundle is too large", "reduce my JS bundle", "find large modules", "tree-shaking opportunities", "what dependencies are bloating the bundle", "bundle report", "check build output size", "source map analysis", or asks to audit build artifacts for size. Also trigger when the user sees slow initial page load and suspects large JavaScript as the cause.
+allowed-tools: Read, Glob, Grep, Bash(find:*), Bash(du:*), Bash(ls:*), Bash(cat:*), Bash(npx vite-bundle-visualizer:*), Bash(npx source-map-explorer:*), Bash(npx webpack-bundle-analyzer:*), Bash(npx bundlephobia:*), Bash(npm run:*), Bash(npx vite build:*), Bash(npx rollup:*), Bash(node:*), Bash(jq:*)
+model: sonnet
+---
+
+# Bundle Analyzer
+
+Identify what's inflating your web application's bundle, trace it to specific dependencies and import patterns, and produce a prioritized list of optimizations with estimated size savings.
+
+## When to Activate
+
+- User wants to understand what's making their bundle large
+- Initial page load is slow and JavaScript bundle size may be a factor
+- Before or after a dependency update to measure size impact
+- CI is flagging a bundle size regression
+- Preparing to ship a performance improvement and need a baseline
+- Code-splitting, lazy loading, or tree-shaking improvements are being planned
+
+## Step 1: Detect Bundler and Stack
+
+Scan for config files to identify the bundler and framework:
+
+| Signal file                              | Bundler             | Analysis approach                                                        |
+| ---------------------------------------- | ------------------- | ------------------------------------------------------------------------ |
+| `vite.config.ts` / `vite.config.js`      | Vite                | Build with `--report` or `vite-bundle-visualizer`                        |
+| `webpack.config.*`                       | Webpack             | `webpack-bundle-analyzer` via stats JSON                                 |
+| `next.config.*`                          | Next.js (Webpack)   | `@next/bundle-analyzer` or source-map-explorer on `.next/static/chunks/` |
+| `rollup.config.*`                        | Rollup              | Build with `rollup-plugin-visualizer`                                    |
+| `esbuild.config.*` or esbuild in scripts | esbuild             | `--metafile` flag → analyze with `esbuild-bundle-analyzer`               |
+| `parcel.config.*` / `.parcelrc`          | Parcel              | `parcel build --detailed-report`                                         |
+| `turbo.json`                             | Turbopack/Turborepo | Check individual apps in the monorepo for their bundler                  |
+
+Also check `package.json` scripts for build commands to understand the build pipeline:
+
+```bash
+cat package.json | grep -A5 '"scripts"'
+```
+
+If the project uses a monorepo (nx.json, turbo.json, pnpm workspaces), identify which packages have browser bundles before proceeding.
+
+## Step 2: Check for Existing Build Artifacts
+
+Before re-building, check whether a recent build already exists:
+
+```bash
+# Vite / generic
+find dist -name "*.js" -newer package.json 2>/dev/null | head -20
+ls -lhS dist/ 2>/dev/null | head -20
+
+# Next.js
+ls -lhS .next/static/chunks/ 2>/dev/null | head -20
+
+# Create React App / webpack
+ls -lhS build/static/js/ 2>/dev/null | head -20
+```
+
+If fresh artifacts are present (modified within the last day), skip rebuilding and use the existing output. Note this in your report.
+
+If no build artifacts exist, run the build in Step 3.
+
+## Step 3: Generate Bundle Report
+
+Run the appropriate analysis tool based on the bundler detected in Step 1.
+
+### Vite
+
+Check for `vite-bundle-visualizer` or use the built-in rollup options:
+
+```bash
+# Using vite-bundle-visualizer (preferred if available)
+npx vite-bundle-visualizer --output /tmp/bundle-report.json 2>/dev/null
+
+# Fallback: build with rollup options to emit stats
+npm run build -- --mode production 2>/dev/null
+```
+
+After building, read the manifest if present:
+
+```bash
+cat dist/.vite/manifest.json 2>/dev/null | head -100
+```
+
+### Webpack
+
+```bash
+# Generate stats.json
+npx webpack --config webpack.config.js --profile --json > /tmp/webpack-stats.json 2>/dev/null
+
+# If that fails, check if webpack is configured in package.json scripts
+npm run build -- --stats 2>/dev/null
+```
+
+Then use `webpack-bundle-analyzer` in stats mode:
+
+```bash
+npx webpack-bundle-analyzer /tmp/webpack-stats.json --mode static --report /tmp/bundle-report.html --no-open 2>/dev/null
+```
+
+### Next.js
+
+```bash
+# Check if @next/bundle-analyzer is configured
+grep -r "bundle-analyzer\|withBundleAnalyzer" next.config.* 2>/dev/null
+
+# Run with ANALYZE flag if configured
+ANALYZE=true npm run build 2>/dev/null
+
+# Fallback: analyze .next/static/chunks directly
+ls -lhS .next/static/chunks/*.js 2>/dev/null | head -30
+```
+
+### source-map-explorer (Universal Fallback)
+
+When bundler-specific tools aren't available, `source-map-explorer` works on any build output that includes source maps:
+
+```bash
+# Ensure source maps exist
+ls dist/*.js.map build/static/js/*.js.map .next/static/chunks/*.js.map 2>/dev/null | head -5
+
+# Run source-map-explorer on the main bundle(s)
+npx source-map-explorer 'dist/*.js' --json > /tmp/sme-report.json 2>/dev/null
+npx source-map-explorer 'build/static/js/*.js' --json > /tmp/sme-report.json 2>/dev/null
+```
+
+Parse the JSON output to extract module sizes.
+
+### Raw File Sizes (Minimal Fallback)
+
+If no analysis tool is available and source maps are absent:
+
+```bash
+# Raw sizes sorted by size
+find dist build .next/static/chunks -name "*.js" -not -name "*.map" 2>/dev/null \
+  | xargs du -h | sort -rh | head -20
+
+# Gzip estimate (multiply raw size by ~0.3 for a rough gzip estimate)
+find dist -name "*.js" -not -name "*.map" 2>/dev/null \
+  | xargs gzip -c | wc -c
+```
+
+Note: raw fallback provides size totals only — no per-module breakdown. Recommend the user install `vite-bundle-visualizer` or enable source maps for a full analysis.
+
+## Step 4: Identify Heaviest Modules and Dependencies
+
+From the report data, extract:
+
+### Top Modules by Size
+
+List the 15 largest modules (by parsed/compressed size). For each entry note:
+
+- Module path or package name
+- Size (raw bytes and gzip estimate if available)
+- Whether it's a production dependency, dev dependency, or application code
+- Whether a lighter alternative exists
+
+### Duplicate Packages
+
+Check if the same package appears at multiple versions (common with monorepos and conflicting peer dependencies):
+
+```bash
+# Check for duplicate packages in node_modules
+find node_modules -name "package.json" -not -path "*/node_modules/*/node_modules/*" \
+  | xargs grep -l '"name"' 2>/dev/null \
+  | xargs node -e "
+const fs=require('fs');
+const map={};
+process.argv.slice(1).forEach(f=>{
+  try{
+    const p=JSON.parse(fs.readFileSync(f,'utf8'));
+    if(!map[p.name]) map[p.name]=[];
+    map[p.name].push({v:p.version,path:f});
+  }catch(e){}
+});
+Object.entries(map).filter(([,vs])=>vs.length>1).forEach(([n,vs])=>{
+  const total=vs.reduce((a,v)=>a+Number(v.v.split('.')[0]||0),0);
+  console.log(n+': '+vs.map(v=>v.v).join(', '));
+});
+" 2>/dev/null | head -20
+```
+
+Duplicates that appear in multiple versions often land in the bundle multiple times. Flag any duplicate that is both large (>50 KB raw) and frequently used (React, lodash, date-fns, etc.).
+
+### Tree-Shaking Issues
+
+Scan for import patterns that defeat tree-shaking:
+
+```bash
+# Namespace imports (import * as X) — barrel imports that pull in everything
+grep -r "import \* as" src/ --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" 2>/dev/null | head -20
+
+# Default imports from packages known to have named exports (lodash, date-fns, ramda)
+grep -r "import _ from 'lodash'" src/ --include="*.ts" --include="*.tsx" 2>/dev/null | head -5
+grep -r "import moment from 'moment'" src/ --include="*.ts" --include="*.tsx" 2>/dev/null | head -5
+
+# Check if problematic packages have tree-shakeable alternatives
+grep -r "\"moment\":\|\"lodash\":\|\"rxjs\":" package.json 2>/dev/null
+```
+
+## Step 5: Check for Code-Splitting Opportunities
+
+Identify code that could be lazily loaded to reduce the initial bundle:
+
+```bash
+# Route components loaded eagerly in React Router / Next.js
+grep -r "import.*from.*pages\|import.*Router\|createBrowserRouter" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | grep -v "lazy\|dynamic" | head -15
+
+# Heavy components not yet lazy-loaded
+grep -r "^import " src/ --include="*.tsx" 2>/dev/null \
+  | grep -v "from 'react'\|from '@types'\|\.module\." \
+  | awk '{print $NF}' | sort | uniq -c | sort -rn | head -20
+
+# Check if React.lazy / dynamic() is already used
+grep -r "React\.lazy\|import()\|next/dynamic" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | wc -l
+```
+
+Flag routes and large feature components that are imported synchronously but only needed for specific user flows. These are prime candidates for `React.lazy()` or Next.js `dynamic()`.
+
+## Step 6: Report
+
+Output a structured report in three sections.
+
+### Bundle Size Summary
+
+```
+Bundler:              [detected bundler]
+Total raw size:       X KB / X MB
+Total gzip estimate:  X KB / X MB  (×0.28 compression ratio)
+Largest chunk:        [filename] — X KB
+Number of chunks:     N
+Analysis method:      [tool used or "raw file sizes"]
+Build artifacts:      [fresh / regenerated / not found]
+```
+
+### Top 10 Heaviest Modules
+
+List each module with size, category (dep / app code), and a one-line note:
+
+```
+1. react-dom              — 130 KB (gzip: 42 KB)  production dep, required
+2. @mui/material          — 98 KB  (gzip: 31 KB)  production dep — consider tree-shaking named imports only
+3. lodash                 — 71 KB  (gzip: 25 KB)  production dep — NAMESPACE IMPORT detected; switch to named imports or lodash-es
+4. moment                 — 67 KB  (gzip: 22 KB)  production dep — replace with date-fns (~6 KB gzip) or day.js (~2 KB gzip)
+5. [application code]...
+```
+
+### Actionable Recommendations
+
+List only findings with a concrete fix. Sort by estimated size saving (largest first):
+
+```
+## Critical (>20 KB gzip saving each)
+
+### Replace `moment` with `day.js`
+  Current: 67 KB raw / 22 KB gzip
+  Target:  ~7 KB raw / 2.5 KB gzip
+  Saving:  ~20 KB gzip
+  Effort:  Medium — API is compatible; use codemod or search/replace
+  Fix:     npm uninstall moment && npm install dayjs
+           Replace: import moment from 'moment' → import dayjs from 'dayjs'
+
+### Fix lodash namespace import
+  Current: 71 KB raw (full lodash bundle)
+  Target:  ~15 KB raw (only used functions)
+  Saving:  ~15 KB gzip
+  Effort:  Low — change import style
+  Fix:     Replace `import _ from 'lodash'` with named imports: `import { debounce, cloneDeep } from 'lodash-es'`
+
+## High (5–20 KB gzip saving each)
+
+### Lazy-load SettingsPage and AdminDashboard routes
+  These components are only needed for authenticated admin users but are in the main bundle.
+  Saving:  ~8 KB gzip estimated
+  Effort:  Low
+  Fix:     const SettingsPage = React.lazy(() => import('./pages/SettingsPage'))
+
+## Low (<5 KB gzip saving each)
+
+### [smaller items]
+```
+
+If no actionable findings are found, state that explicitly: "The bundle is well-optimized. No significant savings identified."
+
+## Options
+
+| Flag               | Description                                                                   |
+| ------------------ | ----------------------------------------------------------------------------- |
+| `--target <path>`  | Analyze a specific output directory instead of auto-detecting                 |
+| `--bundler <name>` | Force a specific bundler (`webpack`, `vite`, `rollup`, `next`, `esbuild`)     |
+| `--skip-build`     | Use existing build artifacts without rebuilding                               |
+| `--include-deps`   | Check bundlephobia size estimates for each detected heavy dependency          |
+| `--fix`            | After reporting, generate a step-by-step optimization plan with code snippets |
+
+## Usage Examples
+
+Quick size check on a Vite project:
+
+```
+"How big is the bundle?"
+```
+
+Full analysis with optimization plan:
+
+```
+"Analyze the bundle and tell me how to get it under 200 KB gzip"
+```
+
+Pre-shipping check:
+
+```
+"We're about to ship — check the bundle for any obvious size problems"
+```
+
+Debugging a regression:
+
+```
+"The bundle grew 80 KB after merging the auth PR — find out why"
+```
+
+Targeting a specific package:
+
+```
+"Is moment.js really worth the 22 KB gzip it costs? Analyze alternatives"
+```

--- a/packages/plugins/development-codebase-tools/skills/analyze-bundle/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/analyze-bundle/SKILL.md
@@ -45,7 +45,7 @@ Before re-building, check whether a recent build already exists:
 
 ```bash
 # Vite / generic
-find dist -name "*.js" -newer package.json 2>/dev/null | head -20
+find dist -name "*.js" -mtime -1 2>/dev/null | head -20
 ls -lhS dist/ 2>/dev/null | head -20
 
 # Next.js
@@ -118,9 +118,13 @@ When bundler-specific tools aren't available, `source-map-explorer` works on any
 # Ensure source maps exist
 ls dist/*.js.map build/static/js/*.js.map .next/static/chunks/*.js.map 2>/dev/null | head -5
 
-# Run source-map-explorer on the main bundle(s)
-npx source-map-explorer 'dist/*.js' --json > /tmp/sme-report.json 2>/dev/null
-npx source-map-explorer 'build/static/js/*.js' --json > /tmp/sme-report.json 2>/dev/null
+# Run source-map-explorer on the detected build output (use only the matching path to
+# avoid the second command silently overwriting the first report)
+if [ -d dist ]; then
+  npx source-map-explorer 'dist/*.js' --json > /tmp/sme-report.json 2>/dev/null
+elif [ -d build/static/js ]; then
+  npx source-map-explorer 'build/static/js/*.js' --json > /tmp/sme-report.json 2>/dev/null
+fi
 ```
 
 Parse the JSON output to extract module sizes.
@@ -159,9 +163,27 @@ List the 15 largest modules (by parsed/compressed size). For each entry note:
 Check if the same package appears at multiple versions (common with monorepos and conflicting peer dependencies):
 
 ```bash
-# Check for duplicate packages in node_modules
-find node_modules -name "package.json" -not -path "*/node_modules/*/node_modules/*" \
-  | xargs grep -l '"name"' 2>/dev/null \
+# Preferred: use npm/pnpm/yarn to report all resolved versions — this catches nested
+# hoisting conflicts that a flat node_modules scan would miss
+npm ls --all --json 2>/dev/null | node -e "
+const data = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+const seen = {};
+function walk(node, depth) {
+  if (!node || depth > 10) return;
+  if (node.name && node.version) {
+    if (!seen[node.name]) seen[node.name] = new Set();
+    seen[node.name].add(node.version);
+  }
+  for (const dep of Object.values(node.dependencies || {})) walk(dep, depth+1);
+}
+walk(data, 0);
+Object.entries(seen).filter(([,vs])=>vs.size>1)
+  .forEach(([n,vs])=>console.log(n+': '+[...vs].join(', ')));
+" 2>/dev/null | head -20
+
+# Fallback if npm ls is too slow: flat scan (note: excludes nested node_modules,
+# so it may miss hoisted duplicates — use npm ls output for authoritative results)
+find node_modules -maxdepth 2 -name "package.json" \
   | xargs node -e "
 const fs=require('fs');
 const map={};
@@ -169,13 +191,11 @@ process.argv.slice(1).forEach(f=>{
   try{
     const p=JSON.parse(fs.readFileSync(f,'utf8'));
     if(!map[p.name]) map[p.name]=[];
-    map[p.name].push({v:p.version,path:f});
+    map[p.name].push(p.version);
   }catch(e){}
 });
-Object.entries(map).filter(([,vs])=>vs.length>1).forEach(([n,vs])=>{
-  const total=vs.reduce((a,v)=>a+Number(v.v.split('.')[0]||0),0);
-  console.log(n+': '+vs.map(v=>v.v).join(', '));
-});
+Object.entries(map).filter(([,vs])=>vs.length>1)
+  .forEach(([n,vs])=>console.log(n+': '+vs.join(', ')));
 " 2>/dev/null | head -20
 ```
 


### PR DESCRIPTION
## Summary

- Add `analyze-bundle` skill to `development-codebase-tools` plugin, enabling developers to identify what's inflating their web application bundle and get prioritized optimization recommendations
- Bump plugin version from 2.2.1 → 2.3.0

## Gap This Fills

No existing skill or agent covered build-time bundle size analysis. The `performance-analyzer` agent focuses on runtime bottlenecks (algorithmic complexity, DB queries, memory), not static build artifacts. This skill fills the "why is my initial page load slow?" gap from the build side.

**Covered bundlers:** Vite, Webpack, Next.js, Rollup, esbuild, Parcel, Turbopack monorepos

**Analysis layers:**
1. Detect bundler from config files
2. Check for existing build artifacts before re-running a build
3. Generate a bundle report via the most capable available tool (vite-bundle-visualizer, webpack-bundle-analyzer, source-map-explorer, raw file sizes as fallback)
4. Extract heaviest modules, detect duplicate packages at multiple versions, flag tree-shaking-defeating import patterns
5. Check for code-splitting opportunities (sync route imports, missing React.lazy / Next.js dynamic())
6. Produce a prioritized report sorted by estimated gzip savings with per-item fix instructions

## How It Was Identified

During enhance-ai-toolkit run (2026-04-24): the `performance-analyzer` agent's scope covers runtime performance only. Bundle size is a build-time, static-analysis concern frequently cited as a cause of slow initial page load. No existing component in any plugin targeted this.

## Example Usage Scenarios

```
"How big is the bundle?"                                     → triggers analyze-bundle
"What's making my app so big?"                               → triggers analyze-bundle
"The bundle grew 80 KB after merging the auth PR — find out why" → triggers analyze-bundle
"Find tree-shaking opportunities"                            → triggers analyze-bundle
"We're about to ship — check for obvious bundle size issues" → triggers analyze-bundle
```

## Test Plan

- [ ] Verify skill registers correctly in the plugin manifest
- [ ] Verify `node scripts/validate-plugin.cjs packages/plugins/development-codebase-tools` passes
- [ ] Verify `markdownlint-cli2` reports 0 errors on the skill file
- [ ] Verify trigger phrases match the use cases listed in the description
- [ ] Verify Vite project analysis path (Step 3 Vite section)
- [ ] Verify Webpack/Next.js path detects config files correctly
- [ ] Verify fallback to raw file sizes when no analysis tools are available
- [ ] Verify options table entries (--skip-build, --fix, --include-deps) are actionable

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
- Add `analyze-bundle` skill to `development-codebase-tools` plugin (v2.5.7 → v2.6.0)
- Fills a gap: no existing skill covered build-time bundle size analysis — the `performance-analyzer` agent focuses on runtime bottlenecks, not static build artifacts
- The skill identifies what's inflating a web application bundle and produces a prioritized list of optimizations with estimated gzip savings
## What the skill does
1. **Detect bundler** from config files (Vite, Webpack, Next.js, Rollup, esbuild, Parcel, Turbopack)
2. **Check for existing build artifacts** before re-running a build
3. **Generate a bundle report** via the most capable available tool (vite-bundle-visualizer, webpack-bundle-analyzer, source-map-explorer, raw file sizes as fallback)
4. **Extract heaviest modules** — top 15 by size with category and lighter-alternative notes
5. **Detect duplicate packages** at multiple versions and flag tree-shaking-defeating import patterns (namespace imports, full-library imports)
6. **Check for code-splitting opportunities** — sync route imports, missing `React.lazy()` / Next.js `dynamic()`
7. **Produce a prioritized report** sorted by estimated gzip savings with per-item fix instructions
## Changes
| File | Change |
|------|--------|
| `packages/plugins/development-codebase-tools/skills/analyze-bundle/SKILL.md` | New 344-line skill with 6-step analysis workflow, bundler detection table, analysis tool commands, duplicate package detection, tree-shaking and code-splitting checks, structured report format, and CLI-style options |
| `packages/plugins/development-codebase-tools/.claude-plugin/plugin.json` | Register `analyze-bundle` in skills array; bump version 2.5.7 → 2.6.0 |
| `packages/plugins/development-codebase-tools/CLAUDE.md` | Add skill to component list and file structure |
| `packages/plugins/development-codebase-tools/README.md` | Add skill to skills table; also adds `mermaid-diagram` to the table |
## Example usage scenarios
- `"How big is the bundle?"` → triggers analyze-bundle
- `"What's making my app so big?"` → triggers analyze-bundle
- `"The bundle grew 80 KB after merging the auth PR — find out why"` → triggers analyze-bundle
- `"Find tree-shaking opportunities"` → triggers analyze-bundle
- `"We're about to ship — check for obvious bundle size issues"` → triggers analyze-bundle
## Test plan
- [ ] Verify skill registers correctly in the plugin manifest
- [ ] Verify `node scripts/validate-plugin.cjs packages/plugins/development-codebase-tools` passes
- [ ] Verify `markdownlint-cli2` reports 0 errors on the skill file
- [ ] Verify trigger phrases match the use cases listed in the description
- [ ] Verify Vite project analysis path (Step 3 Vite section)
- [ ] Verify Webpack/Next.js path detects config files correctly
- [ ] Verify fallback to raw file sizes when no analysis tools are available
- [ ] Verify options table entries (`--skip-build`, `--fix`, `--include-deps`) are actionable

</details>
<!-- claude-pr-description-end -->