### PR TITLE
fix(workflows): mark Claude action steps continue-on-error

### DIFF
--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -1160,6 +1160,12 @@ jobs:
       - name: Run Claude Code Review
         if: steps.cache-check.outputs.cache-hit != 'true' && steps.diff-size.outputs.is_too_large != 'true'
         id: claude
+        # Tolerate action-level failures so the job degrades gracefully via the
+        # downstream "Fallback Review Comment" step (gated on failure()). Without
+        # this, transient errors (workflow validation guard on PRs that modify
+        # .github/workflows/**, API outages, rate limits) fail a required check
+        # despite the workflow already surfacing the error to the PR.
+        continue-on-error: true
         uses: anthropics/claude-code-action@476e359e6203e73dad705c8b322e333fabbd7416 # v1.0.119
         with:
           # Authentication: provide either API key or OAuth token (validated in earlier step)

--- a/.github/workflows/_generate-pr-metadata.yml
+++ b/.github/workflows/_generate-pr-metadata.yml
@@ -877,6 +877,12 @@ jobs:
       - name: Run Claude Code Generation
         if: steps.cache-check.outputs.cache-hit != 'true' && steps.quality-gate.outputs.should_skip != 'true'
         id: claude
+        # Tolerate action-level failures so the job degrades gracefully via the
+        # downstream "Post Generation Error Comment" step (gated on failure()).
+        # Without this, transient errors (workflow validation guard on PRs that
+        # modify .github/workflows/**, API outages, rate limits) fail a required
+        # check despite the workflow already surfacing the error to the PR.
+        continue-on-error: true
         uses: anthropics/claude-code-action@476e359e6203e73dad705c8b322e333fabbd7416 # v1.0.119
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

Two reusable workflows (`_generate-pr-metadata.yml`, `_claude-code-review.yml`) invoke `anthropics/claude-code-action` without `continue-on-error: true`, even though both files already implement graceful-degradation via downstream "Fallback Comment" / "Post Generation Error Comment" steps gated on `failure()`. The result: any non-zero exit from the action fails a required check for downstream consumers, despite the workflow having a perfectly good error path that surfaces the failure to the PR as a comment.

This PR adds `continue-on-error: true` to both action steps so the job reports `success` while the error is communicated through the existing PR-comment fallback.

## What changed

**`_generate-pr-metadata.yml`** (line 877, "Run Claude Code Generation"): adds `continue-on-error: true` plus a 5-line comment explaining why. The quality-gate-eval step at line 427 already uses this pattern — the main generation step was an oversight; aligning both with existing precedent.

**`_claude-code-review.yml`** (line 1160, "Run Claude Code Review"): same change, same precedent, same downstream `Fallback Review Comment` step on `failure()` that already handles this case.

Net effect on each workflow:
- Action exits non-zero → step marked failed, but `continue-on-error: true` keeps the job's overall status as success
- `failure()` expression on the fallback-comment step still evaluates true → PR comment posted (existing behavior, unchanged)
- `success()` expression on downstream steps (Update PR Metadata, Post Review, cache writes) still evaluates false → they correctly skip when Claude failed (existing behavior, unchanged)

Total diff: 2 files, +12 / -0 lines.

## Why this matters now

Downstream consumers (`Uniswap/uniswap-ai`) are blocked. Concrete trail:

1. **`Uniswap/uniswap-ai#104`** (`chore/sync-ai-toolkit-workflows`) has been BLOCKED for 5+ days on the `generate-metadata` required check. Its only purpose is to refresh the ai-toolkit pin in uniswap-ai's calling workflows — every recent PR with this purpose has hit the same failure.
2. **`Uniswap/uniswap-ai#105`** re-discovered the same trap today after re-signing commits and bumping the toolkit pin to `b39cd9a`. With the new pin, `docs-check` now passes (resolving an earlier `@octokit/rest` packaging bug in the previously-pinned action), but `generate-metadata` fails with:

   ```
   ##[error]Action failed with error: Workflow validation failed. The workflow
   file must exist and have identical content to the version on the repository's
   default branch.
   ```

   This is `anthropics/claude-code-action@v1.0.119`'s own self-protection guard: it refuses to run on PRs that modify `.github/workflows/**`. That's *correct security behavior* on the action's part — an attacker could otherwise use a PR-time workflow edit to escalate through the action's elevated permissions. But it's fatal for legitimate toolkit-maintenance PRs, action-version refreshes, and permission tweaks that legitimately need to touch workflow files.

3. The same trap explains why `update-claude-code-action.yml`'s auto-updater has been failing since 2026-04-20 (mentioned in PR #501's commit body). Any automated agent that bumps action pins lands in the same dead-end.

This change doesn't fix the action's guard (it's not ours to fix, and the guard is correct). It just stops the guard's trip from failing a required check when the workflow already has a graceful-degradation path.

## Test plan

- [x] YAML parses
- [x] `git diff` confirms the only changes are the additions (no whitespace drift, no other lines touched)
- [x] Confirmed graceful-degradation semantics: `failure()` and `success()` expressions still evaluate correctly with `continue-on-error: true` (per GitHub Actions docs and existing precedent in this same file's quality-gate-eval step)
- [ ] CI on this PR
- [ ] Smoke-test: rebase `Uniswap/uniswap-ai#105` on a uniswap-ai branch that pins this PR's SHA and confirm `generate-metadata` reports success while still posting the error comment when the underlying action fails

## Session context

### Investigation

Started from `Uniswap/uniswap-ai#105` being BLOCKED. Triaged in this order:
1. Original block: `commits must have verified signatures` ruleset → re-signed PR head, GitHub-verified.
2. Next block: `docs-check / docs-check` cancelled at 15-min timeout. Root cause: previously-pinned ai-toolkit `96ef665b` carried `anthropics/claude-code-action@df37d2f` (v1.0.75), which has a packaging bug — its source imports `@octokit/rest` but the dependency isn't bundled (`Cannot find module '@octokit/rest'`).
3. Bumped uniswap-ai's ai-toolkit pin to `b39cd9a` (latest main). `docs-check` now passes (uses action v1.0.119, packaging bug fixed).
4. **New block: `generate-metadata` FAILURE on the workflow-validation guard.** That's the trap this PR addresses.
5. Separately: `claude-review-auto` FAILURE on `fatal: unable to access 'https://github.com/Uniswap/uniswap-ai/'`. Different issue — appears to be a Node 24 / bullfrog egress interaction. NOT addressed in this PR; separately tracked on `chore/node-24-upgrade`.

### Options evaluated

**Option A — Gate the action on `paths-filter`/`dorny/paths-filter`: skip when `.github/workflows/**` changed.** Cleaner semantically but adds a new action dependency and changes when the workflow runs (a workflow-changing PR gets no review at all). Rejected: less information for the reviewer is worse than a posted-error-comment.

**Option B — Set `continue-on-error: true` on the action step.** Preserves all existing behavior (fallback comment still posts, downstream steps still skip via `success()`) while making the required check pass. Minimal-surface change. **Chosen.**

**Option C — Add `track_progress: false` to silently skip the action's workflow-validation code path.** Tested theory by inspecting workflow inputs: `_claude-docs-check.yml` (passes) and the main-generation call in `_generate-pr-metadata.yml` (fails) BOTH pass `track_progress: false`. The quality-gate-eval call (also fails) does not. So `track_progress` is not the differentiator. Rejected: theory disproven by empirical evidence.

**Option D — Bump `anthropics/claude-code-action` further to see if a newer release softens the guard.** Skimmed v1.0.119 release notes and recent commits; no evidence of behavior change in this area. Rejected: speculative, and any newer release would still preserve the security property of the guard.

### Constraints discovered

- The action's `Workflow validation failed` error is not GitHub API; it's the action's own self-protection. Cannot be fixed by allowlist/permissions tweaks in the workflow YAML — only by either gating the action or tolerating its failure.
- `_claude-docs-check.yml` already passes on workflow-modifying PRs at v1.0.119 (verified on `Uniswap/uniswap-ai#105` run `25761569991`). This means the guard does NOT fire unconditionally; it depends on which API path the action takes. The exact trigger isn't documented upstream, but empirically the `_generate-pr-metadata.yml` invocation path triggers it. Tolerating failure is more reliable than trying to reverse-engineer the trigger.
- `_claude-code-review.yml` on `Uniswap/uniswap-ai#105` failed BEFORE reaching the Claude action (at the `actions/checkout` step, against the bullfrog egress firewall). That's a different bug, tracked on `chore/node-24-upgrade`. This PR's change to `_claude-code-review.yml` is preemptive — it ensures the file follows the same pattern as `_generate-pr-metadata.yml` so when the Node 24 / bullfrog issue is resolved separately, `_claude-code-review.yml`'s Claude action call won't trip the same workflow-validation trap.

### Known limitations

- Does NOT address the auto-updater (`update-claude-code-action.yml`) failing on the same trap. That workflow uses a GitHub App token without `workflows: write` permission (per PR #501's commit body). Separate fix; this PR unblocks the manual path so an org admin can ship the auto-updater fix without being blocked on every intermediate PR.
- Does NOT address the `claude-review-auto` Node 24 / bullfrog interaction — separately tracked on `chore/node-24-upgrade`.
- A truly transient failure (e.g., Anthropic API outage) now reports `success` at the required-check level. The fallback comment on the PR is the only signal. This is a deliberate trade-off: the alternative (failing required check on every API blip) is worse for legitimate PR throughput.

### Refs
- `Uniswap/uniswap-ai#104` — same trap, BLOCKED 5+ days
- `Uniswap/uniswap-ai#105` — same trap, rediscovered today
- `Uniswap/ai-toolkit#501` — previous "expand egress allowlists" PR (different fix path; doesn't address this guard)
- `Uniswap/ai-toolkit#503` — bumped action to v1.0.119 (the version with the guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Two reusable workflows (`_generate-pr-metadata.yml`, `_claude-code-review.yml`) invoke `anthropics/claude-code-action` without `continue-on-error: true`, even though both files already implement graceful-degradation via downstream "Fallback Comment" / "Post Generation Error Comment" steps gated on `failure()`. The result: any non-zero exit from the action fails a required check for downstream consumers, despite the workflow having a perfectly good error path that surfaces the failure to the PR as a comment.
This PR adds `continue-on-error: true` to both action steps so the job reports `success` while the error is communicated through the existing PR-comment fallback.
## What changed
**`_generate-pr-metadata.yml`** (line 877, "Run Claude Code Generation"): adds `continue-on-error: true` plus a 5-line comment explaining why. The quality-gate-eval step at line 427 already uses this pattern — the main generation step was an oversight; aligning both with existing precedent.
**`_claude-code-review.yml`** (line 1160, "Run Claude Code Review"): same change, same precedent, same downstream `Fallback Review Comment` step on `failure()` that already handles this case.
Net effect on each workflow:
- Action exits non-zero → step marked failed, but `continue-on-error: true` keeps the job's overall status as success
- `failure()` expression on the fallback-comment step still evaluates true → PR comment posted (existing behavior, unchanged)
- `success()` expression on downstream steps (Update PR Metadata, Post Review, cache writes) still evaluates false → they correctly skip when Claude failed (existing behavior, unchanged)
Total diff: 2 files, +12 / -0 lines.
## Why this matters now
Downstream consumers (`Uniswap/uniswap-ai`) are blocked. Concrete trail:
1. **`Uniswap/uniswap-ai#104`** (`chore/sync-ai-toolkit-workflows`) has been BLOCKED for 5+ days on the `generate-metadata` required check. Its only purpose is to refresh the ai-toolkit pin in uniswap-ai's calling workflows — every recent PR with this purpose has hit the same failure.
2. **`Uniswap/uniswap-ai#105`** re-discovered the same trap today after re-signing commits and bumping the toolkit pin to `b39cd9a`. With the new pin, `docs-check` now passes (resolving an earlier `@octokit/rest` packaging bug in the previously-pinned action), but `generate-metadata` fails with:
   ```
   ##[error]Action failed with error: Workflow validation failed. The workflow
   file must exist and have identical content to the version on the repository's
   default branch.
   ```
   This is `anthropics/claude-code-action@v1.0.119`'s own self-protection guard: it refuses to run on PRs that modify `.github/workflows/**`. That's *correct security behavior* on the action's part — an attacker could otherwise use a PR-time workflow edit to escalate through the action's elevated permissions. But it's fatal for legitimate toolkit-maintenance PRs, action-version refreshes, and permission tweaks that legitimately need to touch workflow files.
3. The same trap explains why `update-claude-code-action.yml`'s auto-updater has been failing since 2026-04-20 (mentioned in PR #501's commit body). Any automated agent that bumps action pins lands in the same dead-end.
This change doesn't fix the action's guard (it's not ours to fix, and the guard is correct). It just stops the guard's trip from failing a required check when the workflow already has a graceful-degradation path.
## Test plan
- [x] YAML parses
- [x] `git diff` confirms the only changes are the additions (no whitespace drift, no other lines touched)
- [x] Confirmed graceful-degradation semantics: `failure()` and `success()` expressions still evaluate correctly with `continue-on-error: true` (per GitHub Actions docs and existing precedent in this same file's quality-gate-eval step)
- [ ] CI on this PR
- [ ] Smoke-test: rebase `Uniswap/uniswap-ai#105` on a uniswap-ai branch that pins this PR's SHA and confirm `generate-metadata` reports success while still posting the error comment when the underlying action fails
## Session context
### Investigation
Started from `Uniswap/uniswap-ai#105` being BLOCKED. Triaged in this order:
1. Original block: `commits must have verified signatures` ruleset → re-signed PR head, GitHub-verified.
2. Next block: `docs-check / docs-check` cancelled at 15-min timeout. Root cause: previously-pinned ai-toolkit `96ef665b` carried `anthropics/claude-code-action@df37d2f` (v1.0.75), which has a packaging bug — its source imports `@octokit/rest` but the dependency isn't bundled (`Cannot find module '@octokit/rest'`).
3. Bumped uniswap-ai's ai-toolkit pin to `b39cd9a` (latest main). `docs-check` now passes (uses action v1.0.119, packaging bug fixed).
4. **New block: `generate-metadata` FAILURE on the workflow-validation guard.** That's the trap this PR addresses.
5. Separately: `claude-review-auto` FAILURE on `fatal: unable to access 'https://github.com/Uniswap/uniswap-ai/'`. Different issue — appears to be a Node 24 / bullfrog egress interaction. NOT addressed in this PR; separately tracked on `chore/node-24-upgrade`.
### Options evaluated
**Option A — Gate the action on `paths-filter`/`dorny/paths-filter`: skip when `.github/workflows/**` changed.** Cleaner semantically but adds a new action dependency and changes when the workflow runs (a workflow-changing PR gets no review at all). Rejected: less information for the reviewer is worse than a posted-error-comment.
**Option B — Set `continue-on-error: true` on the action step.** Preserves all existing behavior (fallback comment still posts, downstream steps still skip via `success()`) while making the required check pass. Minimal-surface change. **Chosen.**
**Option C — Add `track_progress: false` to silently skip the action's workflow-validation code path.** Tested theory by inspecting workflow inputs: `_claude-docs-check.yml` (passes) and the main-generation call in `_generate-pr-metadata.yml` (fails) BOTH pass `track_progress: false`. The quality-gate-eval call (also fails) does not. So `track_progress` is not the differentiator. Rejected: theory disproven by empirical evidence.
**Option D — Bump `anthropics/claude-code-action` further to see if a newer release softens the guard.** Skimmed v1.0.119 release notes and recent commits; no evidence of behavior change in this area. Rejected: speculative, and any newer release would still preserve the security property of the guard.
### Constraints discovered
- The action's `Workflow validation failed` error is not GitHub API; it's the action's own self-protection. Cannot be fixed by allowlist/permissions tweaks in the workflow YAML — only by either gating the action or tolerating its failure.
- `_claude-docs-check.yml` already passes on workflow-modifying PRs at v1.0.119 (verified on `Uniswap/uniswap-ai#105` run `25761569991`). This means the guard does NOT fire unconditionally; it depends on which API path the action takes. The exact trigger isn't documented upstream, but empirically the `_generate-pr-metadata.yml` invocation path triggers it. Tolerating failure is more reliable than trying to reverse-engineer the trigger.
- `_claude-code-review.yml` on `Uniswap/uniswap-ai#105` failed BEFORE reaching the Claude action (at the `actions/checkout` step, against the bullfrog egress firewall). That's a different bug, tracked on `chore/node-24-upgrade`. This PR's change to `_claude-code-review.yml` is preemptive — it ensures the file follows the same pattern as `_generate-pr-metadata.yml` so when the Node 24 / bullfrog issue is resolved separately, `_claude-code-review.yml`'s Claude action call won't trip the same workflow-validation trap.
### Known limitations
- Does NOT address the auto-updater (`update-claude-code-action.yml`) failing on the same trap. That workflow uses a GitHub App token without `workflows: write` permission (per PR #501's commit body). Separate fix; this PR unblocks the manual path so an org admin can ship the auto-updater fix without being blocked on every intermediate PR.
- Does NOT address the `claude-review-auto` Node 24 / bullfrog interaction — separately tracked on `chore/node-24-upgrade`.
- A truly transient failure (e.g., Anthropic API outage) now reports `success` at the required-check level. The fallback comment on the PR is the only signal. This is a deliberate trade-off: the alternative (failing required check on every API blip) is worse for legitimate PR throughput.
### Refs
- `Uniswap/uniswap-ai#104` — same trap, BLOCKED 5+ days
- `Uniswap/uniswap-ai#105` — same trap, rediscovered today
- `Uniswap/ai-toolkit#501` — previous "expand egress allowlists" PR (different fix path; doesn't address this guard)
- `Uniswap/ai-toolkit#503` — bumped action to v1.0.119 (the version with the guard)

</details>
<!-- claude-pr-description-end -->