### PR TITLE
fix(ci): invoke npm publish directly so OIDC trusted publishing works under bun

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1029,20 +1029,22 @@ jobs:
             if npm view "$package" version --registry=https://registry.npmjs.org &>/dev/null; then
               NPM_VERSION=$(npm view "$package" version --registry=https://registry.npmjs.org 2>/dev/null || echo "unknown")
               echo "📦 Status: EXISTING package (current: $NPM_VERSION)"
-
-              if npx nx release publish --projects="$project" --tag="$INPUT_NPM_TAG" --registry=https://registry.npmjs.org --verbose; then
-                PUBLISH_SUCCESS=true
-              else
-                PUBLISH_SUCCESS=false
-              fi
             else
               echo "🆕 Status: NEW package"
+            fi
 
-              if npx nx release publish --projects="$project" --first-release --tag="$INPUT_NPM_TAG" --registry=https://registry.npmjs.org --verbose; then
-                PUBLISH_SUCCESS=true
-              else
-                PUBLISH_SUCCESS=false
-              fi
+            # Invoke `npm publish` directly (rather than `nx release publish`) so npm OIDC
+            # trusted publishing works. Nx's release-publish executor honors the workspace
+            # `packageManager` field and routes through `bun publish`, which does not
+            # implement the npm OIDC token exchange.
+            PROJECT_ROOT=$(bunx nx show project "$project" --json | jq -r '.root')
+            if [ -z "$PROJECT_ROOT" ] || [ "$PROJECT_ROOT" = "null" ]; then
+              echo "❌ Could not resolve project root for $project"
+              PUBLISH_SUCCESS=false
+            elif (cd "$PROJECT_ROOT" && npm publish --tag="$INPUT_NPM_TAG" --registry=https://registry.npmjs.org); then
+              PUBLISH_SUCCESS=true
+            else
+              PUBLISH_SUCCESS=false
             fi
 
             if [ "$PUBLISH_SUCCESS" = true ]; then


### PR DESCRIPTION
Alternative to #495: keep bun, fix the publish path.

## What broke

After #452 set `"packageManager": "bun@1.3.12"` in root `package.json`, the publish run for that merge commit failed for all 4 packages:

```
bun publish error:
error: missing authentication (run `bunx npm login`)
```

[Failed run](https://github.com/Uniswap/ai-toolkit/actions/runs/25194847181).

## Root cause (verified against Nx 22.0.2 source)

`npx nx release publish` resolves to `@nx/js:release-publish` (`node_modules/@nx/js/src/executors/release-publish/release-publish.impl.js:25`), which calls `detectPackageManager()` and then `getPackageManagerCommand(pm).publish(...)`.

`detectPackageManager()` in Nx 22.0.2 (`node_modules/nx/src/utils/package-manager.js:38`) checks `nx.json` `cli.packageManager` first, then sniffs lockfiles in this order: `bun.lockb`/`bun.lock` → `yarn.lock` → `pnpm-lock.yaml` → `npm`. With `bun.lock` present, the executor binds to `bun publish`.

`bun publish` does not implement the [npm OIDC trusted-publishing token exchange](https://docs.npmjs.com/trusted-publishers) — it only reads `_authToken` style credentials from `~/.npmrc`. With no static token configured (the workflow relies on OIDC), every package fails authentication.

## Why not just set `cli.packageManager: "npm"` in `nx.json`?

Tried it. Nx uses the same `detectPackageManager()` value for project-graph external-dependency resolution, which then expects a `package-lock.json` to look up packages like `jest`. Tests fail with `externalDependency 'jest' could not be found` because only `bun.lock` exists. So the override is too broad.

## Fix

Bypass the Nx publish executor for the final `npm publish` call. Versioning, tagging, and the version-commit are still produced by the prior `nx release version` step (which doesn't shell out to `bun publish`). Only the publish-to-registry step is affected:

```diff
-              if npx nx release publish --projects="$project" --tag="$INPUT_NPM_TAG" --registry=https://registry.npmjs.org --verbose; then
+            PROJECT_ROOT=$(bunx nx show project "$project" --json | jq -r '.root')
+            if (cd "$PROJECT_ROOT" && npm publish --tag="$INPUT_NPM_TAG" --registry=https://registry.npmjs.org); then
```

`npm publish` from each package's source root packs the `files` array in its `package.json` (`["dist", ...]`), and npm CLI 11.7.0 (already installed by the workflow) auto-detects GHA + `id-token: write` and performs the OIDC exchange.

Existing-vs-new package branches collapsed because `npm publish` is the same call for both — `--first-release` was Nx-internal versioning metadata that doesn't apply at publish time.

## Why this is safe

- No project has a custom `nx-release-publish` target override (`grep -l nx-release-publish packages/*/project.json` returns nothing), so the default executor is the only thing being bypassed and there are no per-package publish hooks to lose.
- Versioning behavior is unchanged: `nx release version` still bumps versions, `nx-release:preVersionCommand` (`bunx nx affected -t build`) still builds dist, the version commit and git tag are still created.
- Bun stays as the workspace `packageManager` for daily dev (`bun install`, `bunx nx ...`, lefthook).

## Verification plan

- [ ] CI green on this PR
- [ ] After merge to `next`, observe a successful Publish Packages run on the next push (or trigger manually via the workflow's `workflow_dispatch` if no affected packages on the merge commit)

## Closes

Supersedes #495 (the revert). Recommend closing that one if this lands cleanly.

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

Alternative to #495: keep bun, fix the publish path.
## What broke
After #452 set `"packageManager": "bun@1.3.12"` in root `package.json`, the publish run for that merge commit failed for all 4 packages:
```
bun publish error:
error: missing authentication (run `bunx npm login`)
```
[Failed run](https://github.com/Uniswap/ai-toolkit/actions/runs/25194847181).
## Root cause
`npx nx release publish` resolves to `@nx/js:release-publish`, which calls `detectPackageManager()` and then `getPackageManagerCommand(pm).publish(...)`. With `bun.lock` present, the executor binds to `bun publish`.
`bun publish` does not implement the [npm OIDC trusted-publishing token exchange](https://docs.npmjs.com/trusted-publishers) -- it only reads `_authToken` style credentials from `~/.npmrc`. With no static token configured (the workflow relies on OIDC), every package fails authentication.
## Why not just set `cli.packageManager: "npm"` in `nx.json`?
Nx uses the same `detectPackageManager()` value for project-graph external-dependency resolution, which then expects a `package-lock.json`. Tests fail with `externalDependency 'jest' could not be found` because only `bun.lock` exists.
## Fix
Bypass the Nx publish executor for the final `npm publish` call. Versioning, tagging, and the version-commit are still produced by the prior `nx release version` step. Only the publish-to-registry step is affected:
- Resolve each project's root via `bunx nx show project "$project" --json | jq -r '.root'`
- Run `npm publish` from that directory so npm CLI auto-detects GHA + `id-token: write` and performs the OIDC exchange
- Collapse the existing-vs-new package branches since `npm publish` is the same call for both (`--first-release` was Nx-internal metadata)
## Changes
| File | Change |
|------|--------|
| `.github/workflows/publish-packages.yml` | Replace `npx nx release publish` with direct `npm publish` from each project root; add project-root resolution via `bunx nx show project`; collapse existing/new package branches |
## Why this is safe
- No project has a custom `nx-release-publish` target override, so the default executor is the only thing being bypassed
- Versioning behavior is unchanged: `nx release version` still bumps versions, the pre-version build command still runs, the version commit and git tag are still created
- Bun stays as the workspace `packageManager` for daily dev (`bun install`, `bunx nx ...`, lefthook)
## Verification plan
- [ ] CI green on this PR
- [ ] After merge to `next`, observe a successful Publish Packages run on the next push (or trigger manually via `workflow_dispatch`)
## Closes
Supersedes #495 (the revert). Recommend closing that one if this lands cleanly.

</details>
<!-- claude-pr-description-end -->