### PR TITLE
feat(development-codebase-tools): add debug-issue skill

### DIFF
--- a/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
+++ b/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-codebase-tools",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Codebase exploration, refactoring, and quality analysis",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
+++ b/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-codebase-tools",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Codebase exploration, refactoring, and quality analysis",
   "author": {
     "name": "Uniswap Labs",
@@ -24,6 +24,7 @@
   "skills": [
     "./skills/analyze-code",
     "./skills/analyze-tech-debt",
+    "./skills/debug-issue",
     "./skills/diagram-excalidraw",
     "./skills/explore-codebase",
     "./skills/mermaid-diagram",

--- a/packages/plugins/development-codebase-tools/CLAUDE.md
+++ b/packages/plugins/development-codebase-tools/CLAUDE.md
@@ -10,6 +10,7 @@ This plugin provides codebase exploration, refactoring, and quality analysis too
 
 - **analyze-code**: Multi-agent code explanation for architecture, patterns, security, and performance
 - **analyze-tech-debt**: Identify and prioritize technical debt with remediation plans
+- **debug-issue**: Systematic debugging workflow — accepts any error report (message, stack trace, or vague symptom), locates the origin, gathers context, invokes the debug-assistant-agent for root-cause analysis, and validates the fix
 - **diagram-excalidraw**: Generate Excalidraw architecture diagrams from codebase analysis
 - **mermaid-diagram**: Generate syntactically valid Mermaid.js diagrams (flowcharts, sequence, class, state, ER, Gantt, git)
 - **explore-codebase**: Deep codebase exploration with architectural understanding
@@ -82,6 +83,7 @@ development-codebase-tools/
 ├── skills/
 │   ├── analyze-code/
 │   ├── analyze-tech-debt/
+│   ├── debug-issue/
 │   ├── diagram-excalidraw/
 │   ├── mermaid-diagram/
 │   ├── explore-codebase/

--- a/packages/plugins/development-codebase-tools/README.md
+++ b/packages/plugins/development-codebase-tools/README.md
@@ -18,6 +18,7 @@ claude /plugin install development-codebase-tools
 | ---------------------- | -------------------------------------------------------------------------------------------- |
 | **analyze-code**       | Multi-agent code explanation for architecture, patterns, security, and performance           |
 | **analyze-tech-debt**  | Identify and prioritize technical debt with remediation plans                                |
+| **debug-issue**        | Systematic debugging workflow — from vague symptom to root cause analysis and validated fix  |
 | **diagram-excalidraw** | Generate Excalidraw architecture diagrams from codebase analysis                             |
 | **explore-codebase**   | Deep codebase exploration and understanding                                                  |
 | **refactor-code**      | Comprehensive refactoring with safety checks and pattern application                         |
@@ -54,6 +55,8 @@ claude /plugin install development-codebase-tools
 "Create an architecture diagram of this system"  # triggers diagram-excalidraw
 "What technical debt exists in this module?"     # triggers analyze-tech-debt
 "Run a type safety audit on this codebase"       # triggers strengthen-types
+"I'm getting a TypeError in the auth module"     # triggers debug-issue
+"This keeps crashing in production, help me fix it" # triggers debug-issue
 ```
 
 ## License

--- a/packages/plugins/development-codebase-tools/skills/debug-issue/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/debug-issue/SKILL.md
@@ -9,9 +9,9 @@ description: >-
   phrases include: "getting an error", "this crashes", "why is this failing", "help me fix this", "it broke",
   "not working", "exception thrown", "stack trace", "test is failing", "something is wrong with".
 allowed-tools: >-
-  Read, Glob, Grep, Bash(git log:*), Bash(git diff:*), Bash(git blame:*), Bash(git status:*),
+  Read, Glob, Grep, Edit, Write, Bash(git log:*), Bash(git diff:*), Bash(git blame:*), Bash(git status:*),
   Task(subagent_type:debug-assistant-agent)
-model: claude-opus-4-7
+model: opus
 ---
 
 # Debug Issue

--- a/packages/plugins/development-codebase-tools/skills/debug-issue/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/debug-issue/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: debug-issue
+description: >-
+  Systematic debugging workflow for any code error, crash, test failure, or unexpected behavior. Use this
+  skill whenever a user mentions an error, bug, exception, crash, test failure, or says something "isn't working",
+  "is broken", "keeps failing", or "isn't behaving as expected" — even if they haven't used the word "debug".
+  Also trigger when the user pastes a stack trace, error message, or unexpected output and asks why. Don't wait
+  for the user to say "debug"; if they're describing a problem with running code, this skill applies. Trigger
+  phrases include: "getting an error", "this crashes", "why is this failing", "help me fix this", "it broke",
+  "not working", "exception thrown", "stack trace", "test is failing", "something is wrong with".
+allowed-tools: >-
+  Read, Glob, Grep, Bash(git log:*), Bash(git diff:*), Bash(git blame:*), Bash(git status:*),
+  Task(subagent_type:debug-assistant-agent)
+model: claude-opus-4-7
+---
+
+# Debug Issue
+
+Diagnose and fix any code problem — from vague symptoms to full stack traces — using a structured
+investigation workflow backed by the `debug-assistant-agent`.
+
+The skill accepts any form of bug report: a raw error message, a test failure output, a symptom
+description ("the app freezes when I click save"), or a combination. Its job is to gather the right
+context and translate that rough report into a root cause and a concrete fix.
+
+## When to Activate
+
+- User pastes an error message, exception, or stack trace
+- A test is failing and the reason isn't obvious
+- Something works locally but fails in CI or production
+- Unexpected output that doesn't match what the code should do
+- User says "this broke after my last change" — or doesn't know what changed
+
+## Step 1: Capture the Problem
+
+Before looking at any files, nail down what you're actually dealing with:
+
+- **Symptoms** — what goes wrong? Extract the exact error type and message if there is one.
+- **Trigger** — when does it fail? (always, sometimes, only after a specific action, only in prod)
+- **Stack trace** — if present, read it carefully: the first project-owned frame (not a library frame)
+  is the origin point and your starting location.
+
+If the user gave vague symptoms only ("it just crashes"), ask one targeted clarifying question before
+continuing — something like "do you have the error message or a stack trace?" But keep the interaction
+short; once you have enough to locate the origin, move forward.
+
+## Step 2: Locate the Origin
+
+With the origin file and line in hand, read the code around the failure. The goal here is not to read
+every related file — it's to form a working hypothesis fast.
+
+- Read the relevant function or module: 10–20 lines around the error site give more useful context
+  than the single failing line.
+- Check whether this code changed recently (`git log -10 --oneline <file>` and `git diff HEAD~3 -- <file>`)
+- Look for obvious candidates: null dereferences, incorrect assumptions about async ordering,
+  missing env vars, changed interface contracts, off-by-one conditions.
+
+Write your working hypothesis before moving to Step 3 — for example, "I believe this fails because
+`userId` is undefined when `getUser()` is called on logout." A stated hypothesis keeps the
+investigation from drifting into unfocused file-reading.
+
+## Step 3: Gather Supporting Context
+
+With a hypothesis in hand, collect the evidence that confirms or refutes it. Aim for depth over
+breadth — three closely related files read carefully beat ten files skimmed.
+
+Gather what the `debug-assistant-agent` needs:
+
+| Piece                      | Where to find it                                                                         |
+| -------------------------- | ---------------------------------------------------------------------------------------- |
+| Full error and stack trace | User input, test output, or CI logs                                                      |
+| Failing code               | Read the origin file; note surrounding functions if they're part of the call chain       |
+| Recent changes             | `git log --oneline -5` on package.json, go.mod, requirements.txt, or the affected module |
+| Config / env               | Check relevant .env files, config objects, or framework setup near the failure           |
+| Logs                       | logs/ directory, stdout captures, or ask the user                                        |
+
+If the evidence already strongly supports your hypothesis, you can delegate immediately. There's no
+value in gathering everything available if you already understand the problem.
+
+## Step 4: Analyze with debug-assistant-agent
+
+Invoke the `debug-assistant-agent` with the structured context. Format your prompt to the agent as:
+
+```
+error: <exact error message and type, or "no explicit error — symptom: ...">
+logs: <relevant log output, or "not available">
+context: <the failing code and any related code you read — include file path and function name>
+history: <recent git changes to this area, or "no recent changes">
+environment: <runtime/framework/version info, or "standard dev environment">
+```
+
+The agent returns ranked root-cause hypotheses (with confidence scores), an error pattern
+classification, a three-phase fix plan (immediate change → validation → deployment), and concrete
+code patches.
+
+Pick the highest-confidence hypothesis and fix plan. If two hypotheses are close in confidence,
+note both and proceed with the more likely one — you can revisit if the first fix doesn't hold.
+
+## Step 5: Apply and Validate
+
+Apply the agent's recommended fix, then confirm it works:
+
+1. Make the code changes the agent recommended (Edit/Write the affected files).
+2. Run the relevant test or reproduce the original trigger.
+3. If the error is gone, summarize for the user:
+   - Root cause in plain language
+   - What was changed and why it fixes the problem
+   - Any follow-up to consider (adding a regression test, updating docs, monitoring a metric)
+4. If the error persists or a different error appears, treat the new state as updated input and
+   return to Step 2. What failed is useful information about where the real root cause lies.
+
+## Staying on Track
+
+Debugging can drift into exploration. Two guardrails that keep it productive:
+
+- **One hypothesis at a time.** Pick the most likely cause, apply the fix, verify. Only move to
+  the next hypothesis if verification fails. Trying to fix multiple hypotheses simultaneously
+  muddies the signal.
+- **Distinguish code bugs from environment issues.** If the root cause is a missing env variable,
+  wrong Node/Python version, corrupted cache, or a service that's down — say so clearly. The fix
+  is outside the code and applying a code patch won't help.


### PR DESCRIPTION
## What gap this fills

The `development-codebase-tools` plugin has a powerful `debug-assistant-agent` for root-cause analysis, but no **skill** to serve as the entry point. Developers currently have to manually structure inputs for the agent (error text, logs, context, history, environment) — which they rarely know how to do upfront when something is broken.

This adds a `debug-issue` skill that accepts any form of bug report — a raw error message, a stack trace, "it just crashes", a failing test output — and walks through a structured investigation before delegating to `debug-assistant-agent`.

## How it was identified

Gap analysis during the `enhance-ai-toolkit` cron run: capability mapping showed every major workflow phase had skill coverage *except* debugging, which was agent-only. Debugging is a daily developer activity, making this a high-frequency gap.

## What was added

**`packages/plugins/development-codebase-tools/skills/debug-issue/SKILL.md`** — 5-step debugging workflow skill:
1. **Capture** — accept any form of bug report; extract error type and trigger
2. **Locate** — find the origin file/line from the stack trace; read surrounding code; form a working hypothesis
3. **Gather** — collect supporting evidence (logs, recent git changes, config) with depth-over-breadth guidance
4. **Analyze** — invoke `debug-assistant-agent` with structured context; pick the highest-confidence fix plan
5. **Validate** — apply the fix, run tests, confirm resolution; loop back if the error persists

Plugin bumped to v2.4.0.

## Example usage scenarios

- "I'm getting a TypeError: Cannot read properties of undefined (reading 'id')" → triggers debug-issue
- "This keeps crashing in production" → triggers debug-issue (asks one clarifying question, then proceeds)
- "My test is failing but I don't know why" → triggers debug-issue
- "Why is getUser() returning null here?" → triggers debug-issue

## Test plan

- [ ] Confirm validation passes: `node scripts/validate-plugin.cjs packages/plugins/development-codebase-tools`
- [ ] Confirm markdownlint passes on all modified markdown files
- [ ] Confirm plugin.json lists `debug-issue` in skills array with bumped version `2.4.0`
- [ ] Confirm SKILL.md description includes multiple trigger phrases covering vague and specific error reports
- [ ] Confirm the skill delegates to `debug-assistant-agent` via `Task(subagent_type:debug-assistant-agent)`

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
- Adds `debug-issue` skill to the `development-codebase-tools` plugin (v2.3.1 → v2.4.1)
- Fills a gap: every major workflow phase had skill coverage except debugging, which was agent-only — developers had to manually structure inputs for `debug-assistant-agent`
- The skill accepts any form of bug report (error message, stack trace, vague symptom) and walks through a structured investigation before delegating to the agent
## What the skill does
1. **Capture** — accept any bug report; extract the error type, message, and trigger condition
2. **Locate** — find the origin file/line from the stack trace; read surrounding code; form a working hypothesis
3. **Gather** — collect supporting evidence (logs, recent git changes, config) with depth-over-breadth guidance
4. **Analyze** — invoke `debug-assistant-agent` with structured context; pick the highest-confidence fix plan
5. **Validate** — apply the fix, run tests, confirm resolution; loop back if the error persists
## Changes
| File | Change |
|------|--------|
| `packages/plugins/development-codebase-tools/skills/debug-issue/SKILL.md` | New skill definition (121 lines) with 5-step debugging workflow, structured agent delegation, and investigation guardrails |
| `packages/plugins/development-codebase-tools/.claude-plugin/plugin.json` | Register `debug-issue` in skills array; bump version 2.3.1 → 2.4.1 |
| `packages/plugins/development-codebase-tools/CLAUDE.md` | Add skill to component list and file structure |
| `packages/plugins/development-codebase-tools/README.md` | Add skill to skills table and example usage section |
## Example usage scenarios
- `"I'm getting a TypeError: Cannot read properties of undefined (reading 'id')"` → triggers debug-issue
- `"This keeps crashing in production"` → triggers debug-issue
- `"My test is failing but I don't know why"` → triggers debug-issue
- `"Why is getUser() returning null here?"` → triggers debug-issue
## Test plan
- [ ] Confirm plugin validation passes: `node scripts/validate-plugin.cjs packages/plugins/development-codebase-tools`
- [ ] Confirm markdownlint passes on all modified markdown files
- [ ] Confirm plugin.json lists `debug-issue` in skills array with bumped version `2.4.1`
- [ ] Confirm SKILL.md description includes multiple trigger phrases covering vague and specific error reports
- [ ] Confirm the skill delegates to `debug-assistant-agent` via `Task(subagent_type:debug-assistant-agent)`

</details>
<!-- claude-pr-description-end -->