### PR TITLE
fix(workflows): set BUN_CONFIG_FILE=/dev/null in remaining workflows

### DIFF
--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -251,6 +251,14 @@ on:
         description: "Personal Access Token with repo scope. Required for: (1) resolving review threads via GraphQL API, and (2) auto-fix pushes that trigger subsequent workflow runs. Falls back to GITHUB_TOKEN if not provided, but auto-fix pushes with GITHUB_TOKEN will NOT trigger new workflow runs."
         required: false
 
+# Disable Bun's automatic bunfig.toml loading from CWD. This workflow runs
+# `bun run` against post-review scripts; if a caller checks out PR head
+# content first, `bun run` would auto-load bunfig.toml from the checkout
+# root and `bunfig.toml.preload` would execute arbitrary code with the
+# caller's secrets. Propagates to all jobs and steps in this workflow.
+env:
+  BUN_CONFIG_FILE: /dev/null
+
 jobs:
   claude-review:
     runs-on: ubuntu-latest

--- a/.github/workflows/_claude-docs-check.yml
+++ b/.github/workflows/_claude-docs-check.yml
@@ -740,8 +740,11 @@ jobs:
             SCRIPT_ARGS="$SCRIPT_ARGS --auto-commit"
           fi
 
-          # Run post-processing script
-          bun run "$POST_SCRIPT" $SCRIPT_ARGS
+          # Run post-processing script. BUN_CONFIG_FILE=/dev/null is already set
+          # at the job env (line 187), but pinning it inline keeps Semgrep's
+          # bun-run-in-reusable-workflow rule satisfied and survives anyone
+          # later moving this into a step that overrides the job env.
+          BUN_CONFIG_FILE=/dev/null bun run "$POST_SCRIPT" $SCRIPT_ARGS
 
           # Check if branch was created
           if [ -f /tmp/fixup-branch-name.txt ]; then

--- a/.github/workflows/_claude-docs-check.yml
+++ b/.github/workflows/_claude-docs-check.yml
@@ -170,6 +170,14 @@ on:
         description: "Number of commits pushed when auto_commit is enabled"
         value: ${{ jobs.docs-check.outputs.commits_pushed }}
 
+# Disable Bun's automatic bunfig.toml loading from CWD. When a workflow
+# checks out PR head content (this workflow checks out PR refs to read
+# diffs and post comments), `bun run` would otherwise auto-load
+# bunfig.toml from the checkout root, and `bunfig.toml.preload` executes
+# arbitrary code before the intended script — RCE with caller secrets.
+env:
+  BUN_CONFIG_FILE: /dev/null
+
 jobs:
   docs-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/_claude-task-worker.yml
+++ b/.github/workflows/_claude-task-worker.yml
@@ -165,6 +165,13 @@ on:
         description: "PAT for pushing branches (optional, falls back to GITHUB_TOKEN)"
         required: false
 
+# Disable Bun's automatic bunfig.toml loading from CWD. `bun run` invocations
+# in this workflow run after checkout of the worker's repo; without this,
+# a malicious bunfig.toml at the checkout root would have its preload array
+# execute arbitrary code before the intended script (RCE with caller secrets).
+env:
+  BUN_CONFIG_FILE: /dev/null
+
 jobs:
   process-task:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -7,6 +7,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+# Disable Bun's automatic bunfig.toml loading from CWD. `bun run` invocations
+# in this workflow run after checkout; without this, a malicious bunfig.toml
+# at the checkout root would have its preload array execute arbitrary code
+# before the intended script (RCE with workflow secrets).
+env:
+  BUN_CONFIG_FILE: /dev/null
+
 jobs:
   # Pre-check job to detect automated PRs
   check-automated:

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -58,6 +58,14 @@ concurrency:
   group: publish-${{ github.ref }}
   cancel-in-progress: false
 
+# Disable Bun's automatic bunfig.toml loading from CWD. `bun install` and
+# `bun run` invocations in this workflow run after checkout; without this,
+# a malicious bunfig.toml at the checkout root would have its preload array
+# execute arbitrary code before the intended script (RCE with publish-token
+# scope in this workflow).
+env:
+  BUN_CONFIG_FILE: /dev/null
+
 jobs:
   # ============================================================================
   # DETECT: Determine which packages to publish


### PR DESCRIPTION
## Summary

Two complementary changes to land together:

1. **Worker-side validation** (across 6 reusable workers): reject `toolkit_ref` values outside `{main, next, [a-f0-9]{40}}` before any downstream step uses it.
2. **Caller-side pin**: change `claude-docs-check.yml:78` from `${{ github.head_ref || github.ref_name }}` to `'main'` — the only in-repo caller that wouldn't satisfy the new validator. (External callers — `Uniswap/sdks`, `Uniswap/uniswap-ai` — are already in the allowlist.)

Both must land together. Splitting them would mean either: (a) merging the validator first breaks `claude-docs-check.yml` on every non-main PR including this PR's own docs-check run, or (b) merging the pin first ships a "fix" with no enforcement. Combined as one PR removes both problems.

## The vulnerability class being closed

All six reusable `workflow_call` workers accept a `toolkit_ref` input and use it directly in curl URLs to fetch action.yml / post-*.ts script content from this repository:

```bash
curl -L "https://api.github.com/repos/Uniswap/ai-toolkit/contents/.github/.../action.yml?ref=${TOOLKIT_REF}"
```

The downloaded content is then executed inside the worker job with access to its secrets (`ANTHROPIC_API_KEY`, `LINEAR_API_KEY`, GitHub App installation tokens). If `toolkit_ref` is set to an attacker-controlled ref — e.g., a fork branch or any PR branch via the dynamic-ref pattern — they get RCE-with-secrets the moment any of these workflows is invoked with that branch.

## Changes

### 1. Worker-side validation step (6 files)

Added as the **first** step in each worker job, before any subsequent step uses `TOOLKIT_REF`:

```yaml
- name: Validate toolkit_ref
  env:
    TOOLKIT_REF: ${{ inputs.toolkit_ref }}
  run: |
    case "$TOOLKIT_REF" in
      main|next) ;;
      *)
        if ! printf '%s' "$TOOLKIT_REF" | grep -qE '^[0-9a-fA-F]{40}$'; then
          echo "::error::Invalid toolkit_ref: '$TOOLKIT_REF'. Allowed: main, next, or a full 40-char SHA."
          exit 1
        fi
        ;;
    esac
```

Allowlist:
- `main` / `next` — well-known branch names
- 40-char SHA — pinned commits

Tags, feature branches, fork branches: all rejected.

Patched (6 worker files):
- `_claude-task-worker.yml`
- `_claude-code-review.yml`
- `_claude-docs-check.yml`
- `_claude-main.yml`
- `_generate-pr-metadata.yml`
- `_update-action-versions-worker.yml`

The validation runs BEFORE the bullfrog egress scan, so even if the egress allowlist is misconfigured, attacker-controlled refs are rejected before any network call is made.

### 2. Caller-side pin (1 file)

`claude-docs-check.yml:78` previously passed:

```yaml
toolkit_ref: ${{ github.head_ref || github.ref_name }}
```

This resolves to the PR branch name on every `pull_request:` run. A PR author could land malicious script content on their own branch and have the docs-check workflow execute it with full secrets.

Pinned to `'main'`. Eliminates the attack at the data-source level — the only ref the worker can use is the trusted baseline.

**Trade-off accepted**: PR authors who modify worker scripts (`post-docs-check.ts`, `validate-claude-auth/action.yml`) can no longer self-test their changes via docs-check on the same PR. Replacement test flow:

1. Land the script change on `next` first (existing release branch).
2. Verify docs-check works on `next` (use `workflow_dispatch` with explicit `toolkit_ref: next`).
3. Promote `next` → `main` via the existing `_notify-release.yml` "Next Branch Release" flow.

For ad-hoc testing of an unmerged SHA, the worker accepts a 40-char SHA in `toolkit_ref`. Use `workflow_dispatch` with a SHA pin rather than relying on the PR-triggered docs-check.

## Test plan

Manual: `case` + `grep -qE '^[0-9a-fA-F]{40}$'` accepts only the documented allowlist; everything else fails the job loudly with an `::error::` annotation. Combined with the caller-side pin, the in-repo flow on `main`/`next`/`pull_request` all pass through the validator with `'main'` as the value.

YAML in all 7 files validates with `yaml.safe_load`.

To verify post-merge: invoke a worker with `toolkit_ref: "feature/anything"` (manually via workflow_dispatch) and confirm the validation step exits non-zero with the expected error. Invoke with default (`main`) and confirm it succeeds.

## Session context

Discovered during the bug bounty review that produced [Uniswap/default-token-list#2484](https://github.com/Uniswap/default-token-list/pull/2484) and [Uniswap/ai-toolkit#509](https://github.com/Uniswap/ai-toolkit/pull/509).

This PR consolidates what was originally two PRs (#515 was the caller-side pin) into a single coherent change. #515 has been closed and rolled into this one.

**External callers** that pass `toolkit_ref` are already in the allowlist:
- `Uniswap/sdks/.github/workflows/claude-code-review.yml:36` — pinned SHA `01e6451c...`
- `Uniswap/uniswap-ai/.github/workflows/claude-docs-check.yml:69` — pinned `'main'`

The only in-repo caller using a dynamic ref was the one fixed here.

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Follow-up to commits `1d60322` (`fix(workflows): set BUN_CONFIG_FILE=/dev/null to neutralize bunfig.toml.preload RCE`) and `4ea287d` (`fix(workflows): also prefix BUN_CONFIG_FILE=/dev/null inline on bun run`). Those landed the mitigation on a subset of workflows; this PR extends the same hardening to the remaining 5 workflows that run `bun install` or `bun run` after a checkout.
## The vulnerability class being closed
Bun auto-loads `bunfig.toml` from the current working directory. If a workflow checks out attacker-controlled head content first, a `bunfig.toml` at the checkout root with a `preload` array executes arbitrary JS/TS **before** the intended `bun run` / `bun install` command — RCE with that workflow's secrets (Anthropic, GitHub App tokens, npm publish token, etc.).
Setting `BUN_CONFIG_FILE=/dev/null` at the workflow level redirects Bun to an empty config file, neutralizing the auto-load. The setting propagates to every job and step in the workflow.
## What changed
Workflow-level `env: BUN_CONFIG_FILE: /dev/null` added to 5 workflows:
| File | Why it needs the env var |
|---|---|
| `_claude-code-review.yml` | Runs `bun run` against post-review scripts after checking out PR content |
| `_claude-docs-check.yml` | Runs `bun run` against post-check scripts after checking out PR refs |
| `_claude-task-worker.yml` | Runs `bun run` after checkout of the worker's target repo |
| `ci-pr-checks.yml` | Runs `bun` commands after PR checkout |
| `publish-packages.yml` | Runs `bun install` / `bun run` with package publish-token scope |
Plus one inline pin in `_claude-docs-check.yml:724`:
```bash
BUN_CONFIG_FILE=/dev/null bun run "$POST_SCRIPT" $SCRIPT_ARGS
```
The workflow-level env already covers this call, but pinning inline keeps the existing semgrep `bun-run-in-reusable-workflow` rule satisfied and survives anyone later moving this into a step that overrides the job env.
## Test plan
- [x] YAML parses in all 5 files; each now has a workflow-level `env: BUN_CONFIG_FILE: /dev/null` block
- [x] Inline `BUN_CONFIG_FILE=/dev/null` retained on the docs-check post-script `bun run` to keep semgrep clean
- [x] Diff is additive only — no behavior changes for the legitimate code path (Bun reading an empty config file is equivalent to no `bunfig.toml` being present, which is the case in the repo root for these workflows)
- [ ] CI on this PR
## Out of scope
- Other workflows that don't invoke `bun` or do so without first checking out untrusted content — not reachable via this vector.
- The broader supply-chain hardening tracked under the bun-migration follow-ups (PR #453 introduced bun; the `BUN_CONFIG_FILE` mitigation backfills the missing piece across all bun-using workflows).

</details>
<!-- claude-pr-description-end -->