### PR TITLE
improve(development-planning): tune execute-plan agent description with trigger phrases

### DIFF
--- a/packages/plugins/development-planning/.claude-plugin/plugin.json
+++ b/packages/plugins/development-planning/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-planning",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Implementation planning, execution, and PR creation workflows with multi-agent collaboration",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/development-planning/agents/execute-plan.md
+++ b/packages/plugins/development-planning/agents/execute-plan.md
@@ -1,6 +1,6 @@
 ---
 name: execute-plan-agent
-description: Execute implementation plans step-by-step. Bridge agent that ensures both Task and Skill invocations of execute-plan work correctly.
+description: Execute implementation plans step-by-step. Use when user says "execute the plan", "implement the plan we created", "start building based on the plan", "go ahead and implement it", "proceed with the implementation", "execute as a stack", "create a PR stack while implementing", "implement with one PR per step", or references a plan file and wants to begin coding.
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git:*), Bash(gt:*), Bash(npx:*), Task(subagent_type:test-writer-agent), Task(subagent_type:documentation-agent), Task(subagent_type:pr-creator-agent), Task(subagent_type:commit-message-generator-agent)
 model: opus
 ---


### PR DESCRIPTION
## Summary

- Replaces the vague "bridge agent" description in `execute-plan.md` with concrete trigger phrases that match the skill's own description
- Enables orchestrators to correctly select this agent when users say "execute the plan", "implement as a stack", "one PR per step", etc.
- No logic changes — purely a description quality improvement

## Test plan

- [ ] Agent description now mirrors trigger phrases from `skills/execute-plan/SKILL.md`
- [ ] Plugin validation passes (`npx nx run development-planning:validate`)
- [ ] Markdownlint passes

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
- Replaces the vague "bridge agent" description in `execute-plan.md` with concrete trigger phrases that match the skill's own description
- Enables orchestrators to correctly select this agent when users say "execute the plan", "implement as a stack", "one PR per step", etc.
- No logic changes -- purely a description quality improvement
## Changes
| File | Change |
|------|--------|
| `packages/plugins/development-planning/agents/execute-plan.md` | Replace generic description with specific trigger phrases matching `skills/execute-plan/SKILL.md` |
| `packages/plugins/development-planning/.claude-plugin/plugin.json` | Patch version bump 2.0.1 → 2.0.2 |
## Notes
- Follows the same pattern as recent agent description rewrites in `development-codebase-tools` (refactorer, context-loader, code-explainer, pattern-learner, code-generator, debug-assistant)
- The previous description ("Bridge agent that ensures both Task and Skill invocations of execute-plan work correctly") described internal plumbing rather than user intent, making orchestrator routing unreliable

</details>
<!-- claude-pr-description-end -->