### PR TITLE
fix(workflows): harden $GITHUB_OUTPUT heredoc writes against injection

### DIFF
--- a/.github/actions/build-plugin-config/action.yml
+++ b/.github/actions/build-plugin-config/action.yml
@@ -136,18 +136,24 @@ runs:
         MARKETPLACES=$(echo -n "$MARKETPLACES" | sed '/^$/d')
         PLUGINS=$(echo -n "$PLUGINS" | sed '/^$/d')
 
-        # Output results
+        # Output results with per-call unguessable delimiters.
+        MKT_DELIM_RAND=$(openssl rand -hex 16)
+        PLG_DELIM_RAND=$(openssl rand -hex 16)
+        { [ -n "$MKT_DELIM_RAND" ] && [ -n "$PLG_DELIM_RAND" ]; } || { echo "::error::openssl rand returned empty" >&2; exit 1; }
+        [ "$(printf '%s' "$MARKETPLACES" | wc -c)" -lt 900000 ] || { echo "::error::plugin_marketplaces exceeds 900KB" >&2; exit 1; }
+        [ "$(printf '%s' "$PLUGINS" | wc -c)" -lt 900000 ] || { echo "::error::plugins exceeds 900KB" >&2; exit 1; }
+        MKT_DELIM="MKT_DELIMITER_$(date +%s%N)_${MKT_DELIM_RAND}"
+        PLG_DELIM="PLG_DELIMITER_$(date +%s%N)_${PLG_DELIM_RAND}"
         {
-          echo "plugin_marketplaces<<EOF"
+          echo "plugin_marketplaces<<${MKT_DELIM}"
           echo "$MARKETPLACES"
-          echo "EOF"
-        } >> $GITHUB_OUTPUT
-
+          echo "${MKT_DELIM}"
+        } >> "$GITHUB_OUTPUT"
         {
-          echo "plugins<<EOF"
+          echo "plugins<<${PLG_DELIM}"
           echo "$PLUGINS"
-          echo "EOF"
-        } >> $GITHUB_OUTPUT
+          echo "${PLG_DELIM}"
+        } >> "$GITHUB_OUTPUT"
 
         # Log configuration
         if [[ -n "$MARKETPLACES" ]]; then

--- a/.github/actions/validate-plugins/action.yml
+++ b/.github/actions/validate-plugins/action.yml
@@ -128,12 +128,17 @@ runs:
         echo "plugin_count=$PLUGINS_COUNT" >> $GITHUB_OUTPUT
         echo "marketplace_name=$MARKETPLACE_NAME" >> $GITHUB_OUTPUT
 
-        # Handle multiline JSON output
+        # Handle multiline JSON output with a per-call unguessable delimiter
+        # (defense in depth against $GITHUB_OUTPUT injection).
+        RESULTS_DELIM_RAND=$(openssl rand -hex 16)
+        [ -n "$RESULTS_DELIM_RAND" ] || { echo "::error::openssl rand returned empty" >&2; exit 1; }
+        [ "$(printf '%s' "$RESULTS" | wc -c)" -lt 900000 ] || { echo "::error::plugins_json exceeds 900KB" >&2; exit 1; }
+        RESULTS_DELIM="PLUGINS_JSON_DELIMITER_$(date +%s%N)_${RESULTS_DELIM_RAND}"
         {
-          echo "plugins_json<<EOF"
+          echo "plugins_json<<${RESULTS_DELIM}"
           echo "$RESULTS"
-          echo "EOF"
-        } >> $GITHUB_OUTPUT
+          echo "${RESULTS_DELIM}"
+        } >> "$GITHUB_OUTPUT"
 
         # Create job summary
         {

--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -1149,7 +1149,11 @@ jobs:
           echo "allowed_tools=$ALLOWED_TOOLS" >> $GITHUB_OUTPUT
           # Per-call unguessable heredoc delimiter; defense in depth against
           # the $GITHUB_OUTPUT duplicate-key last-write-wins injection class.
-          ARGS_DELIM="CLAUDE_ARGS_DELIMITER_$(date +%s%N)_$(openssl rand -hex 16)"
+          # Fail fast if openssl returns empty or value exceeds 1MB cap.
+          ARGS_DELIM_RAND=$(openssl rand -hex 16)
+          [ -n "$ARGS_DELIM_RAND" ] || { echo "::error::openssl rand returned empty; refusing to write predictable delimiter" >&2; exit 1; }
+          [ "$(printf '%s' "$CLAUDE_ARGS" | wc -c)" -lt 900000 ] || { echo "::error::claude_args exceeds 900KB; would risk \$GITHUB_OUTPUT truncation" >&2; exit 1; }
+          ARGS_DELIM="CLAUDE_ARGS_DELIMITER_$(date +%s%N)_${ARGS_DELIM_RAND}"
           echo "claude_args<<${ARGS_DELIM}" >> "$GITHUB_OUTPUT"
           echo "$CLAUDE_ARGS" >> "$GITHUB_OUTPUT"
           echo "${ARGS_DELIM}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -1147,9 +1147,12 @@ jobs:
             --allowedTools $ALLOWED_TOOLS"
 
           echo "allowed_tools=$ALLOWED_TOOLS" >> $GITHUB_OUTPUT
-          echo "claude_args<<CLAUDE_ARGS_EOF" >> $GITHUB_OUTPUT
-          echo "$CLAUDE_ARGS" >> $GITHUB_OUTPUT
-          echo "CLAUDE_ARGS_EOF" >> $GITHUB_OUTPUT
+          # Per-call unguessable heredoc delimiter; defense in depth against
+          # the $GITHUB_OUTPUT duplicate-key last-write-wins injection class.
+          ARGS_DELIM="CLAUDE_ARGS_DELIMITER_$(date +%s%N)_$(openssl rand -hex 16)"
+          echo "claude_args<<${ARGS_DELIM}" >> "$GITHUB_OUTPUT"
+          echo "$CLAUDE_ARGS" >> "$GITHUB_OUTPUT"
+          echo "${ARGS_DELIM}" >> "$GITHUB_OUTPUT"
           echo "✅ Configured structured output with JSON schema"
           echo "✅ Configured read-only tools (${#ALLOWED_TOOLS} chars)"
 

--- a/.github/workflows/_claude-docs-check.yml
+++ b/.github/workflows/_claude-docs-check.yml
@@ -637,7 +637,11 @@ jobs:
 
           # Per-call unguessable heredoc delimiter; defense in depth against
           # the $GITHUB_OUTPUT duplicate-key last-write-wins injection class.
-          ARGS_DELIM="CLAUDE_ARGS_DELIMITER_$(date +%s%N)_$(openssl rand -hex 16)"
+          # Fail fast if openssl returns empty or value exceeds 1MB cap.
+          ARGS_DELIM_RAND=$(openssl rand -hex 16)
+          [ -n "$ARGS_DELIM_RAND" ] || { echo "::error::openssl rand returned empty; refusing to write predictable delimiter" >&2; exit 1; }
+          [ "$(printf '%s' "$CLAUDE_ARGS" | wc -c)" -lt 900000 ] || { echo "::error::claude_args exceeds 900KB; would risk \$GITHUB_OUTPUT truncation" >&2; exit 1; }
+          ARGS_DELIM="CLAUDE_ARGS_DELIMITER_$(date +%s%N)_${ARGS_DELIM_RAND}"
           echo "claude_args<<${ARGS_DELIM}" >> "$GITHUB_OUTPUT"
           echo "$CLAUDE_ARGS" >> "$GITHUB_OUTPUT"
           echo "${ARGS_DELIM}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/_claude-docs-check.yml
+++ b/.github/workflows/_claude-docs-check.yml
@@ -635,9 +635,12 @@ jobs:
           # Read-only tools
           CLAUDE_ARGS="$CLAUDE_ARGS --allowedTools Read,Grep,Glob,Bash(git log:*),Bash(git diff:*),Bash(git show:*)"
 
-          echo "claude_args<<CLAUDE_ARGS_EOF" >> $GITHUB_OUTPUT
-          echo "$CLAUDE_ARGS" >> $GITHUB_OUTPUT
-          echo "CLAUDE_ARGS_EOF" >> $GITHUB_OUTPUT
+          # Per-call unguessable heredoc delimiter; defense in depth against
+          # the $GITHUB_OUTPUT duplicate-key last-write-wins injection class.
+          ARGS_DELIM="CLAUDE_ARGS_DELIMITER_$(date +%s%N)_$(openssl rand -hex 16)"
+          echo "claude_args<<${ARGS_DELIM}" >> "$GITHUB_OUTPUT"
+          echo "$CLAUDE_ARGS" >> "$GITHUB_OUTPUT"
+          echo "${ARGS_DELIM}" >> "$GITHUB_OUTPUT"
 
       # Build plugin configuration
       - name: Build plugin configuration

--- a/.github/workflows/_claude-main.yml
+++ b/.github/workflows/_claude-main.yml
@@ -408,9 +408,12 @@ jobs:
             ARGS="$ARGS--mcp-config '$INPUT_MCP_CONFIG'"$'\n'
           fi
 
-          echo "claude_args<<EOF" >> $GITHUB_OUTPUT
-          echo "$ARGS" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          # Per-call unguessable heredoc delimiter; defense in depth against
+          # the $GITHUB_OUTPUT duplicate-key last-write-wins injection class.
+          ARGS_DELIM="CLAUDE_ARGS_DELIMITER_$(date +%s%N)_$(openssl rand -hex 16)"
+          echo "claude_args<<${ARGS_DELIM}" >> "$GITHUB_OUTPUT"
+          echo "$ARGS" >> "$GITHUB_OUTPUT"
+          echo "${ARGS_DELIM}" >> "$GITHUB_OUTPUT"
 
       # Build plugin configuration using shared composite action
       - name: Build plugin configuration

--- a/.github/workflows/_claude-main.yml
+++ b/.github/workflows/_claude-main.yml
@@ -410,7 +410,11 @@ jobs:
 
           # Per-call unguessable heredoc delimiter; defense in depth against
           # the $GITHUB_OUTPUT duplicate-key last-write-wins injection class.
-          ARGS_DELIM="CLAUDE_ARGS_DELIMITER_$(date +%s%N)_$(openssl rand -hex 16)"
+          # Fail fast if openssl returns empty or value exceeds 1MB cap.
+          ARGS_DELIM_RAND=$(openssl rand -hex 16)
+          [ -n "$ARGS_DELIM_RAND" ] || { echo "::error::openssl rand returned empty; refusing to write predictable delimiter" >&2; exit 1; }
+          [ "$(printf '%s' "$ARGS" | wc -c)" -lt 900000 ] || { echo "::error::claude_args exceeds 900KB; would risk \$GITHUB_OUTPUT truncation" >&2; exit 1; }
+          ARGS_DELIM="CLAUDE_ARGS_DELIMITER_$(date +%s%N)_${ARGS_DELIM_RAND}"
           echo "claude_args<<${ARGS_DELIM}" >> "$GITHUB_OUTPUT"
           echo "$ARGS" >> "$GITHUB_OUTPUT"
           echo "${ARGS_DELIM}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/_claude-task-worker.yml
+++ b/.github/workflows/_claude-task-worker.yml
@@ -464,10 +464,14 @@ jobs:
           PROMPT_EOF
           )
 
-          # Escape for GitHub Actions output
-          echo "prompt<<PROMPT_DELIM" >> $GITHUB_OUTPUT
-          echo "$PROMPT" >> $GITHUB_OUTPUT
-          echo "PROMPT_DELIM" >> $GITHUB_OUTPUT
+          # Escape for GitHub Actions output. Use a per-call unguessable
+          # delimiter so an attacker-controlled INPUT_ISSUE_DESCRIPTION cannot
+          # terminate the heredoc and inject a replacement `prompt<<...` entry
+          # (last-write-wins on duplicate keys per the $GITHUB_OUTPUT spec).
+          PROMPT_DELIM="PROMPT_DELIMITER_$(date +%s%N)_$(openssl rand -hex 16)"
+          echo "prompt<<${PROMPT_DELIM}" >> "$GITHUB_OUTPUT"
+          echo "$PROMPT" >> "$GITHUB_OUTPUT"
+          echo "${PROMPT_DELIM}" >> "$GITHUB_OUTPUT"
 
       # Warn about potentially complex tasks
       - name: Assess task complexity

--- a/.github/workflows/_claude-task-worker.yml
+++ b/.github/workflows/_claude-task-worker.yml
@@ -311,7 +311,11 @@ jobs:
           # Note: Using a quoted heredoc ('PROMPT_EOF') to prevent shell expansion,
           # then using envsubst to safely substitute environment variables.
           export INPUT_ISSUE_IDENTIFIER INPUT_ISSUE_TITLE INPUT_ISSUE_URL INPUT_BRANCH_NAME INPUT_TARGET_BRANCH INPUT_ISSUE_DESCRIPTION INPUT_MODEL PR_TYPE_FLAG
-          PROMPT=$(envsubst << 'PROMPT_EOF'
+          # Restrict envsubst to the named variables only; without an allowlist
+          # it expands every $-reference in the body, leaking non-secret runner
+          # context (GITHUB_SHA, GITHUB_REPOSITORY, GITHUB_ACTOR, etc.) into a
+          # prompt sourced partly from attacker-controlled INPUT_ISSUE_DESCRIPTION.
+          PROMPT=$(envsubst '$INPUT_ISSUE_IDENTIFIER $INPUT_ISSUE_TITLE $INPUT_ISSUE_URL $INPUT_BRANCH_NAME $INPUT_TARGET_BRANCH $INPUT_ISSUE_DESCRIPTION $INPUT_MODEL $PR_TYPE_FLAG' << 'PROMPT_EOF'
           # Autonomous Task Execution
 
           You are autonomously implementing Linear issue **${INPUT_ISSUE_IDENTIFIER}**: "${INPUT_ISSUE_TITLE}"
@@ -468,7 +472,14 @@ jobs:
           # delimiter so an attacker-controlled INPUT_ISSUE_DESCRIPTION cannot
           # terminate the heredoc and inject a replacement `prompt<<...` entry
           # (last-write-wins on duplicate keys per the $GITHUB_OUTPUT spec).
-          PROMPT_DELIM="PROMPT_DELIMITER_$(date +%s%N)_$(openssl rand -hex 16)"
+          # Fail fast if openssl returns empty (would otherwise silently
+          # degrade the delimiter to a predictable prefix+timestamp), and
+          # refuse to write a body that exceeds the $GITHUB_OUTPUT 1MB
+          # per-value cap (truncation would leave an unclosed heredoc).
+          PROMPT_DELIM_RAND=$(openssl rand -hex 16)
+          [ -n "$PROMPT_DELIM_RAND" ] || { echo "::error::openssl rand returned empty; refusing to write predictable delimiter" >&2; exit 1; }
+          [ "$(printf '%s' "$PROMPT" | wc -c)" -lt 900000 ] || { echo "::error::prompt body exceeds 900KB; would risk \$GITHUB_OUTPUT truncation" >&2; exit 1; }
+          PROMPT_DELIM="PROMPT_DELIMITER_$(date +%s%N)_${PROMPT_DELIM_RAND}"
           echo "prompt<<${PROMPT_DELIM}" >> "$GITHUB_OUTPUT"
           echo "$PROMPT" >> "$GITHUB_OUTPUT"
           echo "${PROMPT_DELIM}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/_generate-changelog.yml
+++ b/.github/workflows/_generate-changelog.yml
@@ -146,12 +146,18 @@ jobs:
           ## Files changed:
           $DIFF_OUTPUT"
 
-          # Save to output using heredoc
+          # Save to output using a per-call unguessable heredoc delimiter
+          # (defense in depth against $GITHUB_OUTPUT duplicate-key last-write-
+          # wins injection; fail fast on openssl error or size overflow).
+          CTX_DELIM_RAND=$(openssl rand -hex 16)
+          [ -n "$CTX_DELIM_RAND" ] || { echo "::error::openssl rand returned empty" >&2; exit 1; }
+          [ "$(printf '%s' "$FULL_CONTEXT" | wc -c)" -lt 900000 ] || { echo "::error::context exceeds 900KB; would risk \$GITHUB_OUTPUT truncation" >&2; exit 1; }
+          CTX_DELIM="CONTEXT_DELIMITER_$(date +%s%N)_${CTX_DELIM_RAND}"
           {
-            echo 'context<<EOF'
+            echo "context<<${CTX_DELIM}"
             echo "$FULL_CONTEXT"
-            echo 'EOF'
-          } >> $GITHUB_OUTPUT
+            echo "${CTX_DELIM}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Load custom prompt from file
         id: load-prompt
@@ -167,12 +173,20 @@ jobs:
           # Read the prompt file
           CUSTOM_PROMPT=$(cat "$PROMPT_FILE")
 
-          # Save to output using heredoc
+          # Save to output using a per-call unguessable heredoc delimiter.
+          # $CUSTOM_PROMPT is the contents of a caller-supplied file; a
+          # caller pointing at fork-controlled content could otherwise inject
+          # a replacement entry (same class as the default-token-list bounty).
+          # Fail fast on openssl error or size overflow.
+          PROMPT_DELIM_RAND=$(openssl rand -hex 16)
+          [ -n "$PROMPT_DELIM_RAND" ] || { echo "::error::openssl rand returned empty" >&2; exit 1; }
+          [ "$(printf '%s' "$CUSTOM_PROMPT" | wc -c)" -lt 900000 ] || { echo "::error::custom prompt exceeds 900KB" >&2; exit 1; }
+          PROMPT_DELIM="PROMPT_DELIMITER_$(date +%s%N)_${PROMPT_DELIM_RAND}"
           {
-            echo 'prompt<<EOF'
+            echo "prompt<<${PROMPT_DELIM}"
             echo "$CUSTOM_PROMPT"
-            echo 'EOF'
-          } >> $GITHUB_OUTPUT
+            echo "${PROMPT_DELIM}"
+          } >> "$GITHUB_OUTPUT"
 
           echo "✅ Loaded custom prompt from $PROMPT_FILE"
 
@@ -342,12 +356,19 @@ jobs:
 
           echo "✅ AI changelog generated successfully"
 
-          # Save full response to output for parsing
+          # Save full response to output for parsing.
+          # Use a per-call unguessable heredoc delimiter so an attacker who
+          # influences the Anthropic API response (via a poisoned prompt
+          # earlier in the chain) cannot inject a replacement entry.
+          RESP_DELIM_RAND=$(openssl rand -hex 16)
+          [ -n "$RESP_DELIM_RAND" ] || { echo "::error::openssl rand returned empty" >&2; exit 1; }
+          [ "$(printf '%s' "$CHANGELOG" | wc -c)" -lt 900000 ] || { echo "::error::response exceeds 900KB" >&2; exit 1; }
+          RESP_DELIM="RESPONSE_DELIMITER_$(date +%s%N)_${RESP_DELIM_RAND}"
           {
-            echo 'response<<EOF'
+            echo "response<<${RESP_DELIM}"
             echo "$CHANGELOG"
-            echo 'EOF'
-          } >> $GITHUB_OUTPUT
+            echo "${RESP_DELIM}"
+          } >> "$GITHUB_OUTPUT"
 
           # Save format flags for parsing step
           echo "generate_slack=$GENERATE_SLACK" >> $GITHUB_OUTPUT
@@ -374,38 +395,52 @@ jobs:
             # Extract Markdown format (after "## MARKDOWN FORMAT")
             MARKDOWN_CONTENT=$(echo "$RESPONSE" | sed -n '/## MARKDOWN FORMAT/,$p' | sed '1d')
 
-            # Save both outputs
+            # Per-call unguessable delimiters; fail fast on RNG/size errors.
+            SLACK_DELIM_RAND=$(openssl rand -hex 16)
+            MD_DELIM_RAND=$(openssl rand -hex 16)
+            { [ -n "$SLACK_DELIM_RAND" ] && [ -n "$MD_DELIM_RAND" ]; } || { echo "::error::openssl rand returned empty" >&2; exit 1; }
+            [ "$(printf '%s' "$SLACK_CONTENT" | wc -c)" -lt 900000 ] || { echo "::error::slack content exceeds 900KB" >&2; exit 1; }
+            [ "$(printf '%s' "$MARKDOWN_CONTENT" | wc -c)" -lt 900000 ] || { echo "::error::markdown content exceeds 900KB" >&2; exit 1; }
+            SLACK_DELIM="SLACK_DELIMITER_$(date +%s%N)_${SLACK_DELIM_RAND}"
+            MD_DELIM="MD_DELIMITER_$(date +%s%N)_${MD_DELIM_RAND}"
             {
-              echo 'changelog_slack<<EOF'
+              echo "changelog_slack<<${SLACK_DELIM}"
               echo "$SLACK_CONTENT"
-              echo 'EOF'
-            } >> $GITHUB_OUTPUT
-
+              echo "${SLACK_DELIM}"
+            } >> "$GITHUB_OUTPUT"
             {
-              echo 'changelog_markdown<<EOF'
+              echo "changelog_markdown<<${MD_DELIM}"
               echo "$MARKDOWN_CONTENT"
-              echo 'EOF'
-            } >> $GITHUB_OUTPUT
+              echo "${MD_DELIM}"
+            } >> "$GITHUB_OUTPUT"
 
             echo "✅ Parsed both Slack and Markdown formats"
 
           elif [ "$GENERATE_SLACK" == "true" ]; then
             # Slack only - entire response is Slack format
+            SLACK_ONLY_RAND=$(openssl rand -hex 16)
+            [ -n "$SLACK_ONLY_RAND" ] || { echo "::error::openssl rand returned empty" >&2; exit 1; }
+            [ "$(printf '%s' "$RESPONSE" | wc -c)" -lt 900000 ] || { echo "::error::response exceeds 900KB" >&2; exit 1; }
+            SLACK_ONLY_DELIM="SLACK_DELIMITER_$(date +%s%N)_${SLACK_ONLY_RAND}"
             {
-              echo 'changelog_slack<<EOF'
+              echo "changelog_slack<<${SLACK_ONLY_DELIM}"
               echo "$RESPONSE"
-              echo 'EOF'
-            } >> $GITHUB_OUTPUT
+              echo "${SLACK_ONLY_DELIM}"
+            } >> "$GITHUB_OUTPUT"
 
             echo "✅ Generated Slack format"
 
           elif [ "$GENERATE_MARKDOWN" == "true" ]; then
             # Markdown only - entire response is Markdown format
+            MD_ONLY_RAND=$(openssl rand -hex 16)
+            [ -n "$MD_ONLY_RAND" ] || { echo "::error::openssl rand returned empty" >&2; exit 1; }
+            [ "$(printf '%s' "$RESPONSE" | wc -c)" -lt 900000 ] || { echo "::error::response exceeds 900KB" >&2; exit 1; }
+            MD_ONLY_DELIM="MD_DELIMITER_$(date +%s%N)_${MD_ONLY_RAND}"
             {
-              echo 'changelog_markdown<<EOF'
+              echo "changelog_markdown<<${MD_ONLY_DELIM}"
               echo "$RESPONSE"
-              echo 'EOF'
-            } >> $GITHUB_OUTPUT
+              echo "${MD_ONLY_DELIM}"
+            } >> "$GITHUB_OUTPUT"
 
             echo "✅ Generated Markdown format"
           fi
@@ -427,12 +462,17 @@ jobs:
             COMMITS="- No commits found in this range"
           fi
 
-          # Save to output (markdown format only for fallback)
+          # Save to output (markdown format only for fallback). Per-call
+          # unguessable delimiter; fail fast on RNG/size errors.
+          FALLBACK_DELIM_RAND=$(openssl rand -hex 16)
+          [ -n "$FALLBACK_DELIM_RAND" ] || { echo "::error::openssl rand returned empty" >&2; exit 1; }
+          [ "$(printf '%s' "$COMMITS" | wc -c)" -lt 900000 ] || { echo "::error::commits list exceeds 900KB" >&2; exit 1; }
+          FALLBACK_DELIM="CHANGELOG_DELIMITER_$(date +%s%N)_${FALLBACK_DELIM_RAND}"
           {
-            echo 'changelog<<EOF'
+            echo "changelog<<${FALLBACK_DELIM}"
             echo "$COMMITS"
-            echo 'EOF'
-          } >> $GITHUB_OUTPUT
+            echo "${FALLBACK_DELIM}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Summary
         if: always()

--- a/.github/workflows/_generate-pr-metadata.yml
+++ b/.github/workflows/_generate-pr-metadata.yml
@@ -859,9 +859,12 @@ jobs:
             --allowedTools $ALLOWED_TOOLS"
 
           echo "allowed_tools=$ALLOWED_TOOLS" >> $GITHUB_OUTPUT
-          echo "claude_args<<CLAUDE_ARGS_EOF" >> $GITHUB_OUTPUT
-          echo "$CLAUDE_ARGS" >> $GITHUB_OUTPUT
-          echo "CLAUDE_ARGS_EOF" >> $GITHUB_OUTPUT
+          # Per-call unguessable heredoc delimiter; defense in depth against
+          # the $GITHUB_OUTPUT duplicate-key last-write-wins injection class.
+          ARGS_DELIM="CLAUDE_ARGS_DELIMITER_$(date +%s%N)_$(openssl rand -hex 16)"
+          echo "claude_args<<${ARGS_DELIM}" >> "$GITHUB_OUTPUT"
+          echo "$CLAUDE_ARGS" >> "$GITHUB_OUTPUT"
+          echo "${ARGS_DELIM}" >> "$GITHUB_OUTPUT"
           echo "✅ Configured allowed tools (${#ALLOWED_TOOLS} chars)"
 
       # Build plugin configuration using shared composite action

--- a/.github/workflows/_generate-pr-metadata.yml
+++ b/.github/workflows/_generate-pr-metadata.yml
@@ -861,7 +861,11 @@ jobs:
           echo "allowed_tools=$ALLOWED_TOOLS" >> $GITHUB_OUTPUT
           # Per-call unguessable heredoc delimiter; defense in depth against
           # the $GITHUB_OUTPUT duplicate-key last-write-wins injection class.
-          ARGS_DELIM="CLAUDE_ARGS_DELIMITER_$(date +%s%N)_$(openssl rand -hex 16)"
+          # Fail fast if openssl returns empty or value exceeds 1MB cap.
+          ARGS_DELIM_RAND=$(openssl rand -hex 16)
+          [ -n "$ARGS_DELIM_RAND" ] || { echo "::error::openssl rand returned empty; refusing to write predictable delimiter" >&2; exit 1; }
+          [ "$(printf '%s' "$CLAUDE_ARGS" | wc -c)" -lt 900000 ] || { echo "::error::claude_args exceeds 900KB; would risk \$GITHUB_OUTPUT truncation" >&2; exit 1; }
+          ARGS_DELIM="CLAUDE_ARGS_DELIMITER_$(date +%s%N)_${ARGS_DELIM_RAND}"
           echo "claude_args<<${ARGS_DELIM}" >> "$GITHUB_OUTPUT"
           echo "$CLAUDE_ARGS" >> "$GITHUB_OUTPUT"
           echo "${ARGS_DELIM}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/_notify-release.yml
+++ b/.github/workflows/_notify-release.yml
@@ -254,11 +254,16 @@ jobs:
               exit 1
             fi
 
+            # Per-call unguessable delimiter; fail fast on RNG/size errors.
+            NOTION_DELIM_RAND=$(openssl rand -hex 16)
+            [ -n "$NOTION_DELIM_RAND" ] || { echo "::error::openssl rand returned empty" >&2; exit 1; }
+            [ "$(printf '%s' "$NOTION_CHANGELOG" | wc -c)" -lt 900000 ] || { echo "::error::notion changelog exceeds 900KB" >&2; exit 1; }
+            NOTION_DELIM="NOTION_DELIMITER_$(date +%s%N)_${NOTION_DELIM_RAND}"
             {
-              echo 'changelog_for_notion<<EOF'
+              echo "changelog_for_notion<<${NOTION_DELIM}"
               echo "$NOTION_CHANGELOG"
-              echo 'EOF'
-            } >> $GITHUB_OUTPUT
+              echo "${NOTION_DELIM}"
+            } >> "$GITHUB_OUTPUT"
           fi
 
   notify-slack:

--- a/.github/workflows/_update-action-versions-worker.yml
+++ b/.github/workflows/_update-action-versions-worker.yml
@@ -387,10 +387,14 @@ jobs:
           PROMPT_EOF
           )
 
-          # Output using heredoc delimiter
-          echo "prompt<<PROMPT_DELIM" >> $GITHUB_OUTPUT
-          echo "$PROMPT" >> $GITHUB_OUTPUT
-          echo "PROMPT_DELIM" >> $GITHUB_OUTPUT
+          # Output using a per-call unguessable heredoc delimiter so that
+          # any future caller-controlled input cannot terminate the heredoc
+          # and inject a replacement `prompt<<...` entry (last-write-wins on
+          # duplicate keys per the $GITHUB_OUTPUT spec).
+          PROMPT_DELIM="PROMPT_DELIMITER_$(date +%s%N)_$(openssl rand -hex 16)"
+          echo "prompt<<${PROMPT_DELIM}" >> "$GITHUB_OUTPUT"
+          echo "$PROMPT" >> "$GITHUB_OUTPUT"
+          echo "${PROMPT_DELIM}" >> "$GITHUB_OUTPUT"
 
       # Build plugin configuration using shared composite action
       - name: Build plugin configuration

--- a/.github/workflows/_update-action-versions-worker.yml
+++ b/.github/workflows/_update-action-versions-worker.yml
@@ -215,7 +215,10 @@ jobs:
           # then using envsubst to safely substitute environment variables.
           # This avoids needing to escape backticks, $, and \ throughout the prompt.
           export INPUT_BRANCH_NAME INPUT_TARGET_BRANCH INPUT_DRY_RUN
-          PROMPT=$(envsubst << 'PROMPT_EOF'
+          # Restrict envsubst to the named variables only; without an allowlist
+          # it would expand every $-reference, leaking non-secret runner
+          # context into the prompt body.
+          PROMPT=$(envsubst '$INPUT_BRANCH_NAME $INPUT_TARGET_BRANCH $INPUT_DRY_RUN' << 'PROMPT_EOF'
           # GitHub Actions Version Update Task
 
           You are tasked with updating all external GitHub Actions in this repository to their latest versions.
@@ -387,11 +390,13 @@ jobs:
           PROMPT_EOF
           )
 
-          # Output using a per-call unguessable heredoc delimiter so that
-          # any future caller-controlled input cannot terminate the heredoc
-          # and inject a replacement `prompt<<...` entry (last-write-wins on
-          # duplicate keys per the $GITHUB_OUTPUT spec).
-          PROMPT_DELIM="PROMPT_DELIMITER_$(date +%s%N)_$(openssl rand -hex 16)"
+          # Per-call unguessable heredoc delimiter (defense in depth — body
+          # is static today). Fail fast if openssl returns empty or the
+          # body exceeds the $GITHUB_OUTPUT 1MB per-value cap.
+          PROMPT_DELIM_RAND=$(openssl rand -hex 16)
+          [ -n "$PROMPT_DELIM_RAND" ] || { echo "::error::openssl rand returned empty; refusing to write predictable delimiter" >&2; exit 1; }
+          [ "$(printf '%s' "$PROMPT" | wc -c)" -lt 900000 ] || { echo "::error::prompt body exceeds 900KB; would risk \$GITHUB_OUTPUT truncation" >&2; exit 1; }
+          PROMPT_DELIM="PROMPT_DELIMITER_$(date +%s%N)_${PROMPT_DELIM_RAND}"
           echo "prompt<<${PROMPT_DELIM}" >> "$GITHUB_OUTPUT"
           echo "$PROMPT" >> "$GITHUB_OUTPUT"
           echo "${PROMPT_DELIM}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Many shell-driven steps across our `workflow_call` reusable workflows and composite actions write multiline values to `$GITHUB_OUTPUT` using static heredoc delimiters (`PROMPT_DELIM`, `EOF`, `CLAUDE_ARGS_EOF`). Per the [multiline-string spec](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings), the parser terminates a value the moment it reads a line equal to the active delimiter and resolves duplicate keys as last-write-wins. A static delimiter inside any caller-controlled heredoc body is a structural prompt-injection sink.

Two of the sites are exploitable today:

- **`_claude-task-worker.yml`** — heredoc body contains `$INPUT_ISSUE_DESCRIPTION` (Linear ticket description, labeled "untrusted user input" by the workflow's own in-prompt safety paragraph). A bare `PROMPT_DELIM` line followed by `prompt<<EVIL` overwrites the prompt value `claude-code-action` consumes; the safety paragraph ends up in an unused output key.
- **`_generate-changelog.yml:172`** — heredoc body is the contents of a caller-supplied `custom_prompt_file`. A caller that points `custom_prompt_file` at fork-controlled content gets the identical Cantina-class injection.

The other sites' bodies are not currently attacker-controllable, but share the same anti-pattern and are included as defense-in-depth so a future edit that splices in caller-controlled content does not silently reintroduce the class.

Replace every static delimiter with a per-call value composed of `date +%s%N` plus 128 bits of `openssl rand` CSPRNG output. Mirrors the existing `generateUniqueDelimiter()` helper in `.github/scripts/build-prompt.ts:245-253`, which already carries the comment "to prevent injection attacks" — that fix never propagated to the YAML workers.

**Plus** three hardenings flagged by adversarial review:

1. **openssl-rand failsafe.** `bash -e` does not abort on a failing command substitution inside a variable assignment. If `openssl` returns empty, the delimiter silently degrades to a predictable prefix+timestamp. Assert non-empty before use; `exit 1` with `::error::` if empty.
2. **`$GITHUB_OUTPUT` 1MB per-value size guard.** A >1MB attacker payload causes silent mid-line truncation. Refuse to write values > 900KB (conservative below the 1MB limit) with an `::error::` annotation.
3. **`envsubst` variable allowlist backport.** `_claude-task-worker.yml:314` and `_update-action-versions-worker.yml:218` called `envsubst <<EOF` without a positional allowlist, expanding every `$`-reference in the body and leaking non-secret runner context (`GITHUB_SHA`, `GITHUB_REPOSITORY`, `GITHUB_ACTOR`, etc.) into prompts sourced partly from attacker-controlled input. Match the default-token-list pattern: pass `'$INPUT_X $INPUT_Y ...'` explicitly.

## What changed

10 files, +145/−57 lines total across two commits. Every `$GITHUB_OUTPUT` heredoc write in the repo is now uniform.

| File | Sites | Body | Status |
|---|---|---|---|
| `_claude-task-worker.yml` | 1 (`prompt`) | `$PROMPT` (envsubst'd `$INPUT_ISSUE_DESCRIPTION`) | **Exploitable.** Plus envsubst allowlist backport. |
| `_generate-changelog.yml` | 8 (`context`, `prompt`, `response`, `changelog_slack` ×2, `changelog_markdown` ×2, `changelog`) | `$FULL_CONTEXT`, `$CUSTOM_PROMPT` (**caller-controlled file**), `$CHANGELOG`, sed-extracted slices, `$COMMITS` | **`prompt<<EOF` is exploitable.** Others defense in depth. |
| `_update-action-versions-worker.yml` | 1 (`prompt`) | `$PROMPT` (static template) | Defense in depth. Plus envsubst allowlist backport. |
| `_claude-main.yml` | 1 (`claude_args`) | `$ARGS` | Defense in depth. |
| `_claude-docs-check.yml` | 1 (`claude_args`) | `$CLAUDE_ARGS` | Defense in depth. |
| `_claude-code-review.yml` | 1 (`claude_args`) | `$CLAUDE_ARGS` | Defense in depth. |
| `_generate-pr-metadata.yml` | 1 (`claude_args`) | `$CLAUDE_ARGS` | Defense in depth. |
| `_notify-release.yml` | 1 (`changelog_for_notion`) | `$NOTION_CHANGELOG` (transitive from `_generate-changelog.yml`) | Defense in depth. |
| `actions/validate-plugins/action.yml` | 1 (`plugins_json`) | `$RESULTS` (JSON from plugin discovery) | Defense in depth. |
| `actions/build-plugin-config/action.yml` | 2 (`plugin_marketplaces`, `plugins`) | `$MARKETPLACES`, `$PLUGINS` | Defense in depth. |

Each site converts:

```yaml
{ echo 'key<<EOF'; echo "$VAR"; echo 'EOF'; } >> $GITHUB_OUTPUT
```

into:

```yaml
DELIM_RAND=$(openssl rand -hex 16)
[ -n "$DELIM_RAND" ] || { echo "::error::openssl rand returned empty" >&2; exit 1; }
[ "$(printf '%s' "$VAR" | wc -c)" -lt 900000 ] || { echo "::error::value exceeds 900KB" >&2; exit 1; }
DELIM="<PREFIX>_DELIMITER_$(date +%s%N)_${DELIM_RAND}"
{ echo "key<<${DELIM}"; echo "$VAR"; echo "${DELIM}"; } >> "$GITHUB_OUTPUT"
```

## Test plan

Local pressure tests (`/tmp/pressure_test_v2.sh`, 8 hardened-pattern assertions, all passing):
- Attacker injection contained — single `prompt` key after parse, attacker text embedded as ordinary content
- Benign body round-trips
- Delimiter uniqueness across two runs
- openssl-empty abort (simulated via PATH override) — step exits non-zero, zero bytes written
- Oversize abort (900001-byte body) — same
- Just-under-cap success (899999-byte body)

All 10 patched YAML files pass `yaml.safe_load`.

To verify post-merge: trigger a scheduled `claude-auto-tasks.yml` run, inspect the `Build prompt` step log, and confirm `claude-code-action` receives the full assembled prompt.

## Session context

**Investigation.** Discovered through the bug bounty program against `Uniswap/default-token-list`. Tracing the pattern back showed the same shape exists across our `workflow_call` workflows. The `generateUniqueDelimiter()` helper at `.github/scripts/build-prompt.ts:245-253` (commit `7159a4f`, 2025-12-19) shows the team had already identified the class — that fix just never propagated to the YAML.

**Wider sweep across the org** found 8 more Uniswap repos (briefcase, universe, backend, hooklist, uniswap-ai, plus relayer/wiki/private-v4-core) with the same anti-pattern but no current attacker input path; tracking those as separate per-repo hygiene PRs.

**Options evaluated.**
- *Random delimiter + RNG-failsafe + size guard + envsubst allowlist (chosen).* Comprehensive, ~145 lines across 10 files, structurally immune. Matches the existing TS helper.
- *Patch only the two exploitable instances (rejected).* Leaves 14 same-shape sites that will eventually rot into exploitable form when someone adds a caller-controlled input. The hygiene cost is small.
- *Migrate `_claude-task-worker.yml` to `claude-code-action`'s `prompt-file` input (deferred).* `_claude-code-review.yml` and `_generate-pr-metadata.yml` already write the prompt to `/tmp/final-prompt.txt` and export only the file path. Structurally immune by design and a sound longer-term shape for the autonomous workers, but out of scope here.

**Adversarial review.** Ran the patched files through two subagents — a red-team-framed security-analyzer and an independent code-reviewer. The two failure modes addressed by the second commit came from that review. Reviewers confirmed the random delimiter is structurally sound — 128-bit CSPRNG, parser does exact line equality (format-guess attacks fail), no leakage path. The failure modes closed by this PR are the only structural gaps they found in the delimiter-replacement approach.

## Out-of-scope follow-ups noted during this review

Adversarial review surfaced broader hardening that the PROMPT_DELIM fix doesn't and can't address. Tracking separately:

1. **`_claude-docs-check.yml:520-521`** — `sed -i "s|\${CHANGED_FILES}|$CHANGED_FILES_ESCAPED|g"` uses `|` as the sed delimiter, but the escape `sed 's/[&/\]/\\&/g; s/$/\\n/'` does NOT escape `|`. A filename containing `|` (legal in git) would break the substitution and inject arbitrary prompt text. Same general "attacker text → LLM prompt" family, different bug class.
2. **`toolkit_ref` not validated** — all `_claude-*.yml` workers pull `validate-claude-auth/action.yml` from `Uniswap/ai-toolkit@${TOOLKIT_REF}` with no SHA pinning or pattern check. Allowlist to `^(main|next|[0-9a-f]{40})$`.
3. **ai-toolkit `_claude-task-worker.yml` has no file-allowlist gate** — the default-token-list variant has one; ai-toolkit doesn't. Claude runs with `--dangerously-skip-permissions`.
4. **Residual Path B (Linear-comment credential exfil)** — this fix closes structural injection but the LLM still has `mcp__linear__linear_add_comment` plus `Read`-tool access to the GitHub App token file and the Anthropic key. Broader hardening: drop `--dangerously-skip-permissions`, tighten GitHub App scopes, flip `bullfrog` from `audit` to `block` with an explicit allowlist.
5. **Bun `bunfig.toml.preload` RCE class** — semgrep flagged 8+ steps using `bun run` without `BUN_CONFIG_FILE=/dev/null`. If any of these paths includes fork PR content, that's RCE-with-secrets. Locations: `_claude-docs-check.yml:720`, `_claude-code-review.yml:555,622,757,994,1286,1685,1687`.

## Related

Mirror PR in `Uniswap/default-token-list`: https://github.com/Uniswap/default-token-list/pull/2484. Single file (`_claude-task-worker.yml`).

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Shell-driven steps across our `workflow_call` workflows and composite actions write multiline values to `$GITHUB_OUTPUT` using **static heredoc delimiters** (`PROMPT_DELIM`, `EOF`, `CLAUDE_ARGS_EOF`, …). Per the [multiline-string spec](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings), the parser terminates a value the moment it reads a line equal to the active delimiter and resolves duplicate keys last-write-wins. A static delimiter inside any caller-controlled heredoc body is a structural prompt-injection sink.
Today, one site is **exploitable in production**:
- **`_claude-task-worker.yml`** — heredoc body contains `$INPUT_ISSUE_DESCRIPTION` (Linear ticket description, labeled "untrusted user input" by the workflow's own in-prompt safety paragraph). A bare `PROMPT_DELIM` line followed by `prompt<<EVIL` overwrites the prompt value `claude-code-action` consumes; the safety paragraph ends up in an unused output key.
The rest of the sites in this PR use the same anti-pattern with non-caller-controlled bodies today (`$ARGS` / `$CLAUDE_ARGS` / `$CHANGELOG` / `$PLUGINS_JSON`). They are patched as defense-in-depth so a future edit that splices in caller-controlled content does not silently reintroduce the class.
Discovered through the bug bounty program against `Uniswap/default-token-list`. The pattern was already identified by the `generateUniqueDelimiter()` helper at `.github/scripts/build-prompt.ts:245-253` (carrying the comment "to prevent injection attacks") — that fix never propagated to the YAML workers and composite actions.
## What changed
Two commits, +145 / -57 across **10 files** (8 workflows + 2 composite actions).
### Commit 1 — Randomize delimiters
Every static `<<STATIC_DELIM` is replaced with a per-call value composed of `date +%s%N` plus 128 bits of `openssl rand` CSPRNG output:
```yaml
DELIM="<PREFIX>_DELIMITER_$(date +%s%N)_$(openssl rand -hex 16)"
echo "key<<${DELIM}" >> "$GITHUB_OUTPUT"
echo "$VAR" >> "$GITHUB_OUTPUT"
echo "${DELIM}" >> "$GITHUB_OUTPUT"
```
### Commit 2 — Hardening (adversarial review follow-up)
Three failure modes the random delimiter alone doesn't close, plus additional sites found via wider grep:
1. **openssl-rand failsafe.** `bash -e` does not abort on a failing command substitution inside a variable assignment. If `openssl` returns empty (image regression, `/dev/urandom` hiccup, missing binary), the delimiter silently degrades to a predictable prefix+timestamp. Now asserts non-empty before use; `exit 1` with `::error::` annotation if empty.
2. **1MB per-value size guard.** A >1MB attacker payload causes silent mid-line truncation of the heredoc body; the closing delimiter is then missing and the parser either fails or parses subsequent step outputs as the prompt body. Refuses to write values >900KB (conservative cap below the 1MB limit) with an `::error::` annotation.
3. **envsubst variable allowlist.** `_claude-task-worker.yml:314` and `_update-action-versions-worker.yml:218` called `envsubst <<EOF` without positional allowlist — that expands every `$`-reference in the body, including runner context (`$GITHUB_SHA`, `$GITHUB_REPOSITORY`, `$GITHUB_ACTOR`, …) for inputs that contain `${VAR}` syntax. Now passes `'$INPUT_X $INPUT_Y …'` explicitly, matching the `default-token-list` pattern.
### Files patched
| File | Static delim(s) | Reason |
|---|---|---|
| `.github/workflows/_claude-task-worker.yml` | `PROMPT_DELIM` | **Exploitable.** `$INPUT_ISSUE_DESCRIPTION` flows through envsubst into the heredoc body. |
| `.github/workflows/_update-action-versions-worker.yml` | `PROMPT_DELIM` | Same shape; no current attacker input path. |
| `.github/workflows/_claude-main.yml` | `EOF` | Heredoc body is `$ARGS`. Defense in depth. |
| `.github/workflows/_claude-docs-check.yml` | `CLAUDE_ARGS_EOF` | Heredoc body is `$CLAUDE_ARGS`. Defense in depth. |
| `.github/workflows/_claude-code-review.yml` | `CLAUDE_ARGS_EOF` | Heredoc body is `$CLAUDE_ARGS`. Defense in depth. |
| `.github/workflows/_generate-pr-metadata.yml` | `CLAUDE_ARGS_EOF` | Heredoc body is `$CLAUDE_ARGS`. Defense in depth. |
| `.github/workflows/_generate-changelog.yml` | 8 sites (`EOF`, `CONTEXT_EOF`, `PROMPT_EOF`, …) | `custom_prompt_file` is caller-controlled — same class as the Cantina report. |
| `.github/workflows/_notify-release.yml` | `EOF` (`changelog_for_notion`) | Defense in depth. |
| `.github/actions/validate-plugins/action.yml` | `EOF` (`plugins_json`) | Defense in depth. |
| `.github/actions/build-plugin-config/action.yml` | `EOF` (`plugin_marketplaces`, `plugins`) | Defense in depth. |
No changes to Build-prompt step structure, allowed-tools allowlists, or validation steps.
## Test plan
Local pressure test against the `_claude-task-worker.yml` shell sequence (`pressure_test_v2.sh`, 8 assertions, all pass):
- Control: vulnerable code with attacker payload produces `outputs.prompt = attacker text` (bug is real).
- Primary fix: patched code with the same payload produces a single `prompt` output containing both the legitimate body (with "Untrusted Input" warning) and the attacker text embedded as ordinary content. Structural bypass is gone; injection now relies on the LLM honoring the safety paragraph.
- Functionality: benign description round-trips correctly.
- Format-guess attack: attacker line matching `PROMPT_DELIMITER_<digits>_<hex>` with fake values does not terminate; parser does exact line equality.
- Delimiter uniqueness: two consecutive generations produce distinct values.
- Legacy literal: `PROMPT_DELIM` embedded in attacker text is now ordinary content.
- openssl-empty abort: when `openssl` returns empty, the step exits 1 with `::error::` annotation before writing to `$GITHUB_OUTPUT`.
- Oversize abort: a >900KB body is refused with `::error::` before the heredoc closes; just-under-cap input round-trips correctly.
All 10 patched YAML files pass `yaml.safe_load`.
To verify post-merge: trigger a scheduled `claude-auto-tasks.yml` run, inspect the Build prompt step log, and confirm `claude-code-action` receives the full assembled prompt.
## Session context
**Investigation.** Discovered through the bug bounty program against `Uniswap/default-token-list`. Tracing the pattern back showed the same shape exists across our `workflow_call` workflows. The `generateUniqueDelimiter()` helper at `.github/scripts/build-prompt.ts:245-253` (commit 7159a4f, 2025-12-19) shows the team had already identified the class — that fix just never propagated to the YAML/composite-action layer.
**Options evaluated.**
- *Random delimiter + hardening (chosen).* Minimum-touch, ~145 lines across 10 files, structurally immune. Matches the existing TS helper.
- *Patch only the exploitable instance (rejected).* Leaves nine same-shape sites that will eventually rot into exploitable form when someone adds caller-controlled input. The hygiene cost of patching all of them is small.
- *Migrate `_claude-task-worker.yml` to `claude-code-action`'s prompt-file input (deferred).* `_claude-code-review.yml` and `_generate-pr-metadata.yml` already write the prompt to `/tmp/final-prompt.txt` and export only the file path. Structurally immune by design and a sound longer-term shape, but out of scope here.
**Constraints.** GitHub-hosted Ubuntu runners have `openssl` and GNU `date` (with `%N` nanosecond support). Build-prompt steps do not run with `set -x`. The delimiter variable has function-local scope; it is not echoed back via any other step's logging.
**Known limitations.** This patch does not change the bullfrog egress policy (still `audit` in places), does not touch the allowed-tools allowlists, and does not migrate to the file-based prompt pattern. Each of those is a separate, larger hardening worth doing.
## Out-of-scope follow-ups noted during this review
Semgrep flagged a separate class while editing these files: several workflow steps use `bun run` without `BUN_CONFIG_FILE=/dev/null` set in the job env. Bun auto-loads `bunfig.toml` from CWD, and `bunfig.toml.preload` executes arbitrary code before the intended script. If any of these checked-out paths includes fork PR content, that's RCE-with-secrets. Locations flagged: `_claude-docs-check.yml:720`, `_claude-code-review.yml:555,622,757,994,1282,1681,1683`. Tracking separately; not in this PR.
## Related
Mirror PR in `Uniswap/default-token-list`: <https://github.com/Uniswap/default-token-list/pull/2484>. Same class, one file (`_claude-task-worker.yml`).

</details>
<!-- claude-pr-description-end -->