### PR TITLE
improve(development-planning): tune execute-plan skill model ID and error handling

### DIFF
--- a/packages/plugins/development-planning/.claude-plugin/plugin.json
+++ b/packages/plugins/development-planning/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-planning",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Implementation planning, execution, and PR creation workflows with multi-agent collaboration",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/development-planning/agents/execute-plan.md
+++ b/packages/plugins/development-planning/agents/execute-plan.md
@@ -2,7 +2,7 @@
 name: execute-plan-agent
 description: Execute implementation plans step-by-step. Use when user says "execute the plan", "implement the plan we created", "start building based on the plan", "go ahead and implement it", "proceed with the implementation", "execute as a stack", "create a PR stack while implementing", "implement with one PR per step", or references a plan file and wants to begin coding.
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git:*), Bash(gt:*), Bash(npx:*), Task(subagent_type:test-writer-agent), Task(subagent_type:documentation-agent), Task(subagent_type:pr-creator-agent), Task(subagent_type:commit-message-generator-agent)
-model: opus
+model: claude-opus-4-7
 ---
 
 # Execute Plan Agent

--- a/packages/plugins/development-planning/skills/execute-plan/SKILL.md
+++ b/packages/plugins/development-planning/skills/execute-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 description: Execute implementation plans step-by-step. Use when user says "execute the plan", "implement the plan we created", "start building based on the plan", "go ahead and implement it", "proceed with the implementation", "execute as a stack", "create a PR stack while implementing", "implement with one PR per step", or references a plan file and wants to begin coding.
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git:*), Bash(gt:*), Bash(npx:*), Task(subagent_type:test-writer-agent), Task(subagent_type:documentation-agent), Task(subagent_type:pr-creator-agent), Task(subagent_type:commit-message-generator-agent)
-model: opus
+model: claude-opus-4-7
 ---
 
 # Plan Executor
@@ -127,9 +127,9 @@ For comprehensive stack execution guidance, see [graphite-stack-execution.md](..
 
 ### Error Handling
 
-- Report errors clearly with context
-- Attempt to understand and resolve
-- Ask user for guidance if blocked
+- Report errors clearly with the full error output and context
+- Read the full error output, identify the root cause, and attempt a targeted fix
+- Ask user for guidance if two fix attempts fail
 - Continue with other steps when possible
 
 ### Commits


### PR DESCRIPTION
## Summary

- Update `model: opus` → `model: claude-opus-4-7` (explicit model ID for clarity)
- Improve error handling guidance: "Attempt to understand and resolve" → read full error output, identify root cause, attempt a targeted fix, escalate to user after two failed attempts

## Changes

- `packages/plugins/development-planning/skills/execute-plan/SKILL.md`

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
- Update `model: opus` to `model: claude-opus-4-7` in both the execute-plan skill and agent for explicit model ID clarity
- Improve error handling guidance: replace vague "attempt to understand and resolve" with structured approach — read full error output, identify root cause, attempt a targeted fix, escalate to user after two failed attempts
- Bump plugin version 2.0.4 → 2.0.5
## Changes
| File | Change |
|------|--------|
| `packages/plugins/development-planning/skills/execute-plan/SKILL.md` | Update model field to explicit ID; rewrite error handling bullets with actionable, graduated guidance |
| `packages/plugins/development-planning/agents/execute-plan.md` | Update model field from `opus` to `claude-opus-4-7` to align with skill |
| `packages/plugins/development-planning/.claude-plugin/plugin.json` | Patch version bump 2.0.4 → 2.0.5 |
## Notes
- No behavioral changes to the skill's execution logic — purely a prompt quality improvement
- Follows the same pattern as recent agent/skill metadata tuning PRs in `development-planning` and `development-codebase-tools`

</details>
<!-- claude-pr-description-end -->