### PR TITLE
fix(workflows): bump claude-code-action v1.0.75 -> v1.0.115 and fix egress allowlists

### DIFF
--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -285,6 +285,7 @@ jobs:
             *.githubusercontent.com
             api.anthropic.com
             bun.sh
+            registry.npmjs.org
           enable-sudo: false
 
       # Checkout required before using local composite actions

--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -1156,7 +1156,7 @@ jobs:
       - name: Run Claude Code Review
         if: steps.cache-check.outputs.cache-hit != 'true' && steps.diff-size.outputs.is_too_large != 'true'
         id: claude
-        uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1.0.75
+        uses: anthropics/claude-code-action@9db782c3a17ef2bfc274cd17411bc3e0a5ba1345 # v1.0.115
         with:
           # Authentication: provide either API key or OAuth token (validated in earlier step)
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -1649,7 +1649,7 @@ jobs:
       - name: Run Claude Auto-Fix
         id: claude-fix
         if: steps.auto-fix-check.outputs.should_fix == 'true' && steps.pr-branch.outputs.repo_full_name == github.repository
-        uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1.0.75
+        uses: anthropics/claude-code-action@9db782c3a17ef2bfc274cd17411bc3e0a5ba1345 # v1.0.115
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/_claude-docs-check.yml
+++ b/.github/workflows/_claude-docs-check.yml
@@ -207,6 +207,7 @@ jobs:
             *.githubusercontent.com
             api.anthropic.com
             bun.sh
+            registry.npmjs.org
           enable-sudo: false
 
       # Initial checkout

--- a/.github/workflows/_claude-docs-check.yml
+++ b/.github/workflows/_claude-docs-check.yml
@@ -646,7 +646,7 @@ jobs:
       # Run Claude
       - name: Run Claude Docs Check
         id: claude
-        uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1.0.75
+        uses: anthropics/claude-code-action@9db782c3a17ef2bfc274cd17411bc3e0a5ba1345 # v1.0.115
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -968,7 +968,7 @@ jobs:
       - name: Run Claude Auto-Fix
         id: claude-fix
         if: steps.auto-fix-check.outputs.should_fix == 'true' && steps.pr-branch.outputs.repo_full_name == github.repository
-        uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1.0.75
+        uses: anthropics/claude-code-action@9db782c3a17ef2bfc274cd17411bc3e0a5ba1345 # v1.0.115
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/_claude-main.yml
+++ b/.github/workflows/_claude-main.yml
@@ -421,7 +421,7 @@ jobs:
       # Supports both API key and OAuth token authentication (validated in earlier step)
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1.0.75
+        uses: anthropics/claude-code-action@9db782c3a17ef2bfc274cd17411bc3e0a5ba1345 # v1.0.115
         with:
           # Authentication: provide either API key or OAuth token (validated in earlier step)
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/_claude-main.yml
+++ b/.github/workflows/_claude-main.yml
@@ -301,6 +301,8 @@ jobs:
             *.github.com
             *.githubusercontent.com
             api.anthropic.com
+            bun.sh
+            registry.npmjs.org
           enable-sudo: false
 
       # FIXED: Checkout with consistent fetch depth

--- a/.github/workflows/_claude-task-worker.yml
+++ b/.github/workflows/_claude-task-worker.yml
@@ -500,7 +500,7 @@ jobs:
       # Supports both API key and OAuth token authentication (OAuth takes precedence)
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1.0.75
+        uses: anthropics/claude-code-action@9db782c3a17ef2bfc274cd17411bc3e0a5ba1345 # v1.0.115
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/_generate-pr-metadata.yml
+++ b/.github/workflows/_generate-pr-metadata.yml
@@ -431,7 +431,7 @@ jobs:
           steps.quality-gate-prep.outputs.has_user_content == 'true'
         id: quality-gate-eval
         continue-on-error: true
-        uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1.0.75
+        uses: anthropics/claude-code-action@9db782c3a17ef2bfc274cd17411bc3e0a5ba1345 # v1.0.115
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -877,7 +877,7 @@ jobs:
       - name: Run Claude Code Generation
         if: steps.cache-check.outputs.cache-hit != 'true' && steps.quality-gate.outputs.should_skip != 'true'
         id: claude
-        uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1.0.75
+        uses: anthropics/claude-code-action@9db782c3a17ef2bfc274cd17411bc3e0a5ba1345 # v1.0.115
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/_update-action-versions-worker.yml
+++ b/.github/workflows/_update-action-versions-worker.yml
@@ -404,7 +404,7 @@ jobs:
       # Supports both API key and OAuth token authentication (OAuth takes precedence)
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1.0.75
+        uses: anthropics/claude-code-action@9db782c3a17ef2bfc274cd17411bc3e0a5ba1345 # v1.0.115
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/dev-ai-newsletter.yml
+++ b/.github/workflows/dev-ai-newsletter.yml
@@ -385,7 +385,7 @@ jobs:
       # Run Claude Code with MCP servers
       - name: Generate newsletter with Claude
         id: claude
-        uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1.0.75
+        uses: anthropics/claude-code-action@9db782c3a17ef2bfc274cd17411bc3e0a5ba1345 # v1.0.115
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |


### PR DESCRIPTION
## Summary

- Bumps `anthropics/claude-code-action` pin from `df37d2f` (v1.0.75) to `9db782c` (v1.0.115) across all 7 reusable workflow files.
- Pin had drifted 40 versions stale because the [`update-claude-code-action.yml` auto-updater](.github/workflows/update-claude-code-action.yml) has been failing on every run since at least 2026-04-20 — the GitHub App token lacks `workflows` permission, so it cannot push branches that touch `.github/workflows/*.yml`. Out of scope for this PR; tracked separately.
- No breaking changes: input surface is identical between versions (34 inputs, no additions/removals/default changes). 73 commits between versions are mostly Claude Code SDK bumps + hang-fix patches.

## Why

Reported failure: [Uniswap/universe PR #32228 claude review job 74860643276](https://github.com/Uniswap/universe/actions/runs/25508505315/job/74860643276).

Surface error:
```
error: Cannot find module '@octokit/rest' from '/home/runner/work/_actions/anthropics/claude-code-action/df37d2f0760a4b5683a6e617c9325bc1a36443f6/src/github/api/client.ts'
```

Underlying cause: `bun install --production` inside the action's directory hung past the job timeout (logs show 16:26:54 install start → 16:46:16 cancellation, with no progress output in between). When the cancellation killed the install step, the post-step then ran `bun run` against a node_modules tree that had no `@octokit/rest` because the install never completed.

## What v1.0.115 brings that helps

- **#1174 `fix: pin bun runtime config and improve log hygiene`** — `bun run` now passes `--config="${GITHUB_ACTION_PATH}/bunfig.toml"` so runner-level bun config can no longer leak in.
- **#1166 `fix: prevent hang in restoreConfigFromBase on repos with .gitmodules`** — direct hang-prevention.
- **#1163 `fix: restore ripgrep execute bits after bun install --production`** — addresses a `bun install` side-effect.
- **#1132 add subprocess isolation setup**, **#1238 setup-bun v2.2.0 (Node.js 24)**, **#1248/#1167 branch-name handling**.

## Test plan

- [ ] CI passes on this PR (lint, typecheck, test all green locally).
- [ ] Smoke test in `Uniswap/ai-sandbox`: pin `ai-sandbox`'s reusable-workflow ref on `main` to this PR's HEAD SHA, then open a test PR there and confirm the claude code review check completes.
- [ ] Confirm no consuming repo (`universe`, `frontend-monorepo`, etc.) breaks on the cutover.

## Follow-up

The auto-updater workflow needs its bot identity changed to one with `workflows` permission, otherwise this drift will recur. Out of scope for this PR.

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
- Bumps `anthropics/claude-code-action` pin from `df37d2f` (v1.0.75) to `9db782c` (v1.0.115) across all 7 reusable workflow files.
- Adds `registry.npmjs.org` to the bullfrog egress allowlist in `_claude-code-review.yml`, `_claude-docs-check.yml`, and `_claude-main.yml` so `bun install` inside the action can reach the npm registry.
- Adds `bun.sh` to the egress allowlist in `_claude-main.yml` (was already present in the other workflows).
- Pin had drifted 40 versions stale because the [`update-claude-code-action.yml` auto-updater](.github/workflows/update-claude-code-action.yml) has been failing on every run since at least 2026-04-20 — the GitHub App token lacks `workflows` permission, so it cannot push branches that touch `.github/workflows/*.yml`. Out of scope for this PR; tracked separately.
- No breaking changes: input surface is identical between versions (34 inputs, no additions/removals/default changes). 73 commits between versions are mostly Claude Code SDK bumps + hang-fix patches.
## Why
Reported failure: [Uniswap/universe PR #32228 claude review job 74860643276](https://github.com/Uniswap/universe/actions/runs/25508505315/job/74860643276).
Surface error:
```
error: Cannot find module '@octokit/rest' from '/home/runner/work/_actions/anthropics/claude-code-action/df37d2f0760a4b5683a6e617c9325bc1a36443f6/src/github/api/client.ts'
```
Underlying cause: `bun install --production` inside the action's directory hung past the job timeout (logs show 16:26:54 install start → 16:46:16 cancellation, with no progress output in between). When the cancellation killed the install step, the post-step then ran `bun run` against a node_modules tree that had no `@octokit/rest` because the install never completed.
## What v1.0.115 brings that helps
- **#1174 `fix: pin bun runtime config and improve log hygiene`** — `bun run` now passes `--config="${GITHUB_ACTION_PATH}/bunfig.toml"` so runner-level bun config can no longer leak in.
- **#1166 `fix: prevent hang in restoreConfigFromBase on repos with .gitmodules`** — direct hang-prevention.
- **#1163 `fix: restore ripgrep execute bits after bun install --production`** — addresses a `bun install` side-effect.
- **#1132 add subprocess isolation setup**, **#1238 setup-bun v2.2.0 (Node.js 24)**, **#1248/#1167 branch-name handling**.
## Changes
| File | Change |
|------|--------|
| `.github/workflows/_claude-code-review.yml` | Bump pin in 2 steps (review + auto-fix); add `registry.npmjs.org` to egress allowlist |
| `.github/workflows/_claude-docs-check.yml` | Bump pin in 2 steps (docs check + auto-fix); add `registry.npmjs.org` to egress allowlist |
| `.github/workflows/_claude-main.yml` | Bump pin; add `bun.sh` and `registry.npmjs.org` to egress allowlist |
| `.github/workflows/_claude-task-worker.yml` | Bump pin |
| `.github/workflows/_generate-pr-metadata.yml` | Bump pin in 2 steps (quality gate + generation) |
| `.github/workflows/_update-action-versions-worker.yml` | Bump pin |
| `.github/workflows/dev-ai-newsletter.yml` | Bump pin |
## Test plan
- [ ] CI passes on this PR (lint, typecheck, test all green locally).
- [ ] Smoke test in `Uniswap/ai-sandbox`: pin `ai-sandbox`'s reusable-workflow ref on `main` to this PR's HEAD SHA, then open a test PR there and confirm the claude code review check completes.
- [ ] Confirm no consuming repo (`universe`, `frontend-monorepo`, etc.) breaks on the cutover.
## Follow-up
The auto-updater workflow needs its bot identity changed to one with `workflows` permission, otherwise this drift will recur. Out of scope for this PR.

</details>
<!-- claude-pr-description-end -->