### PR TITLE
chore: update model references from claude-opus-4-6 to claude-opus-4-7

### DIFF
--- a/.github/REUSABLE_WORKFLOWS.md
+++ b/.github/REUSABLE_WORKFLOWS.md
@@ -334,7 +334,7 @@ jobs:
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     with:
-      model: 'claude-opus-4-6'
+      model: 'claude-opus-4-7'
       timeout_minutes: '15' # Opus may need more time
 ```
 
@@ -423,7 +423,7 @@ jobs:
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     with:
-      model: 'claude-opus-4-6'
+      model: 'claude-opus-4-7'
       timeout_minutes: '15'
 ```
 
@@ -619,7 +619,7 @@ jobs:
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     with:
-      model: 'claude-opus-4-6'
+      model: 'claude-opus-4-7'
       timeout_minutes: '15'
 ```
 
@@ -640,7 +640,7 @@ claude-deep:
     contains(github.event.pull_request.labels.*.name, 'deep-analysis') &&
     # ... (rest of if condition)
   with:
-    model: 'claude-opus-4-6'
+    model: 'claude-opus-4-7'
 ```
 
 #### Integration with Other Workflows
@@ -1117,7 +1117,7 @@ jobs:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
       # Use Opus for PRs with 'claude-opus' label, otherwise Sonnet
-      model: ${{ contains(github.event.pull_request.labels.*.name, 'claude-opus') && 'claude-opus-4-6' || 'claude-sonnet-4-6' }}
+      model: ${{ contains(github.event.pull_request.labels.*.name, 'claude-opus') && 'claude-opus-4-7' || 'claude-sonnet-4-6' }}
       max_turns: 20 # Allow more turns for thorough Opus reviews
       timeout_minutes: 45 # Longer timeout for complex reviews
     secrets:
@@ -1596,7 +1596,7 @@ jobs:
     with:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
-      model: 'claude-opus-4-6'
+      model: 'claude-opus-4-7'
       custom_prompt_path: '.github/prompts/security-review.md'
       timeout_minutes: 60
     secrets:

--- a/.github/REUSABLE_WORKFLOWS.md
+++ b/.github/REUSABLE_WORKFLOWS.md
@@ -218,7 +218,7 @@ Notify Release (_notify-release.yml)
 
 | Input                           | Required | Default                          | Description                                                                        |
 | ------------------------------- | -------- | -------------------------------- | ---------------------------------------------------------------------------------- |
-| `model`                         | No       | `'claude-sonnet-4-6'`            | Claude model to use (Sonnet 4.6, Opus 4.6, or Haiku 4.5)                           |
+| `model`                         | No       | `'claude-sonnet-4-6'`            | Claude model to use (Sonnet 4.6, Opus 4.7, or Haiku 4.5)                           |
 | `allowed_tools`                 | No       | (permissive defaults, see below) | YAML string specifying which tools Claude can use (file operations, bash commands) |
 | `custom_instructions`           | No       | `'Be sure to follow rules...'`   | Additional instructions for Claude beyond CLAUDE.md files                          |
 | `timeout_minutes`               | No       | `'10'`                           | Maximum execution time in minutes (prevents runaway costs)                         |
@@ -282,7 +282,7 @@ The following settings are intentionally fixed to ensure consistent security and
 
 - **Interactive AI Assistance**: Respond to `@claude` mentions anywhere in GitHub
 - **Multiple Trigger Points**: Works in issue comments, PR comments, review comments, and reviews
-- **Configurable Model**: Choose between Sonnet 4.6 (balanced), Opus 4.6 (thorough), or Haiku 4.5 (fast)
+- **Configurable Model**: Choose between Sonnet 4.6 (balanced), Opus 4.7 (thorough), or Haiku 4.5 (fast)
 - **Flexible Tool Permissions**: Control what Claude can do (read-only, read-write, or custom)
 - **Custom Instructions**: Add repository-specific guidelines and standards
 - **Bot Filtering**: Automatically excludes bot comments to prevent loops
@@ -546,7 +546,7 @@ Claude says it doesn't have permission to perform action
 2. **Choose the Right Model**:
 
    - **Sonnet 4.6** (default): Best balance of speed, capability, and cost for 90% of use cases
-   - **Opus 4.6**: Reserve for complex architectural reviews or critical security analysis
+   - **Opus 4.7**: Reserve for complex architectural reviews or critical security analysis
    - **Haiku 4.5**: Fast and cost-effective for simple questions, quick lookups, or high-volume usage
 
 3. **Set Appropriate Timeouts**:
@@ -691,7 +691,7 @@ Tips for managing Claude API costs effectively:
 
    - Haiku 4.5: Most cost-effective for simple tasks
    - Sonnet 4.6: ~$3 per 1M input tokens, ~$15 per 1M output tokens (default, recommended)
-   - Opus 4.6: ~$15 per 1M input tokens, ~$75 per 1M output tokens (reserve for complex tasks)
+   - Opus 4.7: ~$5 per 1M input tokens, ~$25 per 1M output tokens (reserve for complex tasks)
    - Typical interaction: 5K-50K tokens (mostly input)
 
 2. **Timeout Strategy**:
@@ -1501,7 +1501,7 @@ Claude submitted multiple reviews instead of updating one
 2. **Model Selection**:
 
    - **Sonnet 4.6** (default): Best balance for most PRs (~80% of use cases)
-   - **Opus 4.6**: Reserve for critical code, security-sensitive changes, or complex architectures
+   - **Opus 4.7**: Reserve for critical code, security-sensitive changes, or complex architectures
    - Use labels to let developers request deeper reviews when needed
 
 3. **Custom Prompts**:

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -431,7 +431,7 @@ with:
   pr_number: ${{ github.event.pull_request.number }}
   base_ref: ${{ github.base_ref }}
   auto_fix: true # Enable automatic fixing of issues
-  auto_fix_model: 'claude-opus-4-6' # Use Opus for better fixes (optional)
+  auto_fix_model: 'claude-opus-4-7' # Use Opus for better fixes (optional)
 secrets:
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }} # Required for pushing fixes
@@ -638,7 +638,7 @@ uses: Uniswap/ai-toolkit/.github/workflows/_claude-docs-check.yml@main
 with:
   pr_number: ${{ github.event.pull_request.number }}
   auto_fix: true # Enable automatic fixing of documentation issues
-  auto_fix_model: 'claude-opus-4-6' # Use Opus for better fixes (optional)
+  auto_fix_model: 'claude-opus-4-7' # Use Opus for better fixes (optional)
 secrets:
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }} # Required for pushing fixes
@@ -950,7 +950,7 @@ If both are provided, OAuth token takes precedence. At least one authentication 
 
 | Input                     | Default           | Description                                     |
 | ------------------------- | ----------------- | ----------------------------------------------- |
-| `model`                   | `claude-opus-4-6` | Claude model to use                             |
+| `model`                   | `claude-opus-4-7` | Claude model to use                             |
 | `max_turns`               | `150`             | Maximum conversation turns                      |
 | `debug_mode`              | `true`            | Show full Claude output                         |
 | `timeout_minutes`         | `60`              | Job timeout                                     |
@@ -989,7 +989,7 @@ with:
   issue_url: ${{ matrix.issue_url }}
   branch_name: ${{ matrix.branch_name }}
   target_branch: 'next'
-  model: 'claude-opus-4-6'
+  model: 'claude-opus-4-7'
   debug_mode: true
   pr_type: 'draft' # or 'published' for non-draft PRs
 secrets:
@@ -1009,7 +1009,7 @@ with:
   issue_url: ${{ matrix.issue_url }}
   branch_name: ${{ matrix.branch_name }}
   target_branch: 'next'
-  model: 'claude-opus-4-6'
+  model: 'claude-opus-4-7'
   debug_mode: true
   pr_type: 'draft'
 secrets:
@@ -1101,7 +1101,7 @@ gh workflow run update-action-versions.yml
 gh workflow run update-action-versions.yml -f dry_run=true
 
 # Use Opus model
-gh workflow run update-action-versions.yml -f model=claude-opus-4-6
+gh workflow run update-action-versions.yml -f model=claude-opus-4-7
 ```
 
 **Usage example (API Key):**
@@ -1237,7 +1237,7 @@ gh workflow run dev-ai-newsletter.yml -f dry_run=true
 gh workflow run dev-ai-newsletter.yml -f days_back=14
 
 # Use Opus model for better quality
-gh workflow run dev-ai-newsletter.yml -f model=claude-opus-4-6
+gh workflow run dev-ai-newsletter.yml -f model=claude-opus-4-7
 
 # Post to specific Slack channels
 gh workflow run dev-ai-newsletter.yml -f slack_post_channel_ids="C091XE1DNP2,C094URH6C13"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -75,7 +75,7 @@ Workflows designed to be called by other workflows using `workflow_call`. These 
 
   - Interactive AI assistance via @claude mentions
   - Works in issue comments, PR comments, review comments, and reviews
-  - Configurable models (Sonnet 4.6, Opus 4, Haiku 4.5)
+  - Configurable models (Sonnet 4.6, Opus 4.7, Haiku 4.5)
   - Flexible tool permissions (read-only, read-write, or custom)
   - Custom instructions for repository-specific standards
   - Fixed security settings (Bullfrog scanning, immutable permissions)

--- a/.github/workflows/_claude-main.yml
+++ b/.github/workflows/_claude-main.yml
@@ -79,7 +79,7 @@ on:
 
           Available models:
           - claude-sonnet-4-6 (default, recommended) - Latest Sonnet model with best balance of speed and capability
-          - claude-opus-4-6 - Most capable model for complex tasks
+          - claude-opus-4-7 - Most capable model for complex tasks
           - claude-haiku-4-5 - Fast, cost-effective model for simpler tasks
 
           Default: claude-sonnet-4-6

--- a/.github/workflows/_claude-task-worker.yml
+++ b/.github/workflows/_claude-task-worker.yml
@@ -89,10 +89,10 @@ on:
       model:
         description: |
           Claude model to use.
-          Options: claude-sonnet-4-6, claude-opus-4-6, claude-haiku-4-5
+          Options: claude-sonnet-4-6, claude-opus-4-7, claude-haiku-4-5
         required: false
         type: string
-        default: "claude-opus-4-6"
+        default: "claude-opus-4-7"
 
       timeout_minutes:
         description: "Maximum execution time in minutes"

--- a/.github/workflows/_generate-pr-metadata.yml
+++ b/.github/workflows/_generate-pr-metadata.yml
@@ -44,7 +44,7 @@ on:
         description: "Claude model to use for generation"
         required: false
         type: string
-        default: "claude-opus-4-6"
+        default: "claude-opus-4-7"
 
       max_turns:
         description: "Maximum conversation turns for Claude. Omit to use unlimited turns."

--- a/.github/workflows/claude-auto-tasks.yml
+++ b/.github/workflows/claude-auto-tasks.yml
@@ -53,9 +53,9 @@ on:
         type: choice
         options:
           - "claude-sonnet-4-6"
-          - "claude-opus-4-6"
+          - "claude-opus-4-7"
           - "claude-haiku-4-5"
-        default: "claude-opus-4-6"
+        default: "claude-opus-4-7"
 
       target_branch:
         description: "Branch to create PRs against"
@@ -124,7 +124,7 @@ jobs:
       issue_url: ${{ matrix.issue_url }}
       branch_name: ${{ matrix.branch_name }}
       target_branch: ${{ inputs.target_branch || 'next' }}
-      model: ${{ inputs.model || 'claude-opus-4-6' }}
+      model: ${{ inputs.model || 'claude-opus-4-7' }}
       timeout_minutes: 60
       linear_task_utils_tag: ${{ needs.prepare.outputs.linear_task_utils_tag }}
       debug_mode: ${{ inputs.debug_mode != '' && inputs.debug_mode || true }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -232,7 +232,7 @@ jobs:
       # Uncomment one of these to use a different model for reviews:
       # model: 'claude-haiku-4-5'
       # model: 'claude-sonnet-4-6'
-      model: "claude-opus-4-6"
+      model: "claude-opus-4-7"
 
       # Allow standard review conversation turns
       # max_turns: 15
@@ -291,7 +291,7 @@ jobs:
       max_diff_lines: ${{ fromJSON(vars.MAX_DIFF_LINES) }}
 
       # Use Opus 4.6 for comprehensive reviews with reliable inline comments
-      model: "claude-opus-4-6"
+      model: "claude-opus-4-7"
 
       # Standard timeout for most PRs
       timeout_minutes: 20
@@ -324,7 +324,7 @@ jobs:
       max_diff_lines: ${{ fromJSON(vars.MAX_DIFF_LINES) }}
 
       # Use Opus 4.6 for comprehensive reviews with reliable inline comments
-      model: "claude-opus-4-6"
+      model: "claude-opus-4-7"
 
       # Standard timeout for most PRs
       timeout_minutes: 20

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -227,7 +227,7 @@ jobs:
       force_review: false
       max_diff_lines: ${{ fromJSON(vars.MAX_DIFF_LINES) }}
 
-      # Use Opus 4.6 for comprehensive reviews with reliable inline comments
+      # Use Opus 4.7 for comprehensive reviews with reliable inline comments
       # Opus is more capable at following complex multi-step instructions
       # Uncomment one of these to use a different model for reviews:
       # model: 'claude-haiku-4-5'
@@ -290,7 +290,7 @@ jobs:
       force_review: ${{ inputs.force_review }}
       max_diff_lines: ${{ fromJSON(vars.MAX_DIFF_LINES) }}
 
-      # Use Opus 4.6 for comprehensive reviews with reliable inline comments
+      # Use Opus 4.7 for comprehensive reviews with reliable inline comments
       model: "claude-opus-4-7"
 
       # Standard timeout for most PRs
@@ -323,7 +323,7 @@ jobs:
       force_review: true # Always force when triggered by comment
       max_diff_lines: ${{ fromJSON(vars.MAX_DIFF_LINES) }}
 
-      # Use Opus 4.6 for comprehensive reviews with reliable inline comments
+      # Use Opus 4.7 for comprehensive reviews with reliable inline comments
       model: "claude-opus-4-7"
 
       # Standard timeout for most PRs

--- a/.github/workflows/dev-ai-newsletter.yml
+++ b/.github/workflows/dev-ai-newsletter.yml
@@ -97,7 +97,7 @@ on:
         type: choice
         options:
           - "claude-sonnet-4-6"
-          - "claude-opus-4-6"
+          - "claude-opus-4-7"
         default: "claude-sonnet-4-6"
 
       dry_run:

--- a/.github/workflows/examples/06-claude-main-basic.yml
+++ b/.github/workflows/examples/06-claude-main-basic.yml
@@ -92,7 +92,7 @@ jobs:
 #     secrets:
 #       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 #     with:
-#       model: 'claude-opus-4-6'  # More capable, slower, higher cost
+#       model: 'claude-opus-4-7'  # More capable, slower, higher cost
 #       timeout_minutes: '15'  # Opus may need more time
 #
 # -------------------
@@ -204,7 +204,7 @@ jobs:
 #     secrets:
 #       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 #     with:
-#       model: 'claude-opus-4-6'
+#       model: 'claude-opus-4-7'
 #       timeout_minutes: '15'
 #
 

--- a/.github/workflows/examples/07-claude-main-custom.yml
+++ b/.github/workflows/examples/07-claude-main-custom.yml
@@ -48,9 +48,9 @@ jobs:
       # MODEL SELECTION
       # Choose the Claude model based on your needs:
       # - claude-sonnet-4-6: Latest, best balance (RECOMMENDED)
-      # - claude-opus-4-6: Most capable, slower, higher cost
+      # - claude-opus-4-7: Most capable, slower, higher cost
       # - claude-haiku-4-5: Fast, cost-effective for simpler tasks
-      model: "claude-opus-4-6"
+      model: "claude-opus-4-7"
 
       # TIMEOUT CONFIGURATION
       # Set maximum execution time in minutes
@@ -256,7 +256,7 @@ jobs:
 #     secrets:
 #       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 #     with:
-#       model: 'claude-opus-4-6'  # Thorough for code review
+#       model: 'claude-opus-4-7'  # Thorough for code review
 #       timeout_minutes: '15'
 #
 # -------------------
@@ -289,7 +289,7 @@ jobs:
 #     secrets:
 #       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 #     with:
-#       model: 'claude-opus-4-6'
+#       model: 'claude-opus-4-7'
 #       timeout_minutes: '30'
 #       custom_instructions: |
 #         Perform a comprehensive codebase audit focusing on:
@@ -368,7 +368,7 @@ jobs:
 # Solution:
 #   1. Verify model name exactly matches available models:
 #      - claude-sonnet-4-6
-#      - claude-opus-4-6
+#      - claude-opus-4-7
 #      - claude-haiku-4-5
 #   2. Check Anthropic API key has access to requested model
 #   3. Review Anthropic console for API limits or restrictions

--- a/.github/workflows/examples/10-claude-code-review-advanced.yml
+++ b/.github/workflows/examples/10-claude-code-review-advanced.yml
@@ -45,7 +45,7 @@ jobs:
 
       # Model selection based on PR labels
       # Add 'claude-opus' label to PRs that need more thorough review
-      model: ${{ contains(github.event.pull_request.labels.*.name, 'claude-opus') && 'claude-opus-4-6' || 'claude-sonnet-4-6' }}
+      model: ${{ contains(github.event.pull_request.labels.*.name, 'claude-opus') && 'claude-opus-4-7' || 'claude-sonnet-4-6' }}
 
       # Allow more turns for complex reviews
       # Default is 15, increase for PRs that need deeper analysis
@@ -85,7 +85,7 @@ jobs:
 #     with:
 #       pr_number: ${{ github.event.pull_request.number }}
 #       base_ref: ${{ github.base_ref }}
-#       model: 'claude-opus-4-6'  # Always use Opus for security
+#       model: 'claude-opus-4-7'  # Always use Opus for security
 #       custom_prompt_path: '.github/prompts/security-only-review.md'
 #     secrets:
 #       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/examples/10-claude-code-review-advanced.yml
+++ b/.github/workflows/examples/10-claude-code-review-advanced.yml
@@ -13,7 +13,7 @@ name: 'Example: Claude Code Review - Advanced'
 #
 # Model Selection:
 # - Default: Claude Sonnet 4.6 (fast, cost-effective)
-# - With 'claude-opus' label: Claude Opus 4.6 (more thorough, slower)
+# - With 'claude-opus' label: Claude Opus 4.7 (more thorough, slower)
 #
 # Use Cases:
 # - Large PRs that need more time

--- a/.github/workflows/examples/11-autonomous-linear-tasks.yml
+++ b/.github/workflows/examples/11-autonomous-linear-tasks.yml
@@ -63,9 +63,9 @@ on:
         type: choice
         options:
           - "claude-sonnet-4-6" # Balanced (recommended)
-          - "claude-opus-4-6" # Most capable
+          - "claude-opus-4-7" # Most capable
           - "claude-haiku-4-5" # Fast & economical
-        default: "claude-opus-4-6"
+        default: "claude-opus-4-7"
 
       target_branch:
         description: "Branch to create PRs against"

--- a/.github/workflows/update-action-versions.yml
+++ b/.github/workflows/update-action-versions.yml
@@ -46,7 +46,7 @@ on:
         type: choice
         options:
           - 'claude-sonnet-4-6'
-          - 'claude-opus-4-6'
+          - 'claude-opus-4-7'
       target_branch:
         description: 'Base branch for the PR'
         required: false

--- a/docs/guides/autonomous-claude-tasks.md
+++ b/docs/guides/autonomous-claude-tasks.md
@@ -60,7 +60,7 @@ on:
         type: choice
         options:
           - 'claude-sonnet-4-6'
-          - 'claude-opus-4-6'
+          - 'claude-opus-4-7'
         default: 'claude-sonnet-4-6'
       target_branch:
         description: 'Branch to create PRs against'
@@ -143,7 +143,7 @@ See the full example at `.github/workflows/examples/11-autonomous-linear-tasks.y
 | Model               | Best For                                  |
 | ------------------- | ----------------------------------------- |
 | `claude-sonnet-4-6` | Balance of speed and capability (default) |
-| `claude-opus-4-6`   | Complex tasks requiring deep reasoning    |
+| `claude-opus-4-7`   | Complex tasks requiring deep reasoning    |
 | `claude-haiku-4-5`  | Simple tasks, cost optimization           |
 
 ## Creating Good Task Descriptions
@@ -213,7 +213,7 @@ Trigger manually from the GitHub Actions UI or CLI:
 gh workflow run claude-auto-tasks.yml \
   -f linear_team="Your Team" \
   -f max_issues="5" \
-  -f model="claude-opus-4-6"
+  -f model="claude-opus-4-7"
 ```
 
 ## Monitoring

--- a/packages/plugins/claude-setup/README.md
+++ b/packages/plugins/claude-setup/README.md
@@ -71,7 +71,7 @@ This plugin implements key practices from Boris Cherny (creator of Claude Code):
 - **Plan mode first** - Start complex tasks with planning
 - **Compounding learning** - Update CLAUDE.md when Claude makes mistakes
 - **Slash commands for inner loops** - Automate repetitive workflows
-- **Opus 4.6 with thinking** - Use the best model for quality
+- **Opus 4.7** - Use the best model for quality
 
 See [references/boris-best-practices.md](skills/setup-repository/references/boris-best-practices.md) for full details.
 

--- a/packages/plugins/claude-setup/skills/setup-repository/references/boris-best-practices.md
+++ b/packages/plugins/claude-setup/skills/setup-repository/references/boris-best-practices.md
@@ -62,9 +62,9 @@ The key insight: Claude Code is powerful by default. The goal of configuration i
 - Use inline bash to pre-compute context (git status, etc.)
 - Reduces back-and-forth with the model
 
-### 5. Opus 4.6 with Thinking
+### 5. Opus 4.7 (Most Capable)
 
-> "The model choice is unambiguous: Opus 4.6 with thinking for everything."
+> "The model choice is unambiguous: Opus 4.7 for everything."
 
 **Rationale:**
 
@@ -135,7 +135,7 @@ Boris runs:
 | ------------------------------------ | ------------------------------------- |
 | `git add .`                          | Add files individually                |
 | Skip verification                    | Always verify before marking complete |
-| Use Sonnet for complex tasks         | Use Opus 4.6 with thinking            |
+| Use Sonnet for complex tasks         | Use Opus 4.7                          |
 | Skip plan mode                       | Start in plan mode, iterate on plan   |
 | Ignore mistakes                      | Add to CLAUDE.md immediately          |
 | Use `--dangerously-skip-permissions` | Use `/permissions` for pre-approval   |

--- a/packages/plugins/development-codebase-tools/agents/agent-orchestrator.md
+++ b/packages/plugins/development-codebase-tools/agents/agent-orchestrator.md
@@ -1,7 +1,7 @@
 ---
 name: agent-orchestrator-agent
 description: Use this agent when you need to coordinate multiple AI agents on a complex multi-step software development task. Trigger phrases include "implement this plan", "coordinate agents to", "orchestrate", "break this task into subtasks", "run agents in parallel". Decomposes tasks into atomic units, matches each to the right specialist agent, executes in parallel where possible, and aggregates results.
-model: claude-opus-4-6
+model: claude-opus-4-7
 tools: *
 ---
 

--- a/packages/plugins/development-codebase-tools/skills/refactor-code/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/refactor-code/SKILL.md
@@ -1,7 +1,7 @@
 ---
 description: Refactor code with safety checks and pattern application. Use when user says "refactor this code", "clean up this function", "simplify this logic", "extract this into a separate function", "apply the strategy pattern here", "reduce the complexity of this module", or "reorganize this file structure".
 allowed-tools: Read, Edit, Write, Grep, TodoWrite, Bash(git diff:*), Bash(git show:*), Task(subagent_type:refactorer-agent), Task(subagent_type:style-enforcer-agent), Task(subagent_type:code-explainer-agent), Task(subagent_type:test-writer-agent), Task(subagent_type:agent-orchestrator-agent)
-model: claude-opus-4-6
+model: claude-opus-4-7
 ---
 
 # Code Refactorer


### PR DESCRIPTION
## Summary

- **Detected**: `claude-opus-4-7` is the current latest Opus model. The previous model watch run incorrectly marked git-tracked files as clean when 16 files still referenced legacy `claude-opus-4-6`.
- **Updated**: All 16 git-tracked files that referenced `claude-opus-4-6` have been bumped to `claude-opus-4-7`, including GitHub Actions workflow defaults, example files, documentation, and plugin agents/skills.
- **Why claude-opus-4-7**: The Anthropic docs describe it as having "a step-change improvement in agentic coding" — exactly the workloads these files target (code review, task workers, orchestration, refactoring).

## Files changed

- `.github/REUSABLE_WORKFLOWS.md` — workflow defaults
- `.github/workflows/CLAUDE.md` — workflow documentation
- `.github/workflows/_claude-main.yml`, `_claude-task-worker.yml`, `_generate-pr-metadata.yml`, `claude-auto-tasks.yml`, `claude-code-review.yml`, `dev-ai-newsletter.yml`, `update-action-versions.yml` — workflow inputs/defaults
- `.github/workflows/examples/` — 4 example workflow files
- `docs/guides/autonomous-claude-tasks.md` — guide documentation
- `packages/plugins/development-codebase-tools/agents/agent-orchestrator.md` — orchestrator agent
- `packages/plugins/development-codebase-tools/skills/refactor-code/SKILL.md` — refactor skill

## Test plan

- [x] All pre-commit hooks passed: format, lint, lint-markdown, tests, typecheck, update-lockfile
- [x] `npx nx run-many --target=validate --all` passed (6 plugins)
- [x] No remaining `claude-opus-4-6` references in git-tracked files