### PR TITLE
fix(workflows): pin claude-docs-check toolkit_ref to main

### DIFF
--- a/.github/workflows/claude-docs-check.yml
+++ b/.github/workflows/claude-docs-check.yml
@@ -74,8 +74,14 @@ jobs:
       fail_on_missing_version: true
       # Don't fail on missing docs (just warn)
       fail_on_missing_docs: false
-      # Use local actions since we're in ai-toolkit
-      toolkit_ref: ${{ github.head_ref || github.ref_name }}
+      # Pin to main rather than the trigger ref. ${{ github.head_ref || github.ref_name }}
+      # would let any PR author point the worker at action.yml / post-*.ts script
+      # content from their own branch — the worker then downloads and executes
+      # that content with the workflow's secrets (RCE-with-secrets via supply
+      # chain). Self-testing changes to worker scripts is now done by landing
+      # them to `next` first and verifying there, or by invoking the
+      # workflow_dispatch entrypoint with an explicit SHA in the allowlist.
+      toolkit_ref: 'main'
     secrets:
       # Use OAuth token (Pro/Max) instead of API key
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

This caller passes `toolkit_ref: ${{ github.head_ref || github.ref_name }}`, which resolves to the PR branch name on every `pull_request:` run. The downstream worker (`_claude-docs-check.yml`) then `curl`s `validate-claude-auth/action.yml` and `post-docs-check.ts` from `Uniswap/ai-toolkit@$TOOLKIT_REF` and executes them inside the worker job with access to `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `WORKFLOW_PAT`, and the GitHub App installation token.

**A PR author can land malicious script content on their own branch and have the docs-check workflow execute it with full secrets.** For internal-author PRs (anyone with push access to this repo) the attack is complete RCE-with-secrets. For fork PRs the blast is bounded by what `pull_request:` exposes, but the pattern is brittle either way and would become critical the moment any caller migrated to `pull_request_target:`.

Pin to `'main'`. Eliminates the attack at the data-source level — the only ref the worker can use is the trusted baseline.

## What changed

`.github/workflows/claude-docs-check.yml` line 78:

```diff
-      # Use local actions since we're in ai-toolkit
-      toolkit_ref: ${{ github.head_ref || github.ref_name }}
+      # Pin to main rather than the trigger ref. ${{ github.head_ref || github.ref_name }}
+      # would let any PR author point the worker at action.yml / post-*.ts script
+      # content from their own branch — the worker then downloads and executes
+      # that content with the workflow's secrets ...
+      toolkit_ref: 'main'
```

One line of substantive change plus an explanatory comment. No other files touched.

## Trade-off accepted

PR authors who modify worker scripts (`post-docs-check.ts`, `validate-claude-auth/action.yml`) can no longer self-test their changes via docs-check on the same PR. The pre-merge docs-check now always runs against `main`'s scripts, not the PR's.

Replacement test flow:

1. Land the script change on `next` first (existing release branch).
2. Verify docs-check works on `next` (use `workflow_dispatch` with explicit `toolkit_ref: next`).
3. Promote `next` → `main` via the existing `_notify-release.yml` "Next Branch Release" flow.

For ad-hoc testing of an unmerged SHA, the worker accepts a 40-char SHA in `toolkit_ref`. Use `workflow_dispatch` with a SHA pin rather than relying on the PR-triggered docs-check.

## Sequencing with #511

**This PR must merge BEFORE [#511](https://github.com/Uniswap/ai-toolkit/pull/511).**

#511 adds a validation step inside the worker that rejects `toolkit_ref` values outside `{main, next, [a-f0-9]{40}}`. The worker is invoked from the caller via `uses: ./.github/workflows/_claude-docs-check.yml` — same ref as the caller. So when #511 runs through its own docs-check on its own branch, the current (pre-Option-A) caller passes `toolkit_ref: fix/f3-toolkit-ref`, and the new validation step in #511's own worker rejects it. #511 fails its own docs-check.

Landing this PR first pins the caller to `main`, after which #511's validation has no caller in this repo that would fail.

External callers (`Uniswap/sdks`, `Uniswap/uniswap-ai`, etc.) are already in the allowlist — pinned SHA or `'main'`. So this Option A is the only blocker for #511.

## Test plan

Manual: the change is a single literal value replacement. `'main'` is in #511's allowlist by construction. Post-merge, every `pull_request:` and `push:` trigger of `claude-docs-check.yml` will pass `toolkit_ref: main` to the worker. The worker's curl will fetch from `Uniswap/ai-toolkit@main` — a known-trusted ref.

YAML validates with `yaml.safe_load`.

## Session context

This is **Option A** from the trade-off analysis in #511's PR description:

| Option | Behavior |
|---|---|
| **A (this PR)** | Pin to `main`. Lose self-testing on PRs; gain security. |
| B | Pin to a specific SHA. Same as A but requires manual bump on script changes. |
| C | Split into two callers — one pinned, one `workflow_dispatch`-only with dynamic ref. |
| D | Conditional dynamic based on author identity. Doesn't close insider threat. |
| E | Eliminate `toolkit_ref` entirely (vendor scripts in-repo). Bigger refactor. |

Option A was chosen for the affected caller because docs-check script iteration is infrequent, so the cost of losing same-PR self-test is low. If the team finds iteration is more frequent than expected, follow up with Option C.

Discovered during the bug bounty review that produced [#509](https://github.com/Uniswap/ai-toolkit/pull/509) and [Uniswap/default-token-list#2484](https://github.com/Uniswap/default-token-list/pull/2484).

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
The `claude-docs-check.yml` caller passes `toolkit_ref: ${{ github.head_ref || github.ref_name }}`, which resolves to the PR branch name on every `pull_request:` run. The downstream worker (`_claude-docs-check.yml`) then `curl`s `validate-claude-auth/action.yml` and `post-docs-check.ts` from `Uniswap/ai-toolkit@$TOOLKIT_REF` and executes them inside the worker job with access to `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `WORKFLOW_PAT`, and the GitHub App installation token.
**A PR author can land malicious script content on their own branch and have the docs-check workflow execute it with full secrets.** For internal-author PRs (anyone with push access to this repo) the attack is complete RCE-with-secrets. For fork PRs the blast is bounded by what `pull_request:` exposes, but the pattern is brittle either way and would become critical the moment any caller migrated to `pull_request_target:`.
Pin to `'main'`. Eliminates the attack at the data-source level — the only ref the worker can use is the trusted baseline.
## What changed
`.github/workflows/claude-docs-check.yml` line 78:
```diff
-      # Use local actions since we're in ai-toolkit
-      toolkit_ref: ${{ github.head_ref || github.ref_name }}
+      # Pin to main rather than the trigger ref. ${{ github.head_ref || github.ref_name }}
+      # would let any PR author point the worker at action.yml / post-*.ts script
+      # content from their own branch — the worker then downloads and executes
+      # that content with the workflow's secrets ...
+      toolkit_ref: 'main'
```
One line of substantive change plus an explanatory comment. No other files touched.
## Trade-off accepted
PR authors who modify worker scripts (`post-docs-check.ts`, `validate-claude-auth/action.yml`) can no longer self-test their changes via docs-check on the same PR. The pre-merge docs-check now always runs against `main`'s scripts, not the PR's.
Replacement test flow:
1. Land the script change on `next` first (existing release branch).
2. Verify docs-check works on `next` (use `workflow_dispatch` with explicit `toolkit_ref: next`).
3. Promote `next` → `main` via the existing `_notify-release.yml` "Next Branch Release" flow.
For ad-hoc testing of an unmerged SHA, the worker accepts a 40-char SHA in `toolkit_ref`. Use `workflow_dispatch` with a SHA pin rather than relying on the PR-triggered docs-check.
## Sequencing with #511
**This PR must merge BEFORE [#511](https://github.com/Uniswap/ai-toolkit/pull/511).**
#511 adds a validation step inside the worker that rejects `toolkit_ref` values outside `{main, next, [a-f0-9]{40}}`. The worker is invoked from the caller via `uses: ./.github/workflows/_claude-docs-check.yml` — same ref as the caller. So when #511 runs through its own docs-check on its own branch, the current (pre-Option-A) caller passes `toolkit_ref: fix/f3-toolkit-ref`, and the new validation step in #511's own worker rejects it. #511 fails its own docs-check.
Landing this PR first pins the caller to `main`, after which #511's validation has no caller in this repo that would fail.
External callers (`Uniswap/sdks`, `Uniswap/uniswap-ai`, etc.) are already in the allowlist — pinned SHA or `'main'`. So this Option A is the only blocker for #511.
## Test plan
Manual: the change is a single literal value replacement. `'main'` is in #511's allowlist by construction. Post-merge, every `pull_request:` and `push:` trigger of `claude-docs-check.yml` will pass `toolkit_ref: main` to the worker. The worker's curl will fetch from `Uniswap/ai-toolkit@main` — a known-trusted ref.
YAML validates with `yaml.safe_load`.
## Session context
This is **Option A** from the trade-off analysis in #511's PR description:
| Option | Behavior |
|---|---|
| **A (this PR)** | Pin to `main`. Lose self-testing on PRs; gain security. |
| B | Pin to a specific SHA. Same as A but requires manual bump on script changes. |
| C | Split into two callers — one pinned, one `workflow_dispatch`-only with dynamic ref. |
| D | Conditional dynamic based on author identity. Doesn't close insider threat. |
| E | Eliminate `toolkit_ref` entirely (vendor scripts in-repo). Bigger refactor. |
Option A was chosen for the affected caller because docs-check script iteration is infrequent, so the cost of losing same-PR self-test is low. If the team finds iteration is more frequent than expected, follow up with Option C.
Discovered during the bug bounty review that produced [#509](https://github.com/Uniswap/ai-toolkit/pull/509) and [Uniswap/default-token-list#2484](https://github.com/Uniswap/default-token-list/pull/2484).

</details>
<!-- claude-pr-description-end -->