### PR TITLE
fix(workflows): bump claude-code-action and expand egress allowlists

### DIFF
--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -285,6 +285,7 @@ jobs:
             *.githubusercontent.com
             api.anthropic.com
             claude.ai
+            *.claude.ai
             bun.sh
             registry.npmjs.org
             *.npmjs.org

--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -285,6 +285,8 @@ jobs:
             *.githubusercontent.com
             api.anthropic.com
             bun.sh
+            registry.npmjs.org
+            *.npmjs.org
           enable-sudo: false
 
       # Checkout required before using local composite actions

--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -284,6 +284,7 @@ jobs:
             *.github.com
             *.githubusercontent.com
             api.anthropic.com
+            claude.ai
             bun.sh
             registry.npmjs.org
             *.npmjs.org

--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -1158,7 +1158,7 @@ jobs:
       - name: Run Claude Code Review
         if: steps.cache-check.outputs.cache-hit != 'true' && steps.diff-size.outputs.is_too_large != 'true'
         id: claude
-        uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1.0.75
+        uses: anthropics/claude-code-action@9db782c3a17ef2bfc274cd17411bc3e0a5ba1345 # v1.0.115
         with:
           # Authentication: provide either API key or OAuth token (validated in earlier step)
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -1651,7 +1651,7 @@ jobs:
       - name: Run Claude Auto-Fix
         id: claude-fix
         if: steps.auto-fix-check.outputs.should_fix == 'true' && steps.pr-branch.outputs.repo_full_name == github.repository
-        uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1.0.75
+        uses: anthropics/claude-code-action@9db782c3a17ef2bfc274cd17411bc3e0a5ba1345 # v1.0.115
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/_claude-docs-check.yml
+++ b/.github/workflows/_claude-docs-check.yml
@@ -207,6 +207,7 @@ jobs:
             *.githubusercontent.com
             api.anthropic.com
             claude.ai
+            *.claude.ai
             bun.sh
             registry.npmjs.org
             *.npmjs.org

--- a/.github/workflows/_claude-docs-check.yml
+++ b/.github/workflows/_claude-docs-check.yml
@@ -206,6 +206,7 @@ jobs:
             *.github.com
             *.githubusercontent.com
             api.anthropic.com
+            claude.ai
             bun.sh
             registry.npmjs.org
             *.npmjs.org

--- a/.github/workflows/_claude-docs-check.yml
+++ b/.github/workflows/_claude-docs-check.yml
@@ -648,7 +648,7 @@ jobs:
       # Run Claude
       - name: Run Claude Docs Check
         id: claude
-        uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1.0.75
+        uses: anthropics/claude-code-action@9db782c3a17ef2bfc274cd17411bc3e0a5ba1345 # v1.0.115
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -970,7 +970,7 @@ jobs:
       - name: Run Claude Auto-Fix
         id: claude-fix
         if: steps.auto-fix-check.outputs.should_fix == 'true' && steps.pr-branch.outputs.repo_full_name == github.repository
-        uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1.0.75
+        uses: anthropics/claude-code-action@9db782c3a17ef2bfc274cd17411bc3e0a5ba1345 # v1.0.115
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/_claude-docs-check.yml
+++ b/.github/workflows/_claude-docs-check.yml
@@ -207,6 +207,8 @@ jobs:
             *.githubusercontent.com
             api.anthropic.com
             bun.sh
+            registry.npmjs.org
+            *.npmjs.org
           enable-sudo: false
 
       # Initial checkout

--- a/.github/workflows/_claude-main.yml
+++ b/.github/workflows/_claude-main.yml
@@ -301,6 +301,9 @@ jobs:
             *.github.com
             *.githubusercontent.com
             api.anthropic.com
+            bun.sh
+            registry.npmjs.org
+            *.npmjs.org
           enable-sudo: false
 
       # FIXED: Checkout with consistent fetch depth
@@ -421,7 +424,7 @@ jobs:
       # Supports both API key and OAuth token authentication (validated in earlier step)
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1.0.75
+        uses: anthropics/claude-code-action@9db782c3a17ef2bfc274cd17411bc3e0a5ba1345 # v1.0.115
         with:
           # Authentication: provide either API key or OAuth token (validated in earlier step)
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/_claude-main.yml
+++ b/.github/workflows/_claude-main.yml
@@ -301,6 +301,7 @@ jobs:
             *.github.com
             *.githubusercontent.com
             api.anthropic.com
+            claude.ai
             bun.sh
             registry.npmjs.org
             *.npmjs.org

--- a/.github/workflows/_claude-main.yml
+++ b/.github/workflows/_claude-main.yml
@@ -302,6 +302,7 @@ jobs:
             *.githubusercontent.com
             api.anthropic.com
             claude.ai
+            *.claude.ai
             bun.sh
             registry.npmjs.org
             *.npmjs.org

--- a/.github/workflows/_claude-task-worker.yml
+++ b/.github/workflows/_claude-task-worker.yml
@@ -500,7 +500,7 @@ jobs:
       # Supports both API key and OAuth token authentication (OAuth takes precedence)
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1.0.75
+        uses: anthropics/claude-code-action@9db782c3a17ef2bfc274cd17411bc3e0a5ba1345 # v1.0.115
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/_generate-pr-metadata.yml
+++ b/.github/workflows/_generate-pr-metadata.yml
@@ -431,7 +431,7 @@ jobs:
           steps.quality-gate-prep.outputs.has_user_content == 'true'
         id: quality-gate-eval
         continue-on-error: true
-        uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1.0.75
+        uses: anthropics/claude-code-action@9db782c3a17ef2bfc274cd17411bc3e0a5ba1345 # v1.0.115
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -877,7 +877,7 @@ jobs:
       - name: Run Claude Code Generation
         if: steps.cache-check.outputs.cache-hit != 'true' && steps.quality-gate.outputs.should_skip != 'true'
         id: claude
-        uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1.0.75
+        uses: anthropics/claude-code-action@9db782c3a17ef2bfc274cd17411bc3e0a5ba1345 # v1.0.115
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/_update-action-versions-worker.yml
+++ b/.github/workflows/_update-action-versions-worker.yml
@@ -404,7 +404,7 @@ jobs:
       # Supports both API key and OAuth token authentication (OAuth takes precedence)
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1.0.75
+        uses: anthropics/claude-code-action@9db782c3a17ef2bfc274cd17411bc3e0a5ba1345 # v1.0.115
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/dev-ai-newsletter.yml
+++ b/.github/workflows/dev-ai-newsletter.yml
@@ -385,7 +385,7 @@ jobs:
       # Run Claude Code with MCP servers
       - name: Generate newsletter with Claude
         id: claude
-        uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1.0.75
+        uses: anthropics/claude-code-action@9db782c3a17ef2bfc274cd17411bc3e0a5ba1345 # v1.0.115
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |


### PR DESCRIPTION
## Summary

Two bundled fixes to unblock automated PR review and related Claude workflows:

1. **Bullfrog block-mode allowlist gaps.** `claude-code-action`'s setup step runs `bun install --production` to fetch its own runtime deps (e.g. `@octokit/rest`) from `registry.npmjs.org`. Three reusable workflows had block-mode allowlists that didn't permit the npm registry, hanging the install until the job timeout (~20m) and surfacing the misleading downstream error `Cannot find module '@octokit/rest'`.
2. **`anthropics/claude-code-action` pin v1.0.75 → v1.0.115** across all 10 use sites. The pin had drifted 40 versions stale because the `update-claude-code-action.yml` auto-updater has been failing on every run since 2026-04-20 (the GH App token used by that job lacks `workflows` permission). The stale pin was triggering API errors (`\"thinking.type.enabled\" is not supported for this model`) once the egress fix unblocked actually reaching the model call.

First observed in the wild on [Uniswap/universe#32228](https://github.com/Uniswap/universe/runs/74860643276).

## What changed

**Allowlist expansions (3 workflows):**
- `_claude-code-review.yml` — added `registry.npmjs.org`, `*.npmjs.org`
- `_claude-docs-check.yml` — added `registry.npmjs.org`, `*.npmjs.org`
- `_claude-main.yml` — added `bun.sh` AND `registry.npmjs.org`, `*.npmjs.org` (this workflow was missing both; it was a latent twin that hadn't been visibly broken because it only fires on `@claude` mentions)

**Action SHA bump (10 use sites across 7 files):**
- `df37d2f0760a4b5683a6e617c9325bc1a36443f6` (v1.0.75) → `9db782c3a17ef2bfc274cd17411bc3e0a5ba1345` (v1.0.115)
- The bump itself is API-stable (identical 34-input surface). The 73 intervening commits are mostly Claude Code SDK bumps, including the API schema fixes that resolve the `thinking.type.enabled` error.

## Test plan

- [x] **Diagnosed root cause** — confirmed via the failing job log that `bun install --production` started at 16:26:54, hung for ~19 minutes, and was canceled. Bullfrog cleanup output showed `Blocked DNS request to registry.npmjs.org` (and the Azure search-domain variant) as the only blocked hosts.
- [x] **Verified other passing workflows** — `Build check`, `Run Typecheck, Lint, and Build`, etc. all passed because they have npm allowed; the gap was specific to these reusable workflows.
- [x] **Verified the v1.0.75 → v1.0.115 surface is API-stable** — same 34 inputs, no additions/removals/default changes between the versions.
- [x] **Diff is minimal** — only allowlist additions and SHA replacements; no behavior changes elsewhere.
- [ ] **Validate against `Uniswap/universe#32228`** — once this lands and ships, bump the pinned `toolkit_ref` in `Uniswap/universe/.github/workflows/claude-code-review.yml` (currently `96ef665ba04221de07e94fcc3ea69fe32c7cf306`) and re-run the failed check.
- [ ] **Latent fixes** (`_claude-docs-check.yml`, `_claude-main.yml`) — will be exercised on their next trigger.

## Session context

### Investigation

The failed `claude-review-auto / claude-review` check on Uniswap/universe#32228 surfaced as `Cannot find module '@octokit/rest'`, which initially looked like a missing dep declaration. Reading the log backwards showed `bun install --production` had been running for 19m22s before GHA cancelled the step — the missing-module error was downstream of an install that never completed. Bullfrog's post-job cleanup included `Blocked DNS request to registry.npmjs.org` warnings, confirming the hang was caused by the firewall.

The two changes are bundled because the egress fix exposes the stale-pin failures: as long as `bun install` was hanging, the workflow never reached the model call where the v1.0.75 schema mismatch fails. Fixing one without the other would just trade a hang for a 400 error.

### Options evaluated and rejected

- **Add the per-VM `registry.npmjs.org.<azure-suffix>.internal.cloudapp.net` form seen in logs.** Rejected: the suffix is per-runner ephemeral; the resolver only tries the search-domain form when the bare query is denied. Allowlisting the bare name is sufficient.
- **Add `*.cloudapp.net` for safety.** Rejected: would allow egress to arbitrary Azure-hosted services.
- **Switch back to `egress-policy: audit`.** Rejected: the workflow comments explicitly direct maintainers to update the allowlist rather than reverting to audit. Block mode is intentional defense against malicious config files in fork PRs.
- **Skip `_claude-main.yml`** (since it hasn't visibly broken). Rejected: it's the same root cause and would silently break the next time someone `@claude`-mentions in a PR.
- **Keep on v1.0.75 and only fix the allowlist.** Rejected: stale pin causes API 400 errors on `thinking.type.enabled`. The egress fix unmasks this; need both.

### Constraints discovered

- The pinned SHA in `Uniswap/universe/.github/workflows/claude-code-review.yml` (`96ef665b…`) is identical on `next` w.r.t. the allowlist and SHA pin, so the fix is current and complete on `next`.
- The auto-updater (`update-claude-code-action.yml`) has been broken since 2026-04-20 — this is what allowed the pin to drift 40 versions. Tracked separately; not fixed here. Root cause: `refusing to allow a GitHub App to create or update workflow … without 'workflows' permission`.

### Known limitations

- `Uniswap/universe` (and any other consumer repos) won't pick this up automatically — they pin `toolkit_ref` to a specific SHA. A follow-up PR per consumer is needed once this lands.
- `ci-check-pr-title.yml` is also in block mode but uses GHA's default allowlist (no `allowed-domains` set). Does only sparse checkout + composite action; doesn't appear to need npm. Out of scope.
- Pre-existing semgrep findings about `bun run` in some of the touched files are flagged but already mitigated at the job level via `BUN_CONFIG_FILE: /dev/null` (with explicit comments in the workflow documenting that as the primary defense). Unrelated to this change.

<details>
<summary>Timeline</summary>

1. **Triage** — fetched checks for `Uniswap/universe#32228`; only `claude-review-auto / claude-review` failed.
2. **First read of failed log** — looked like a missing-module bug; the real failure was 19 minutes earlier in `bun install`.
3. **Hypothesis: bullfrog audit mode** — checked `claude.yml` and `claude-auto-tasks.yml` in universe, both used `egress-policy: audit`. Almost concluded warnings were benign.
4. **Followed the reusable workflow chain** — `claude-code-review.yml` calls `Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@96ef665b`, which sets `egress-policy: block` with no npm host allowed. That's the actual config that ran.
5. **Initial PR (this one)** — added `registry.npmjs.org` and `*.npmjs.org` to two workflows.
6. **Reviewer feedback** — flagged `_claude-main.yml` as a latent twin missing both `bun.sh` and `registry.npmjs.org`; also flagged the orthogonal `claude-code-action` pin staleness; closed the parallel #500 in favor of this PR.
7. **Bundled the SHA bump and the third workflow's allowlist fix**, applied across all 10 use sites in 7 workflow files.

</details>



🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Two bundled fixes to unblock automated PR review and related Claude workflows:
1. **Bullfrog block-mode allowlist gaps.** `claude-code-action`'s setup step runs `bun install --production` to fetch its own runtime deps (e.g. `@octokit/rest`) from `registry.npmjs.org`, and on the SDK install path it also reaches `claude.ai`. Three reusable workflows had block-mode allowlists that didn't permit these hosts, hanging the install until the job timeout (~20m) and surfacing the misleading downstream error `Cannot find module '@octokit/rest'`.
2. **`anthropics/claude-code-action` pin v1.0.75 → v1.0.115** across all 10 use sites. The pin had drifted 40 versions stale because the `update-claude-code-action.yml` auto-updater has been failing on every run since 2026-04-20 (the GH App token used by that job lacks `workflows` permission). The stale pin was triggering API errors (`"thinking.type.enabled" is not supported for this model`) once the egress fix unblocked actually reaching the model call.
First observed in the wild on [Uniswap/universe#32228](https://github.com/Uniswap/universe/runs/74860643276).
## What changed
**Allowlist expansions (3 workflows):**
- `_claude-code-review.yml` — added `registry.npmjs.org`, `*.npmjs.org`, `claude.ai`, `*.claude.ai`
- `_claude-docs-check.yml` — added `registry.npmjs.org`, `*.npmjs.org`, `claude.ai`, `*.claude.ai`
- `_claude-main.yml` — added `bun.sh`, `registry.npmjs.org`, `*.npmjs.org`, `claude.ai`, `*.claude.ai` (this workflow was missing all of them; latent twin not visibly broken because it only fires on `@claude` mentions)
**Action SHA bump (10 use sites across 7 files):**
- `df37d2f0760a4b5683a6e617c9325bc1a36443f6` (v1.0.75) → `9db782c3a17ef2bfc274cd17411bc3e0a5ba1345` (v1.0.115)
- The bump itself is API-stable (identical 34-input surface). The 73 intervening commits are mostly Claude Code SDK bumps, including the API schema fixes that resolve the `thinking.type.enabled` error.
## Test plan
- [x] **Diagnosed root cause** — confirmed via the failing job log that `bun install --production` started at 16:26:54, hung for ~19 minutes, and was canceled. Bullfrog cleanup output showed `Blocked DNS request to registry.npmjs.org` (and the Azure search-domain variant) as the only blocked hosts.
- [x] **Verified other passing workflows** — `Build check`, `Run Typecheck, Lint, and Build`, etc. all passed because they have npm allowed; the gap was specific to these reusable workflows.
- [x] **Verified the v1.0.75 → v1.0.115 surface is API-stable** — same 34 inputs, no additions/removals/default changes between the versions.
- [x] **Diff is minimal** — only allowlist additions and SHA replacements; no behavior changes elsewhere.
- [ ] **Validate against `Uniswap/universe#32228`** — once this lands and ships, bump the pinned `toolkit_ref` in `Uniswap/universe/.github/workflows/claude-code-review.yml` and re-run the failed check.
- [ ] **Latent fixes** (`_claude-docs-check.yml`, `_claude-main.yml`) — will be exercised on their next trigger.
## Session context
### Investigation
The failed `claude-review-auto / claude-review` check on Uniswap/universe#32228 surfaced as `Cannot find module '@octokit/rest'`, which initially looked like a missing dep declaration. Reading the log backwards showed `bun install --production` had been running for 19m22s before GHA cancelled the step — the missing-module error was downstream of an install that never completed. Bullfrog's post-job cleanup included `Blocked DNS request to registry.npmjs.org` warnings, confirming the hang was caused by the firewall.
The two changes are bundled because the egress fix exposes the stale-pin failures: as long as `bun install` was hanging, the workflow never reached the model call where the v1.0.75 schema mismatch fails. Fixing one without the other would just trade a hang for a 400 error.
### Options evaluated and rejected
- **Add the per-VM `registry.npmjs.org.<azure-suffix>.internal.cloudapp.net` form seen in logs.** Rejected: the suffix is per-runner ephemeral; the resolver only tries the search-domain form when the bare query is denied. Allowlisting the bare name is sufficient.
- **Add `*.cloudapp.net` for safety.** Rejected: would allow egress to arbitrary Azure-hosted services.
- **Switch back to `egress-policy: audit`.** Rejected: the workflow comments explicitly direct maintainers to update the allowlist rather than reverting to audit. Block mode is intentional defense against malicious config files in fork PRs.
- **Skip `_claude-main.yml`** (since it hasn't visibly broken). Rejected: it's the same root cause and would silently break the next time someone `@claude`-mentions in a PR.
- **Keep on v1.0.75 and only fix the allowlist.** Rejected: stale pin causes API 400 errors on `thinking.type.enabled`. The egress fix unmasks this; need both.
### Known limitations
- `Uniswap/universe` (and any other consumer repos) won't pick this up automatically — they pin `toolkit_ref` to a specific SHA. A follow-up PR per consumer is needed once this lands.
- The auto-updater (`update-claude-code-action.yml`) has been broken since 2026-04-20 — this is what allowed the pin to drift 40 versions. Tracked separately; not fixed here. Root cause: `refusing to allow a GitHub App to create or update workflow … without 'workflows' permission`.
- `ci-check-pr-title.yml` is also in block mode but uses GHA's default allowlist (no `allowed-domains` set). Does only sparse checkout + composite action; doesn't appear to need npm. Out of scope.
- Pre-existing semgrep findings about `bun run` in some of the touched files are flagged but already mitigated at the job level via `BUN_CONFIG_FILE: /dev/null` (with explicit comments in the workflow documenting that as the primary defense). Unrelated to this change.

</details>
<!-- claude-pr-description-end -->