### PR TITLE
improve(development-planning): tune planner agent metadata

### DIFF
--- a/packages/plugins/development-planning/.claude-plugin/plugin.json
+++ b/packages/plugins/development-planning/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-planning",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Implementation planning, execution, and PR creation workflows with multi-agent collaboration",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/development-planning/agents/planner.md
+++ b/packages/plugins/development-planning/agents/planner.md
@@ -1,6 +1,8 @@
 ---
 name: planner-agent
-description: Create clear, actionable implementation plans without writing code
+description: Create clear, actionable implementation plans without writing code. Use when asked to plan a feature, design an implementation approach, create a task breakdown, or decide how to implement a change before writing any code.
+allowed-tools: Read, Write, Glob, Grep
+model: claude-opus-4-7
 ---
 
 # Planner Agent


### PR DESCRIPTION
## Summary

- Adds `allowed-tools: Read, Write, Glob, Grep` — the planner reads codebase files, uses Glob/Grep for pattern discovery, and writes the output plan file; this tightens permissions to exactly what the agent requires
- Adds `model: claude-opus-4-7` — strategic planning requires deep reasoning across trade-offs and architecture; opus is the appropriate model for this agent
- Expands `description` with concrete trigger phrases so the orchestrator selects this agent correctly when a user asks to plan a feature, design an approach, or create a task breakdown

## Test plan

- [ ] Confirm `npx nx run development-planning:validate` passes (done locally)
- [ ] Verify planner agent is invoked correctly when orchestrating a plan-implementation flow

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
- Adds `allowed-tools: Read, Write, Glob, Grep` — the planner reads codebase files, uses Glob/Grep for pattern discovery, and writes the output plan file; this tightens permissions to exactly what the agent requires
- Adds `model: claude-opus-4-7` — strategic planning requires deep reasoning across trade-offs and architecture; opus is the appropriate model for this agent
- Expands `description` with concrete trigger phrases so the orchestrator selects this agent correctly when a user asks to plan a feature, design an approach, or create a task breakdown
- Bumps plugin version 2.0.1 → 2.0.2 (patch — frontmatter-only change, no functional changes)
## Changes
| File | Change |
|------|--------|
| `packages/plugins/development-planning/agents/planner.md` | Added `allowed-tools`, `model`, and expanded `description` frontmatter fields |
| `packages/plugins/development-planning/.claude-plugin/plugin.json` | Bumped version 2.0.1 → 2.0.2 |
## Test plan
- [ ] Confirm `npx nx run development-planning:validate` passes
- [ ] Verify planner agent is invoked correctly when orchestrating a plan-implementation flow

</details>
<!-- claude-pr-description-end -->