### PR TITLE
fix(workflows): allowlist toolkit_ref to block fork-branch RCE

### DIFF
--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -279,6 +279,25 @@ jobs:
       actions: read # Required to check CI status
 
     steps:
+      # Validate toolkit_ref BEFORE any downstream step uses it to download
+      # action.yml / post-*.ts script content from the ai-toolkit repo.
+      # Without this, an attacker-controlled ref could substitute malicious
+      # script content that runs inside this job with access to its secrets.
+      - name: Validate toolkit_ref
+        env:
+          TOOLKIT_REF: ${{ inputs.toolkit_ref }}
+        run: |
+          case "$TOOLKIT_REF" in
+            main|next) ;;
+            *)
+              if ! printf '%s' "$TOOLKIT_REF" | grep -qE '^[0-9a-fA-F]{40}$'; then
+                echo "::error::Invalid toolkit_ref: '$TOOLKIT_REF'. Allowed: main, next, or a full 40-char SHA."
+                exit 1
+              fi
+              ;;
+          esac
+          echo "✅ toolkit_ref validated: $TOOLKIT_REF"
+
       # Security scanning — block mode prevents secret exfiltration if RCE is achieved
       # via attacker-controlled config files (bunfig.toml, .npmrc, etc.) in fork PRs.
       # If a legitimate host is missing, the workflow will fail loudly — update the

--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -279,6 +279,31 @@ jobs:
       actions: read # Required to check CI status
 
     steps:
+      # Security scanning — block mode prevents secret exfiltration if RCE is achieved
+      # via attacker-controlled config files (bunfig.toml, .npmrc, etc.) in fork PRs.
+      # If a legitimate host is missing, the workflow will fail loudly — update the
+      # allowlist rather than switching back to audit mode.
+      # Per .github/workflows/CLAUDE.md, bullfrog must be the FIRST step in
+      # every job on a non-macOS runner ("no exceptions"), so it runs before
+      # the toolkit_ref validation below. Ordering is safe: bullfrog does not
+      # consume toolkit_ref, and the validation runs before any step that
+      # downloads action.yml or post-*.ts content using it.
+      - name: Security Scan
+        uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
+        with:
+          egress-policy: block
+          allowed-domains: |
+            github.com
+            *.github.com
+            *.githubusercontent.com
+            api.anthropic.com
+            claude.ai
+            *.claude.ai
+            bun.sh
+            registry.npmjs.org
+            *.npmjs.org
+          enable-sudo: false
+
       # Validate toolkit_ref BEFORE any downstream step uses it to download
       # action.yml / post-*.ts script content from the ai-toolkit repo.
       # Without this, an attacker-controlled ref could substitute malicious
@@ -297,26 +322,6 @@ jobs:
               ;;
           esac
           echo "✅ toolkit_ref validated: $TOOLKIT_REF"
-
-      # Security scanning — block mode prevents secret exfiltration if RCE is achieved
-      # via attacker-controlled config files (bunfig.toml, .npmrc, etc.) in fork PRs.
-      # If a legitimate host is missing, the workflow will fail loudly — update the
-      # allowlist rather than switching back to audit mode.
-      - name: Security Scan
-        uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
-        with:
-          egress-policy: block
-          allowed-domains: |
-            github.com
-            *.github.com
-            *.githubusercontent.com
-            api.anthropic.com
-            claude.ai
-            *.claude.ai
-            bun.sh
-            registry.npmjs.org
-            *.npmjs.org
-          enable-sudo: false
 
       # Checkout required before using local composite actions
       - name: Checkout repository

--- a/.github/workflows/_claude-docs-check.yml
+++ b/.github/workflows/_claude-docs-check.yml
@@ -203,6 +203,25 @@ jobs:
       commits_pushed: ${{ steps.process-results.outputs.commits_pushed }}
 
     steps:
+      # Validate toolkit_ref BEFORE any downstream step uses it to download
+      # action.yml / post-*.ts script content from the ai-toolkit repo.
+      # Without this, an attacker-controlled ref could substitute malicious
+      # script content that runs inside this job with access to its secrets.
+      - name: Validate toolkit_ref
+        env:
+          TOOLKIT_REF: ${{ inputs.toolkit_ref }}
+        run: |
+          case "$TOOLKIT_REF" in
+            main|next) ;;
+            *)
+              if ! printf '%s' "$TOOLKIT_REF" | grep -qE '^[0-9a-fA-F]{40}$'; then
+                echo "::error::Invalid toolkit_ref: '$TOOLKIT_REF'. Allowed: main, next, or a full 40-char SHA."
+                exit 1
+              fi
+              ;;
+          esac
+          echo "✅ toolkit_ref validated: $TOOLKIT_REF"
+
       # Security scanning — block mode prevents secret exfiltration if RCE is achieved.
       # Allowlist validated against Datadog (service:github-actions, 7d window).
       - name: Security Scan

--- a/.github/workflows/_claude-docs-check.yml
+++ b/.github/workflows/_claude-docs-check.yml
@@ -203,6 +203,29 @@ jobs:
       commits_pushed: ${{ steps.process-results.outputs.commits_pushed }}
 
     steps:
+      # Security scanning — block mode prevents secret exfiltration if RCE is achieved.
+      # Allowlist validated against Datadog (service:github-actions, 7d window).
+      # Per .github/workflows/CLAUDE.md, bullfrog must be the FIRST step in
+      # every job on a non-macOS runner ("no exceptions"), so it runs before
+      # the toolkit_ref validation below. Ordering is safe: bullfrog does not
+      # consume toolkit_ref, and the validation runs before any step that
+      # downloads action.yml or post-*.ts content using it.
+      - name: Security Scan
+        uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
+        with:
+          egress-policy: block
+          allowed-domains: |
+            github.com
+            *.github.com
+            *.githubusercontent.com
+            api.anthropic.com
+            claude.ai
+            *.claude.ai
+            bun.sh
+            registry.npmjs.org
+            *.npmjs.org
+          enable-sudo: false
+
       # Validate toolkit_ref BEFORE any downstream step uses it to download
       # action.yml / post-*.ts script content from the ai-toolkit repo.
       # Without this, an attacker-controlled ref could substitute malicious
@@ -221,24 +244,6 @@ jobs:
               ;;
           esac
           echo "✅ toolkit_ref validated: $TOOLKIT_REF"
-
-      # Security scanning — block mode prevents secret exfiltration if RCE is achieved.
-      # Allowlist validated against Datadog (service:github-actions, 7d window).
-      - name: Security Scan
-        uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
-        with:
-          egress-policy: block
-          allowed-domains: |
-            github.com
-            *.github.com
-            *.githubusercontent.com
-            api.anthropic.com
-            claude.ai
-            *.claude.ai
-            bun.sh
-            registry.npmjs.org
-            *.npmjs.org
-          enable-sudo: false
 
       # Initial checkout
       - name: Checkout repository

--- a/.github/workflows/_claude-main.yml
+++ b/.github/workflows/_claude-main.yml
@@ -290,6 +290,29 @@ jobs:
       cancel-in-progress: true
 
     steps:
+      # FIXED: Security scanning with bullfrog — block mode prevents exfiltration
+      # This step cannot be disabled or modified.
+      # Per .github/workflows/CLAUDE.md, bullfrog must be the FIRST step in
+      # every job on a non-macOS runner ("no exceptions"), so it runs before
+      # the toolkit_ref validation below. Ordering is safe: bullfrog does not
+      # consume toolkit_ref, and the validation runs before any step that
+      # downloads action.yml or post-*.ts content using it.
+      - name: Security scanning
+        uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
+        with:
+          egress-policy: block
+          allowed-domains: |
+            github.com
+            *.github.com
+            *.githubusercontent.com
+            api.anthropic.com
+            claude.ai
+            *.claude.ai
+            bun.sh
+            registry.npmjs.org
+            *.npmjs.org
+          enable-sudo: false
+
       # Validate toolkit_ref BEFORE any downstream step uses it to download
       # action.yml / post-*.ts script content from the ai-toolkit repo.
       # Without this, an attacker-controlled ref could substitute malicious
@@ -308,24 +331,6 @@ jobs:
               ;;
           esac
           echo "✅ toolkit_ref validated: $TOOLKIT_REF"
-
-      # FIXED: Security scanning with bullfrog — block mode prevents exfiltration
-      # This step cannot be disabled or modified
-      - name: Security scanning
-        uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
-        with:
-          egress-policy: block
-          allowed-domains: |
-            github.com
-            *.github.com
-            *.githubusercontent.com
-            api.anthropic.com
-            claude.ai
-            *.claude.ai
-            bun.sh
-            registry.npmjs.org
-            *.npmjs.org
-          enable-sudo: false
 
       # FIXED: Checkout with consistent fetch depth
       - name: Checkout repository

--- a/.github/workflows/_claude-main.yml
+++ b/.github/workflows/_claude-main.yml
@@ -290,6 +290,25 @@ jobs:
       cancel-in-progress: true
 
     steps:
+      # Validate toolkit_ref BEFORE any downstream step uses it to download
+      # action.yml / post-*.ts script content from the ai-toolkit repo.
+      # Without this, an attacker-controlled ref could substitute malicious
+      # script content that runs inside this job with access to its secrets.
+      - name: Validate toolkit_ref
+        env:
+          TOOLKIT_REF: ${{ inputs.toolkit_ref }}
+        run: |
+          case "$TOOLKIT_REF" in
+            main|next) ;;
+            *)
+              if ! printf '%s' "$TOOLKIT_REF" | grep -qE '^[0-9a-fA-F]{40}$'; then
+                echo "::error::Invalid toolkit_ref: '$TOOLKIT_REF'. Allowed: main, next, or a full 40-char SHA."
+                exit 1
+              fi
+              ;;
+          esac
+          echo "✅ toolkit_ref validated: $TOOLKIT_REF"
+
       # FIXED: Security scanning with bullfrog — block mode prevents exfiltration
       # This step cannot be disabled or modified
       - name: Security scanning

--- a/.github/workflows/_claude-task-worker.yml
+++ b/.github/workflows/_claude-task-worker.yml
@@ -186,27 +186,13 @@ jobs:
       actions: read
 
     steps:
-      # Validate toolkit_ref BEFORE any downstream step uses it to download
-      # action.yml / post-*.ts script content from the ai-toolkit repo.
-      # Without this, an attacker-controlled ref (e.g., a fork branch passed
-      # by a caller) could substitute malicious script content that runs
-      # inside this job's process with access to its secrets.
-      - name: Validate toolkit_ref
-        env:
-          TOOLKIT_REF: ${{ inputs.toolkit_ref }}
-        run: |
-          case "$TOOLKIT_REF" in
-            main|next) ;;
-            *)
-              if ! printf '%s' "$TOOLKIT_REF" | grep -qE '^[0-9a-fA-F]{40}$'; then
-                echo "::error::Invalid toolkit_ref: '$TOOLKIT_REF'. Allowed: main, next, or a full 40-char SHA."
-                exit 1
-              fi
-              ;;
-          esac
-          echo "✅ toolkit_ref validated: $TOOLKIT_REF"
-
       # Security scanning — block mode prevents secret exfiltration if RCE is achieved.
+      #
+      # Per .github/workflows/CLAUDE.md, bullfrog must be the FIRST step in
+      # every job on a non-macOS runner ("no exceptions"), so it runs before
+      # the toolkit_ref validation below. Ordering is safe: bullfrog does not
+      # consume toolkit_ref, and the validation runs before any step that
+      # downloads action.yml or post-*.ts content using it.
       #
       # Allowlist is workflow-specific. github.com / api.github.com are in
       # bullfrog's defaultDomains (agent/agent.go:18) and don't need to be
@@ -226,6 +212,26 @@ jobs:
             api.linear.app
             registry.npmjs.org
           enable-sudo: false
+
+      # Validate toolkit_ref BEFORE any downstream step uses it to download
+      # action.yml / post-*.ts script content from the ai-toolkit repo.
+      # Without this, an attacker-controlled ref (e.g., a fork branch passed
+      # by a caller) could substitute malicious script content that runs
+      # inside this job's process with access to its secrets.
+      - name: Validate toolkit_ref
+        env:
+          TOOLKIT_REF: ${{ inputs.toolkit_ref }}
+        run: |
+          case "$TOOLKIT_REF" in
+            main|next) ;;
+            *)
+              if ! printf '%s' "$TOOLKIT_REF" | grep -qE '^[0-9a-fA-F]{40}$'; then
+                echo "::error::Invalid toolkit_ref: '$TOOLKIT_REF'. Allowed: main, next, or a full 40-char SHA."
+                exit 1
+              fi
+              ;;
+          esac
+          echo "✅ toolkit_ref validated: $TOOLKIT_REF"
 
       # Checkout the target branch
       # Must come before validate-claude-auth (local composite action)

--- a/.github/workflows/_claude-task-worker.yml
+++ b/.github/workflows/_claude-task-worker.yml
@@ -186,6 +186,26 @@ jobs:
       actions: read
 
     steps:
+      # Validate toolkit_ref BEFORE any downstream step uses it to download
+      # action.yml / post-*.ts script content from the ai-toolkit repo.
+      # Without this, an attacker-controlled ref (e.g., a fork branch passed
+      # by a caller) could substitute malicious script content that runs
+      # inside this job's process with access to its secrets.
+      - name: Validate toolkit_ref
+        env:
+          TOOLKIT_REF: ${{ inputs.toolkit_ref }}
+        run: |
+          case "$TOOLKIT_REF" in
+            main|next) ;;
+            *)
+              if ! printf '%s' "$TOOLKIT_REF" | grep -qE '^[0-9a-fA-F]{40}$'; then
+                echo "::error::Invalid toolkit_ref: '$TOOLKIT_REF'. Allowed: main, next, or a full 40-char SHA."
+                exit 1
+              fi
+              ;;
+          esac
+          echo "✅ toolkit_ref validated: $TOOLKIT_REF"
+
       # Security scanning — block mode prevents secret exfiltration if RCE is achieved.
       #
       # Allowlist is workflow-specific. github.com / api.github.com are in

--- a/.github/workflows/_generate-pr-metadata.yml
+++ b/.github/workflows/_generate-pr-metadata.yml
@@ -172,6 +172,25 @@ jobs:
       pull-requests: write # Required to update PR title and description
 
     steps:
+      # Validate toolkit_ref BEFORE any downstream step uses it to download
+      # action.yml / post-*.ts script content from the ai-toolkit repo.
+      # Without this, an attacker-controlled ref could substitute malicious
+      # script content that runs inside this job with access to its secrets.
+      - name: Validate toolkit_ref
+        env:
+          TOOLKIT_REF: ${{ inputs.toolkit_ref }}
+        run: |
+          case "$TOOLKIT_REF" in
+            main|next) ;;
+            *)
+              if ! printf '%s' "$TOOLKIT_REF" | grep -qE '^[0-9a-fA-F]{40}$'; then
+                echo "::error::Invalid toolkit_ref: '$TOOLKIT_REF'. Allowed: main, next, or a full 40-char SHA."
+                exit 1
+              fi
+              ;;
+          esac
+          echo "✅ toolkit_ref validated: $TOOLKIT_REF"
+
       # Security scanning (required for all workflows)
       - name: Security Scan
         uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4

--- a/.github/workflows/_generate-pr-metadata.yml
+++ b/.github/workflows/_generate-pr-metadata.yml
@@ -172,6 +172,17 @@ jobs:
       pull-requests: write # Required to update PR title and description
 
     steps:
+      # Security scanning (required for all workflows).
+      # Per .github/workflows/CLAUDE.md, bullfrog must be the FIRST step in
+      # every job on a non-macOS runner ("no exceptions"), so it runs before
+      # the toolkit_ref validation below. Ordering is safe: bullfrog does not
+      # consume toolkit_ref, and the validation runs before any step that
+      # downloads action.yml or post-*.ts content using it.
+      - name: Security Scan
+        uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
+        with:
+          egress-policy: audit
+
       # Validate toolkit_ref BEFORE any downstream step uses it to download
       # action.yml / post-*.ts script content from the ai-toolkit repo.
       # Without this, an attacker-controlled ref could substitute malicious
@@ -190,12 +201,6 @@ jobs:
               ;;
           esac
           echo "✅ toolkit_ref validated: $TOOLKIT_REF"
-
-      # Security scanning (required for all workflows)
-      - name: Security Scan
-        uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
-        with:
-          egress-policy: audit
 
       # Checkout code with full history for pattern analysis
       # Must come before validate-claude-auth (local composite action)

--- a/.github/workflows/_update-action-versions-worker.yml
+++ b/.github/workflows/_update-action-versions-worker.yml
@@ -125,6 +125,17 @@ jobs:
       actions: read
 
     steps:
+      # Security scanning.
+      # Per .github/workflows/CLAUDE.md, bullfrog must be the FIRST step in
+      # every job on a non-macOS runner ("no exceptions"), so it runs before
+      # the toolkit_ref validation below. Ordering is safe: bullfrog does not
+      # consume toolkit_ref, and the validation runs before any step that
+      # downloads action.yml or post-*.ts content using it.
+      - name: Security scanning
+        uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
+        with:
+          egress-policy: audit
+
       # Validate toolkit_ref BEFORE any downstream step uses it to download
       # action.yml / post-*.ts script content from the ai-toolkit repo.
       # Without this, an attacker-controlled ref could substitute malicious
@@ -143,12 +154,6 @@ jobs:
               ;;
           esac
           echo "✅ toolkit_ref validated: $TOOLKIT_REF"
-
-      # Security scanning
-      - name: Security scanning
-        uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
-        with:
-          egress-policy: audit
 
       # Checkout the update branch
       # Must come before validate-claude-auth (local composite action)

--- a/.github/workflows/_update-action-versions-worker.yml
+++ b/.github/workflows/_update-action-versions-worker.yml
@@ -125,6 +125,25 @@ jobs:
       actions: read
 
     steps:
+      # Validate toolkit_ref BEFORE any downstream step uses it to download
+      # action.yml / post-*.ts script content from the ai-toolkit repo.
+      # Without this, an attacker-controlled ref could substitute malicious
+      # script content that runs inside this job with access to its secrets.
+      - name: Validate toolkit_ref
+        env:
+          TOOLKIT_REF: ${{ inputs.toolkit_ref }}
+        run: |
+          case "$TOOLKIT_REF" in
+            main|next) ;;
+            *)
+              if ! printf '%s' "$TOOLKIT_REF" | grep -qE '^[0-9a-fA-F]{40}$'; then
+                echo "::error::Invalid toolkit_ref: '$TOOLKIT_REF'. Allowed: main, next, or a full 40-char SHA."
+                exit 1
+              fi
+              ;;
+          esac
+          echo "✅ toolkit_ref validated: $TOOLKIT_REF"
+
       # Security scanning
       - name: Security scanning
         uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4

--- a/.github/workflows/claude-docs-check.yml
+++ b/.github/workflows/claude-docs-check.yml
@@ -81,6 +81,11 @@ jobs:
       # chain). Self-testing changes to worker scripts is now done by landing
       # them to `next` first and verifying there, or by invoking the
       # workflow_dispatch entrypoint with an explicit SHA in the allowlist.
+      #
+      # External repos copying this file as a template: keep this as 'main'.
+      # The reusable worker's toolkit_ref allowlist now blocks fork-branch
+      # values, but `next` is permitted and would pick up untested worker
+      # changes; pinning to 'main' avoids that.
       toolkit_ref: 'main'
     secrets:
       # Use OAuth token (Pro/Max) instead of API key

--- a/.github/workflows/claude-docs-check.yml
+++ b/.github/workflows/claude-docs-check.yml
@@ -74,8 +74,14 @@ jobs:
       fail_on_missing_version: true
       # Don't fail on missing docs (just warn)
       fail_on_missing_docs: false
-      # Use local actions since we're in ai-toolkit
-      toolkit_ref: ${{ github.head_ref || github.ref_name }}
+      # Pin to main rather than the trigger ref. ${{ github.head_ref || github.ref_name }}
+      # would let any PR author point the worker at action.yml / post-*.ts script
+      # content from their own branch — the worker then downloads and executes
+      # that content with the workflow's secrets (RCE-with-secrets via supply
+      # chain). Self-testing changes to worker scripts is now done by landing
+      # them to `next` first and verifying there, or by invoking the
+      # workflow_dispatch entrypoint with an explicit SHA in the allowlist.
+      toolkit_ref: 'main'
     secrets:
       # Use OAuth token (Pro/Max) instead of API key
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

All six reusable `workflow_call` workers accept a `toolkit_ref` input and use it directly in curl URLs to fetch action.yml / post-*.ts script content from this repository:

```bash
curl -L "https://api.github.com/repos/Uniswap/ai-toolkit/contents/.github/.../action.yml?ref=${TOOLKIT_REF}"
```

The downloaded content is then executed inside the worker job with access to its secrets (`ANTHROPIC_API_KEY`, `LINEAR_API_KEY`, GitHub App installation tokens). If `toolkit_ref` is set to an attacker-controlled ref — e.g., a fork branch or a tag — they get RCE-with-secrets the moment any of these workflows is invoked with their branch.

Some callers (e.g., `claude-docs-check.yml:78`) pass `toolkit_ref: ${{ github.head_ref || github.ref_name }}` — the trigger ref. So an attacker who can author a PR can influence `toolkit_ref` via the head ref name.

## Fix

Add a `Validate toolkit_ref` step as the **first** step in each worker job, before any subsequent step uses `TOOLKIT_REF`:

```yaml
- name: Validate toolkit_ref
  env:
    TOOLKIT_REF: ${{ inputs.toolkit_ref }}
  run: |
    case "$TOOLKIT_REF" in
      main|next) ;;
      *)
        if ! printf '%s' "$TOOLKIT_REF" | grep -qE '^[0-9a-fA-F]{40}$'; then
          echo "::error::Invalid toolkit_ref: '$TOOLKIT_REF'. Allowed: main, next, or a full 40-char SHA."
          exit 1
        fi
        ;;
    esac
```

Allowlist:
- `main` / `next` — well-known branch names
- 40-char SHA — pinned commits

Tags, feature branches, fork branches: all rejected.

Patched (6 worker files):
- `_claude-task-worker.yml`
- `_claude-code-review.yml`
- `_claude-docs-check.yml`
- `_claude-main.yml`
- `_generate-pr-metadata.yml`
- `_update-action-versions-worker.yml`

## Test plan

The validation runs BEFORE the bullfrog egress scan, so even if the egress allowlist is misconfigured, attacker-controlled refs are rejected before any network call is made.

Manual: `case` + `grep -qE '^[0-9a-fA-F]{40}$'` accepts only the documented allowlist; everything else fails the job loudly with an `::error::` annotation.

YAML validates with `yaml.safe_load`.

To verify post-merge: invoke one of the workers with `toolkit_ref: "feature/anything"` and confirm the validation step exits non-zero with the expected error. Invoke with `toolkit_ref: main` and confirm it succeeds.

## Session context

Discovered during the bug bounty review that produced [Uniswap/default-token-list#2484](https://github.com/Uniswap/default-token-list/pull/2484) and [Uniswap/ai-toolkit#509](https://github.com/Uniswap/ai-toolkit/pull/509).

**Caller-side follow-up.** Callers that pass `toolkit_ref` from a non-allowlisted source (e.g., `claude-docs-check.yml:78` passes the trigger ref) will now fail at runtime. Either pin the caller to `main`/`next`/SHA, OR drop the dynamic ref and rely on workflow_call's default. The strict-validation surface this exposes is the point: callers will need to make a deliberate choice.

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
All six reusable `workflow_call` workers accept a `toolkit_ref` input and use it directly in `curl` URLs to fetch `action.yml` / `post-*.ts` script content from this repo:
```bash
curl -L "https://api.github.com/repos/Uniswap/ai-toolkit/contents/.github/.../action.yml?ref=${TOOLKIT_REF}"
```
The downloaded content is then executed inside the worker job with access to its secrets (`ANTHROPIC_API_KEY`, `LINEAR_API_KEY`, GitHub App installation tokens). If `toolkit_ref` is set to an attacker-controlled ref — e.g., a fork branch or a tag — they get RCE-with-secrets the moment any of these workflows is invoked with their branch.
One caller (`claude-docs-check.yml:78`) was passing `toolkit_ref: ${{ github.head_ref || github.ref_name }}` — the trigger ref. So a PR author could influence `toolkit_ref` via the head ref name.
## Fix
Two coordinated changes:
**1. Worker-side allowlist (6 files).** Add a `Validate toolkit_ref` step in each worker job, placed after the bullfrog egress step (per the "bullfrog must be first" rule in `.github/workflows/CLAUDE.md`) but before any step that uses `TOOLKIT_REF`:
```yaml
- name: Validate toolkit_ref
  env:
    TOOLKIT_REF: ${{ inputs.toolkit_ref }}
  run: |
    case "$TOOLKIT_REF" in
      main|next) ;;
      *)
        if ! printf '%s' "$TOOLKIT_REF" | grep -qE '^[0-9a-fA-F]{40}$'; then
          echo "::error::Invalid toolkit_ref: '$TOOLKIT_REF'. Allowed: main, next, or a full 40-char SHA."
          exit 1
        fi
        ;;
    esac
```
Allowlist:
- `main` / `next` — well-known branch names
- 40-char SHA — pinned commits
Tags, feature branches, and fork branches are all rejected. The validation does no network egress (`case` / `printf` / `grep`), so placing it after bullfrog rather than first has no impact on the threat model.
**2. Caller-side pin.** `claude-docs-check.yml` was the one caller still passing the trigger ref — now pinned to `'main'`. The comment block was extended to note that external repos copying this consumer workflow as a template should keep `toolkit_ref` pinned to `main`: the worker's allowlist blocks fork branches but still permits `next`.
## What changed
| File | Edit |
| --- | --- |
| `.github/workflows/_claude-task-worker.yml` | Add `Validate toolkit_ref` step after bullfrog |
| `.github/workflows/_claude-code-review.yml` | Add `Validate toolkit_ref` step after bullfrog |
| `.github/workflows/_claude-docs-check.yml` | Add `Validate toolkit_ref` step after bullfrog |
| `.github/workflows/_claude-main.yml` | Add `Validate toolkit_ref` step after bullfrog |
| `.github/workflows/_generate-pr-metadata.yml` | Add `Validate toolkit_ref` step after bullfrog |
| `.github/workflows/_update-action-versions-worker.yml` | Add `Validate toolkit_ref` step after bullfrog |
| `.github/workflows/claude-docs-check.yml` | Pin `toolkit_ref` to `'main'`; extend comment block for external template consumers |
Total: +162 / -6 across 7 files.
## Test plan
- [x] Validation runs before any step that consumes `toolkit_ref` to fetch `action.yml` / `post-*.ts` content, so attacker-controlled refs are rejected before any sensitive curl/exec.
- [x] Validation step itself does no network egress, so placing it after bullfrog is safe.
- [x] Manual verification: `case` + `grep -qE '^[0-9a-fA-F]{40}$'` accepts only the documented allowlist; everything else fails the job loudly with an `::error::` annotation.
- [x] YAML parses with `yaml.safe_load`.
- [x] `claude-docs-check.yml` caller updated to a pinned `'main'` so it doesn't hit the new strict validation on its own PRs.
- [ ] Post-merge: invoke a worker with `toolkit_ref: "feature/anything"` and confirm the validation step exits non-zero with the expected error. Invoke with `toolkit_ref: main` and confirm it succeeds.
## Caller-side follow-up
Other callers in consumer repos that pass `toolkit_ref` from a non-allowlisted source will now fail at runtime. Either pin the caller to `main` / `next` / a SHA, OR drop the dynamic ref and rely on `workflow_call`'s default. The strict-validation surface this exposes is the point: callers must make a deliberate choice.
## Session context
Discovered during the bug bounty review that produced [Uniswap/default-token-list#2484](https://github.com/Uniswap/default-token-list/pull/2484) and [Uniswap/ai-toolkit#509](https://github.com/Uniswap/ai-toolkit/pull/509).

</details>
<!-- claude-pr-description-end -->