### PR TITLE
fix(workflows): pass github_token to claude-code-action in _generate-pr-metadata

### DIFF
--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -425,7 +425,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MERGE_BASE_SHA: ${{ steps.pr-info.outputs.merge_base_sha }}
         run: |
-          git -c http.extraheader="Authorization: basic $(echo -n "x-access-token:${GITHUB_TOKEN}" | base64)" \
+          # `base64 -w 0` disables line wrapping. GNU coreutils' base64 (the
+          # default on Ubuntu runners) wraps at column 76, which inserts a
+          # literal newline into the Authorization header value once the
+          # encoded `x-access-token:${token}` exceeds 56 bytes (i.e. token
+          # length ≥ 42 chars). HTTP parses that newline as end-of-header
+          # and rejects the next line as a malformed continuation, which
+          # libcurl reports as `Failed sending HTTP request` and git exits
+          # 128. actions/checkout doesn't hit this because it builds the
+          # header in JS via Buffer.toString('base64') (no wrap).
+          git -c http.extraheader="Authorization: basic $(echo -n "x-access-token:${GITHUB_TOKEN}" | base64 -w 0)" \
             fetch --depth=1 origin "$MERGE_BASE_SHA"
           echo "✅ Fetched merge base: ${MERGE_BASE_SHA:0:12}"
 

--- a/.github/workflows/_generate-pr-metadata.yml
+++ b/.github/workflows/_generate-pr-metadata.yml
@@ -435,6 +435,13 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Providing github_token short-circuits the action's OIDC→app-token
+          # exchange in setupGitHubToken() (src/github/token.ts), which is what
+          # trips Anthropic's `workflow_not_found_on_default_branch` validation
+          # on PRs that modify .github/workflows/**. Match the pattern from
+          # _claude-docs-check.yml and _claude-code-review.yml, which already
+          # pass github_token for this reason.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             You are evaluating whether a pull request description adequately
             describes the code changes.
@@ -881,6 +888,10 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # See note on quality-gate-eval above: github_token short-circuits the
+          # OIDC→app-token exchange that trips the workflow-validation guard on
+          # PRs that modify .github/workflows/**.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: "Read and act upon the prompt at @${{ steps.build-prompt.outputs.prompt_file_path }}"
           track_progress: false # Disable to avoid PR comments
           allowed_bots: dependabot


### PR DESCRIPTION
## Summary

Two independent bugs in `_generate-pr-metadata.yml` and `_claude-code-review.yml` cause Uniswap/uniswap-ai PRs that modify `.github/workflows/**` to fail two required checks (`generate-metadata` and `claude-review-auto`). Both have nothing to do with bullfrog, branch protection, or the workflow-validation guard being *correct* — they're concrete bugs at the call sites. This PR fixes both.

| Commit | File | Fix | Lines |
|---|---|---|---|
| `ed0310a` | `_generate-pr-metadata.yml` | Add `github_token: ${{ secrets.GITHUB_TOKEN }}` to both `claude-code-action` calls | +11 |
| `9d95953` | `_claude-code-review.yml` | Add `-w 0` to base64 in the merge-base fetch's inline auth header | +10 / -1 |

Both fixes are tight: 21 total inserted lines across 2 files, mostly comments explaining the why so neither bug is silently reintroduced later.

## Bug 1 — `generate-metadata` fails with "Workflow validation failed"

**Mechanism (verified in action source):** `_generate-pr-metadata.yml` omits the `github_token` input on both `anthropics/claude-code-action@476e359e` invocations (quality-gate-eval at line 434 and main generation at line 880). Reading the action's `src/github/token.ts`:

```typescript
export async function setupGitHubToken(): Promise<string> {
  // Check if GitHub token was provided as override
  const providedToken = process.env.OVERRIDE_GITHUB_TOKEN;
  if (providedToken) { return providedToken; }    // short-circuit

  // Otherwise fall through to OIDC exchange which returns
  // error_code: workflow_not_found_on_default_branch when the calling
  // workflow file differs from main.
  const oidcToken = await retryWithBackoff(() => getOidcToken());
  const appToken = await exchangeForAppToken(oidcToken, permissions);
  return appToken;
}
```

`action.yml` wires `inputs.github_token` to `OVERRIDE_GITHUB_TOKEN`, so providing it bypasses the exchange entirely. The validation guard still protects callers that don't supply a token; this fix doesn't weaken that security property.

**Symptom evidence:** `Uniswap/uniswap-ai#105` `generate-metadata` run `25761569899` fails with `##[error]Action failed with error: Workflow validation failed`. The sibling workflow `_claude-docs-check.yml` already passes `github_token` (line 653) and succeeds on the same PR (run `25761569991`). `_claude-code-review.yml` likewise already passes it (line 1163). Just `_generate-pr-metadata.yml` was missing it.

## Bug 2 — `claude-review-auto` fails with "Failed sending HTTP request"

**Mechanism:** the "Fetch merge base for diff" step in `_claude-code-review.yml` builds an HTTP Basic auth header inline:

```bash
git -c http.extraheader="Authorization: basic $(echo -n "x-access-token:${GITHUB_TOKEN}" | base64)" \
    fetch --depth=1 origin "$MERGE_BASE_SHA"
```

GNU coreutils' `base64` (default on `ubuntu-latest` runners) wraps at column 76. Once `x-access-token:${token}` exceeds 56 bytes (token length ≥ 42 chars), the encoded value contains a literal `\n`. HTTP parses that as end-of-header; the next line has no `:` separator, so GitHub treats it as a malformed continuation and resets the connection. libcurl reports `CURLE_SEND_ERROR` → "Failed sending HTTP request" → git exits 128.

**Verified locally on Ubuntu 24.04:**

```
token length 32 → base64 = 64 chars  → 1 line, no wrap
token length 50 → base64 = 88 chars  → 2 lines, wraps at col 76  ← BUG
token length 50 + `-w 0` → 1 line                                 ← FIX
```

**Why bullfrog logged nothing for this request:** bullfrog logs every block. The agent forwarded the request to `github.com` (which is in the allowlist); GitHub rejected it for the malformed header. Bullfrog wasn't at fault — consistent with the "bullfrog logs failures" property.

**Why `actions/checkout` works in the same job:** it builds the Authorization header in JavaScript via `Buffer.from(...).toString('base64')`, which doesn't wrap. The two prior `actions/checkout` fetches in the job succeed for that reason.

**Why this is a recent regression:** actions-issued `GITHUB_TOKEN` length has been getting longer (older `ghs_` + 28-char body = 32 chars; newer formats reach 40–93 chars), crossing the wrap threshold. Same code that worked yesterday now fails on most PRs.

**Why main runs succeed:** the failing step is gated by `MERGE_BASE_SHA` from PR-info, which is only populated on `pull_request` events. The two successful `claude-code-review` runs on `main` yesterday (`25691891647`, `25688417264`) never executed this step.

## Test plan

- [x] YAML parses; diff stat = +11 / -1 across 2 files
- [x] Bug 1 mechanism verified by reading `anthropics/claude-code-action` source at the pinned SHA
- [x] Bug 2 mechanism verified by reproducing GNU base64 wrap behavior in a real `ubuntu:24.04` container
- [x] Both fixes are applications of patterns already in use elsewhere in this same repo (no novel constructs)
- [ ] CI on this PR
- [ ] Smoke-test: re-trigger both required checks on `Uniswap/uniswap-ai#105` after a sync PR lands these fixes

## Out of scope (deliberately, separate concerns)

- **Pre-existing semgrep findings**: a static-analysis scan flagged 7 sites in `_claude-code-review.yml` using `bun run` without `BUN_CONFIG_FILE=/dev/null` (lines 555, 622, 757, 994, 1279, 1678, 1680). This is the same bunfig.toml preload RCE class addressed by PR #453; either #453 missed these sites or they regressed afterwards. Worth a focused follow-up PR, not bundled here.
- **Token in `git`'s argv**: the inline `git -c http.extraheader="..."` puts the base64-encoded token in argv. Could be tightened via `git config --local http.extraheader` set/unset around the fetch. Minor hardening; not the bug.
- **`Authorization: basic` vs `Authorization: Basic`**: HTTP scheme is case-insensitive per RFC 7235; lowercase works but canonical is title-case. Cosmetic.
- **`update-claude-code-action.yml` auto-updater** failing on a GitHub App token without `workflows: write` permission (per PR #501's commit body). Separate fix needed there.

## Refs
- `Uniswap/uniswap-ai#105` — discovery PR (`generate-metadata` run `25761569899`, `claude-review-auto` run `25761569874`)
- `Uniswap/uniswap-ai#104` — same trap, 5+ days stuck on Bug 1
- `anthropics/claude-code-action` `src/github/token.ts` at v1.0.119 (`476e359e`)
- Local reproduction of GNU base64 wrap in `ubuntu:24.04` (Bug 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Both `claude-code-action` invocations in `_generate-pr-metadata.yml` omit the `github_token` input. This causes `setupGitHubToken()` in the action to fall through to the OIDC → app-token exchange against `api.anthropic.com/api/github/github-app-token-exchange`, which returns `error_code: workflow_not_found_on_default_branch` and fails the job whenever the PR modifies `.github/workflows/**`. The sibling workflows `_claude-docs-check.yml` and `_claude-code-review.yml` already pass `github_token` and run cleanly under the same conditions; this file was just missing the input.
## The mechanism (verified in action source)
From `anthropics/claude-code-action` `src/github/token.ts` at the pinned SHA (`476e359e`, v1.0.119):
```typescript
export async function setupGitHubToken(): Promise<string> {
  // Check if GitHub token was provided as override
  const providedToken = process.env.OVERRIDE_GITHUB_TOKEN;
  if (providedToken) { return providedToken; }    // short-circuit
  // Otherwise fall through to OIDC exchange which returns
  // error_code: workflow_not_found_on_default_branch when the
  // calling workflow file differs from main.
  const oidcToken = await retryWithBackoff(() => getOidcToken());
  const appToken = await exchangeForAppToken(oidcToken, permissions);
  return appToken;
}
```
The action's `action.yml` wires `inputs.github_token` to `OVERRIDE_GITHUB_TOKEN`, so providing it bypasses the exchange entirely. The validation guard still protects callers that genuinely need the OIDC-issued app token (those not supplying `github_token`); this PR doesn't weaken that path.
## What changed
| File | Edit |
|---|---|
| `_generate-pr-metadata.yml` line 434 (quality-gate-eval) | Add `github_token: ${{ secrets.GITHUB_TOKEN }}` with a 6-line comment |
| `_generate-pr-metadata.yml` line 880 (main generation) | Same edit with a 3-line back-reference comment |
Total: +11 / -0 lines, one file.
## Evidence
- `Uniswap/uniswap-ai#105` `generate-metadata` run `25761569899` fails with: `##[error]Action failed with error: Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch.`
- `Uniswap/uniswap-ai#105` `docs-check` run `25761569991` (same SHA, same workflow-modifying PR) succeeds — because `_claude-docs-check.yml` already passes `github_token`.
## Test plan
- [x] YAML parses; diff is exactly the two additions + comments
- [x] Mechanism verified by reading the action source at the pinned SHA
- [x] Pattern already in production on `_claude-docs-check.yml` (line 653) and `_claude-code-review.yml` (line 1163)
- [ ] CI on this PR
- [ ] Smoke-test: re-trigger `generate-metadata` on `Uniswap/uniswap-ai#105` after a sync PR lands the new pin
## Out of scope
- The separate `claude-review-auto` checkout failure on workflow-modifying PRs (`libcurl CURLE_SEND_ERROR` during a custom `git -c http.extraheader` fetch at `_claude-code-review.yml` line 408). No bullfrog "Blocked" log entries, `github.com` is already in the allowlist. Could be a bullfrog v0.8.4 + Node 24 TLS interaction; would need runtime debugging to confirm.
- The `update-claude-code-action.yml` auto-updater failing on a GitHub App token without `workflows: write`, per PR #501's commit body.

</details>
<!-- claude-pr-description-end -->