### PR TITLE
refactor(development-planning): tune create-pr skill with actionable steps and error handling

### DIFF
--- a/packages/plugins/development-planning/.claude-plugin/plugin.json
+++ b/packages/plugins/development-planning/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-planning",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Implementation planning, execution, and PR creation workflows with multi-agent collaboration",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/development-planning/skills/create-pr/SKILL.md
+++ b/packages/plugins/development-planning/skills/create-pr/SKILL.md
@@ -20,7 +20,7 @@ Create or update pull requests with auto-generated conventional commits and desc
 ## Error Handling
 
 - **No changes / no commits ahead of target**: Stop and inform the user — there is nothing to submit
-- **PR already exists for this branch**: Switch to update mode; run `gh pr edit` or `gt submit` to push the latest commits
+- **PR already exists for this branch**: Switch to update mode; run `git push` to publish the latest commits (use `gt submit` for Graphite), then `gh pr edit` if the PR title or body also need updating
 - **User rejects commit message**: Re-generate with user-provided guidance, then confirm again before proceeding
 
 ## Conventional Commit Types

--- a/packages/plugins/development-planning/skills/create-pr/SKILL.md
+++ b/packages/plugins/development-planning/skills/create-pr/SKILL.md
@@ -8,22 +8,20 @@ model: opus
 
 Create or update pull requests with auto-generated conventional commits and descriptions. Supports both standard Git + GitHub CLI (default) and Graphite workflows.
 
-## When to Activate
-
-- User wants to create a PR
-- Changes ready for review
-- User says "submit" or "push for review"
-- PR update needed
-- User mentions PR creation, GitHub, or Graphite
-
 ## What It Does
 
-1. **Analyze Diff**: Compare current branch to target
-2. **Detect Change Type**: feat, fix, refactor, etc.
-3. **Generate Commit**: Create conventional commit (with user confirmation)
+1. **Analyze Diff**: Run `git diff origin/<target>...HEAD` to inspect all changed files
+2. **Detect Change Type**: Classify as feat, fix, refactor, etc. based on the diff
+3. **Generate Commit**: Use `commit-message-generator-agent` to draft a conventional commit message, then ask user to confirm before staging/committing
 4. **Create PR Title**: `<type>(<scope>): <description>`
-5. **Write Description**: Comprehensive PR body
-6. **Submit**: Use `gt submit` or `gh pr create`
+5. **Write Description**: Comprehensive PR body (summary, modified files, testing notes, linked issues)
+6. **Submit**: Use `gt submit` (Graphite) or `gh pr create` (default)
+
+## Error Handling
+
+- **No changes / no commits ahead of target**: Stop and inform the user — there is nothing to submit
+- **PR already exists for this branch**: Switch to update mode; run `gh pr edit` or `gt submit` to push the latest commits
+- **User rejects commit message**: Re-generate with user-provided guidance, then confirm again before proceeding
 
 ## Conventional Commit Types
 


### PR DESCRIPTION
## Summary

- Removes the "When to Activate" section, which was fully redundant with the frontmatter `description` field (same trigger phrases duplicated in both places)
- Makes "What It Does" steps actionable: adds the specific command (`git diff origin/<target>...HEAD`) and subagent reference (`commit-message-generator-agent`) instead of vague phase names
- Adds an "Error Handling" section covering the three most common failure modes: no changes to submit, PR already exists, and user rejecting the commit message

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
- Remove the "When to Activate" section — it was fully redundant with the frontmatter `description` field (same trigger phrases duplicated in both places), adding ~8 lines of token waste per invocation
- Make "What It Does" steps actionable: add the specific command (`git diff origin/<target>...HEAD`) and subagent reference (`commit-message-generator-agent`) instead of vague phase names
- Add an "Error Handling" section covering the three most common failure modes: no changes to submit, PR already exists for the branch, and user rejecting the generated commit message
## Changes
| File | Change |
|------|--------|
| `packages/plugins/development-planning/skills/create-pr/SKILL.md` | Remove redundant activation section, sharpen step descriptions with concrete commands and agent references, add error handling guidance |
| `packages/plugins/development-planning/.claude-plugin/plugin.json` | Patch version bump 2.0.3 → 2.0.4 |
## Notes
- Single file change, prompt-only — no functional or behavioral changes to the skill's orchestration logic
- Follows the same pattern as recent skill/agent prompt optimizations (`explore-codebase`, `diagram-excalidraw`, `refactorer`, `debug-assistant`)

</details>
<!-- claude-pr-description-end -->