### PR TITLE
fix(workflows): replace sed-with-pipe-delimiter with python str.replace

### DIFF
--- a/.github/workflows/_claude-docs-check.yml
+++ b/.github/workflows/_claude-docs-check.yml
@@ -507,18 +507,30 @@ jobs:
 
           PROMPT_EOF
 
-          # Substitute variables
-          sed -i "s|\${REPO_OWNER}|$REPO_OWNER|g" /tmp/docs-check-prompt.txt
-          sed -i "s|\${REPO_NAME}|$REPO_NAME|g" /tmp/docs-check-prompt.txt
-          sed -i "s|\${PR_NUMBER}|$PR_NUMBER|g" /tmp/docs-check-prompt.txt
-          sed -i "s|\${BASE_REF}|$BASE_REF|g" /tmp/docs-check-prompt.txt
-          sed -i "s|\${LINES_CHANGED}|$LINES_CHANGED|g" /tmp/docs-check-prompt.txt
-          sed -i "s|\${FAIL_ON_MISSING_DOCS}|$FAIL_ON_MISSING_DOCS|g" /tmp/docs-check-prompt.txt
-          sed -i "s|\${FAIL_ON_MISSING_VERSION}|$FAIL_ON_MISSING_VERSION|g" /tmp/docs-check-prompt.txt
-
-          # Insert changed files (escape for sed)
-          CHANGED_FILES_ESCAPED=$(printf '%s\n' "$CHANGED_FILES" | sed 's/[&/\]/\\&/g; s/$/\\n/' | tr -d '\n')
-          sed -i "s|\${CHANGED_FILES}|$CHANGED_FILES_ESCAPED|g" /tmp/docs-check-prompt.txt
+          # Substitute placeholders using python's str.replace.
+          #
+          # Why not sed: the previous code used `sed -i "s|\${VAR}|$VALUE|g"`
+          # with `|` as the sed delimiter. The escape applied to $CHANGED_FILES
+          # was `sed 's/[&/\]/\\&/g'`, which escapes `&`, `/`, `\` but NOT `|`
+          # (the actual delimiter). A filename in $CHANGED_FILES containing `|`
+          # — legal on Linux, not quoted by git's default `core.quotepath`
+          # since `|` is in the printable ASCII range — would break the
+          # substitution into garbage flags and cause the docs-check workflow
+          # to fail loudly or, worse, write a partial value.
+          #
+          # Python's str.replace is plain-text and immune to this class.
+          export REPO_OWNER REPO_NAME CHANGED_FILES
+          python3 - <<'PYEOF'
+          import os
+          from pathlib import Path
+          p = Path('/tmp/docs-check-prompt.txt')
+          content = p.read_text()
+          for key in ('REPO_OWNER', 'REPO_NAME', 'PR_NUMBER', 'BASE_REF',
+                      'LINES_CHANGED', 'FAIL_ON_MISSING_DOCS',
+                      'FAIL_ON_MISSING_VERSION', 'CHANGED_FILES'):
+              content = content.replace('${' + key + '}', os.environ.get(key, ''))
+          p.write_text(content)
+          PYEOF
 
           # For the diff, we'll append it separately due to size
           echo "" >> /tmp/docs-check-prompt.txt


### PR DESCRIPTION
## Summary

`_claude-docs-check.yml`'s `Build Docs Check Prompt` step substitutes 8 placeholders into the prompt template via `sed -i "s|\${VAR}|$VALUE|g"` with `|` as the sed delimiter. The escape applied to `$CHANGED_FILES` on line 520 is `sed 's/[&/\]/\\&/g'` — it escapes `&`, `/`, `\` but **not** `|` (the actual delimiter).

A filename in `$CHANGED_FILES` containing `|` (legal on Linux; not quoted by git's default `core.quotepath` since `|` is in the printable ASCII range) breaks the substitution into garbage flags and causes the docs-check workflow to fail or write a partial value into the prompt. PR authors can introduce such filenames via fork PRs.

## Fix

Replace the 8 `sed -i` calls with a single `python3` script that uses `str.replace`. Python's `str.replace` is plain-text and immune to this entire class of delimiter-injection bugs.

```python
for key in ('REPO_OWNER', 'REPO_NAME', 'PR_NUMBER', 'BASE_REF',
            'LINES_CHANGED', 'FAIL_ON_MISSING_DOCS',
            'FAIL_ON_MISSING_VERSION', 'CHANGED_FILES'):
    content = content.replace('${' + key + '}', os.environ.get(key, ''))
```

## Test plan

Manual reasoning: the substitution is deterministic and independent of input bytes. Python `str.replace` is documented to be plain-text, no regex/glob interpretation.

YAML validates with `yaml.safe_load`.

To verify post-merge: trigger the docs-check workflow on a PR that includes a file with `|` in its name (`touch 'evil|file.md'; git add -A; git commit; git push`); confirm the workflow runs without sed errors and the prompt contains the literal filename.

## Session context

Discovered during the bug bounty review that produced [Uniswap/default-token-list#2484](https://github.com/Uniswap/default-token-list/pull/2484) and [Uniswap/ai-toolkit#509](https://github.com/Uniswap/ai-toolkit/pull/509). Out-of-scope for the heredoc-delimiter PR but the same general class ("attacker text reaches the LLM prompt via a brittle escape").

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
`_claude-docs-check.yml`'s `Build Docs Check Prompt` step substitutes 8 placeholders into the prompt template via `sed -i "s|\${VAR}|$VALUE|g"` with `|` as the sed delimiter. The escape applied to `$CHANGED_FILES` on line 520 is `sed 's/[&/\]/\\&/g'` — it escapes `&`, `/`, `\` but **not** `|` (the actual delimiter).
A filename in `$CHANGED_FILES` containing `|` (legal on Linux; not quoted by git's default `core.quotepath` since `|` is in the printable ASCII range) breaks the substitution into garbage flags and causes the docs-check workflow to fail or write a partial value into the prompt. PR authors can introduce such filenames via fork PRs.
## Fix
Replace the 8 `sed -i` calls with a single `python3` script that uses `str.replace`. Python's `str.replace` is plain-text and immune to this entire class of delimiter-injection bugs.
```python
for key in ('REPO_OWNER', 'REPO_NAME', 'PR_NUMBER', 'BASE_REF',
            'LINES_CHANGED', 'FAIL_ON_MISSING_DOCS',
            'FAIL_ON_MISSING_VERSION', 'CHANGED_FILES'):
    content = content.replace('${' + key + '}', os.environ.get(key, ''))
```
## What changed
| File | Change |
| --- | --- |
| `.github/workflows/_claude-docs-check.yml` | Replace 8 `sed -i` placeholder substitutions (plus the bespoke `CHANGED_FILES` escape) with a single Python heredoc using `str.replace`; +24 / -12 |
## Test plan
- [x] Manual reasoning: the substitution is deterministic and independent of input bytes. Python `str.replace` is documented to be plain-text — no regex/glob interpretation.
- [x] YAML validates with `yaml.safe_load`.
- [ ] Post-merge verification: trigger the docs-check workflow on a PR that includes a file with `|` in its name (`touch 'evil|file.md'; git add -A; git commit; git push`); confirm the workflow runs without sed errors and the prompt contains the literal filename.
## Session context
Discovered during the bug bounty review that produced [Uniswap/default-token-list#2484](https://github.com/Uniswap/default-token-list/pull/2484) and [Uniswap/ai-toolkit#509](https://github.com/Uniswap/ai-toolkit/pull/509). Out-of-scope for the heredoc-delimiter PR but the same general class ("attacker text reaches the LLM prompt via a brittle escape").

</details>
<!-- claude-pr-description-end -->