### PR TITLE
fix(workflows): add validate-changed-files blocklist to task worker

### DIFF
--- a/.github/workflows/_claude-task-worker.yml
+++ b/.github/workflows/_claude-task-worker.yml
@@ -530,6 +530,45 @@ jobs:
           additional_permissions: |
             actions: read
 
+      # Validate changed files (blocklist for sensitive paths).
+      # The autonomous task worker is generic-purpose — it can legitimately
+      # modify any source file in the repo. But certain paths must require
+      # human review even if a prompt-injected Claude session asks to change
+      # them: workflow/action definitions (would alter CI itself), package-
+      # manager config (.npmrc, bunfig.toml — would change install behavior),
+      # CODEOWNERS (would alter review gates), and any secret material.
+      # Refine this blocklist as the team finds new sensitive-path categories.
+      - name: Validate changed files
+        env:
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+        run: |
+          CHANGED=$(git diff --name-only origin/"$TARGET_BRANCH"..HEAD 2>/dev/null || echo "")
+          if [ -z "$CHANGED" ]; then
+            echo "No files changed"
+            exit 0
+          fi
+          echo "Changed files:"
+          echo "$CHANGED"
+          BLOCKED=0
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              .github/workflows/*|.github/actions/*|.github/CODEOWNERS|CODEOWNERS)
+                echo "::error::Blocked: $f — CI/review-gate files require human review, not autonomous Claude modification"
+                BLOCKED=1 ;;
+              .npmrc|.bun-version|bunfig.toml|.bunfig.toml|.yarnrc|.yarnrc.yml|.pnpmrc)
+                echo "::error::Blocked: $f — package-manager config requires human review"
+                BLOCKED=1 ;;
+              .env|.env.*|*.pem|*.key|secrets/*)
+                echo "::error::Blocked: $f — secret material must never be committed by an autonomous run"
+                BLOCKED=1 ;;
+            esac
+          done <<EOF
+          $CHANGED
+          EOF
+          [ "$BLOCKED" -eq 0 ] || { echo "::error::One or more changed files are in the blocklist; failing job."; exit 1; }
+          echo "✅ All changed files passed the blocklist check"
+
       # Verify commit author identity defense-in-depth
       #
       # The GIT_AUTHOR_* env vars on the Run Claude Code step are honored by

--- a/.github/workflows/_claude-task-worker.yml
+++ b/.github/workflows/_claude-task-worker.yml
@@ -534,15 +534,29 @@ jobs:
       # The autonomous task worker is generic-purpose — it can legitimately
       # modify any source file in the repo. But certain paths must require
       # human review even if a prompt-injected Claude session asks to change
-      # them: workflow/action definitions (would alter CI itself), package-
-      # manager config (.npmrc, bunfig.toml — would change install behavior),
-      # CODEOWNERS (would alter review gates), and any secret material.
-      # Refine this blocklist as the team finds new sensitive-path categories.
+      # them: workflow/action definitions and bot configs (would alter CI
+      # itself), package-manager config (.npmrc, bunfig.toml — would change
+      # install behavior), CODEOWNERS (would alter review gates), and any
+      # secret material. Refine this blocklist as the team finds new
+      # sensitive-path categories.
+      #
+      # Patterns are bash `case` globs: they match the full path string,
+      # `*` spans '/'. Root-anchored dotfiles (.npmrc, .env) need an
+      # explicit `*/...` variant to also match nested monorepo locations
+      # (apps/foo/.npmrc), since `case ".npmrc"` only matches the literal
+      # repo-root file.
       - name: Validate changed files
         env:
           TARGET_BRANCH: ${{ inputs.target_branch }}
         run: |
-          CHANGED=$(git diff --name-only origin/"$TARGET_BRANCH"..HEAD 2>/dev/null || echo "")
+          set -euo pipefail
+          # Distinguish "git command failed" from "diff is genuinely empty":
+          # swallowing the former would let an attacker who corrupted git
+          # state earlier in the job silently skip the blocklist.
+          if ! CHANGED=$(git diff --name-only "origin/$TARGET_BRANCH..HEAD"); then
+            echo "::error::Failed to compute diff against origin/$TARGET_BRANCH; refusing to skip blocklist check"
+            exit 1
+          fi
           if [ -z "$CHANGED" ]; then
             echo "No files changed"
             exit 0
@@ -553,19 +567,32 @@ jobs:
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             case "$f" in
-              .github/workflows/*|.github/actions/*|.github/CODEOWNERS|CODEOWNERS)
+              # CI / review-gate surfaces (workflows, composite actions, CODEOWNERS, bot configs).
+              # Anchored under .github/ since that's where GitHub honors them.
+              .github/workflows/*|.github/actions/*|\
+              .github/CODEOWNERS|CODEOWNERS|\
+              .github/dependabot.yml|\
+              .github/renovate.json|.github/renovate.json5|\
+              .github/settings.yml)
                 echo "::error::Blocked: $f — CI/review-gate files require human review, not autonomous Claude modification"
                 BLOCKED=1 ;;
-              .npmrc|.bun-version|bunfig.toml|.bunfig.toml|.yarnrc|.yarnrc.yml|.pnpmrc)
+              # Package-manager config — both repo-root and nested monorepo packages.
+              .npmrc|*/.npmrc|\
+              .bun-version|*/.bun-version|\
+              bunfig.toml|*/bunfig.toml|.bunfig.toml|*/.bunfig.toml|\
+              .yarnrc|*/.yarnrc|.yarnrc.yml|*/.yarnrc.yml|\
+              .pnpmrc|*/.pnpmrc)
                 echo "::error::Blocked: $f — package-manager config requires human review"
                 BLOCKED=1 ;;
-              .env|.env.*|*.pem|*.key|secrets/*)
+              # Secret material — both root and nested. *.pem/*.key already
+              # cover nested paths because `case` `*` spans '/'.
+              .env|.env.*|*/.env|*/.env.*|\
+              secrets/*|*/secrets/*|\
+              *.pem|*.key)
                 echo "::error::Blocked: $f — secret material must never be committed by an autonomous run"
                 BLOCKED=1 ;;
             esac
-          done <<EOF
-          $CHANGED
-          EOF
+          done <<<"$CHANGED"
           [ "$BLOCKED" -eq 0 ] || { echo "::error::One or more changed files are in the blocklist; failing job."; exit 1; }
           echo "✅ All changed files passed the blocklist check"
 


### PR DESCRIPTION
## Summary

The sister `_claude-task-worker.yml` in `Uniswap/default-token-list` has a `Validate changed files` step (lines 476-491) that runs after the Claude session ends and rejects modifications outside the expected allowlist. It is explicitly described as "defense-in-depth against prompt injection".

This worker has no such step. Combined with `--dangerously-skip-permissions` (in the same Claude session — see [the separate hardening PR for that change](#)), a prompt-injected session can modify any file in the repo and only human PR review stands between the change and `main`.

## Fix

Add a `Validate changed files` step that runs `git diff --name-only origin/$TARGET_BRANCH..HEAD` against a **blocklist** (not allowlist — this worker is generic-purpose and could legitimately modify any source file). The blocklist covers paths that must require human review even for legitimate changes:

- `.github/workflows/*` and `.github/actions/*` — changing CI definitions
- `CODEOWNERS` files — changing review-gate definitions
- Package-manager config: `.npmrc`, `bunfig.toml`, `.yarnrc`, `.pnpmrc`
- Secret material: `.env`, `.env.*`, `*.pem`, `*.key`, `secrets/*`

If any changed file matches the blocklist, the job exits non-zero with an `::error::` annotation listing the offending file.

The blocklist is intended as a starting point. Refine when the team finds additional sensitive-path categories.

## Test plan

Manual: each `case` pattern is a bash glob, matching the conservative defaults a security team would set. The blocklist is verbose but flat — easy to review and extend.

YAML validates with `yaml.safe_load`.

To verify post-merge: file a Linear ticket asking the worker to modify `.github/workflows/test.yml`. Confirm the post-Claude step fails with the expected error, the bot's PR is not eligible to merge.

## Session context

Discovered during the bug bounty review that produced [Uniswap/default-token-list#2484](https://github.com/Uniswap/default-token-list/pull/2484) and [Uniswap/ai-toolkit#509](https://github.com/Uniswap/ai-toolkit/pull/509). The default-token-list worker already has an allowlist; this PR brings the ai-toolkit worker up to parity.

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
The sister `_claude-task-worker.yml` in `Uniswap/default-token-list` has a `Validate changed files` step that runs after the Claude session ends and rejects modifications outside the expected allowlist. It is explicitly described as "defense-in-depth against prompt injection".
This worker has no such step. Combined with `--dangerously-skip-permissions` (in the same Claude session — see the separate hardening PR for that change), a prompt-injected session can modify any file in the repo and only human PR review stands between the change and `main`.
## Fix
Add a `Validate changed files` step in `.github/workflows/_claude-task-worker.yml` that runs `git diff --name-only origin/$TARGET_BRANCH..HEAD` against a **blocklist** (not allowlist — this worker is generic-purpose and could legitimately modify any source file). The blocklist covers paths that must require human review even for legitimate changes:
- `.github/workflows/*` and `.github/actions/*` — CI definitions
- `.github/CODEOWNERS` / `CODEOWNERS` — review-gate definitions
- `.github/dependabot.yml`, `.github/renovate.json{,5}`, `.github/settings.yml` — bot configs
- Package-manager config: `.npmrc`, `.bun-version`, `bunfig.toml`, `.yarnrc{,.yml}`, `.pnpmrc` (both repo-root and nested monorepo locations)
- Secret material: `.env`, `.env.*`, `secrets/*`, `*.pem`, `*.key`
If any changed file matches the blocklist, the job exits non-zero with an `::error::` annotation listing the offending file. A failed `git diff` is treated as a hard error (rather than an empty-diff success) so an attacker who corrupts git state earlier in the job can't silently skip the check.
The blocklist is intended as a starting point. Refine when the team finds additional sensitive-path categories.
## What changed
| File | Change |
| --- | --- |
| `.github/workflows/_claude-task-worker.yml` | Add `Validate changed files` step after the Claude action; +66 / -0 |
## Test plan
- [x] Each `case` pattern is a bash glob (where `*` spans `/`), matching the conservative defaults a security team would set
- [x] Root-anchored dotfiles (`.npmrc`, `.env`, etc.) get an explicit `*/...` variant so nested monorepo locations (`apps/foo/.npmrc`) are also blocked
- [x] `git diff` failure exits non-zero rather than falling through to a "no changes" success
- [x] Blocklist is verbose but flat — easy to review and extend
- [ ] Post-merge verification: file a Linear ticket asking the worker to modify `.github/workflows/test.yml`. Confirm the post-Claude step fails with the expected error and the bot's PR is not eligible to merge.
## Session context
Discovered during the bug bounty review that produced [Uniswap/default-token-list#2484](https://github.com/Uniswap/default-token-list/pull/2484) and [Uniswap/ai-toolkit#509](https://github.com/Uniswap/ai-toolkit/pull/509). The default-token-list worker already has an allowlist; this PR brings the ai-toolkit worker up to parity (using a blocklist instead, since this worker is generic-purpose).

</details>
<!-- claude-pr-description-end -->