### PR TITLE
fix(workflows): tighten bullfrog allowlists per workflow

### DIFF
--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -309,6 +309,7 @@ jobs:
             raw.githubusercontent.com
             api.anthropic.com
             claude.ai
+            downloads.claude.ai
             registry.npmjs.org
           enable-sudo: false
 

--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -292,24 +292,23 @@ jobs:
         uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
         with:
           egress-policy: block
-          # Per-workflow tightened allowlist. Empirical data from block-mode
-          # logs shows only http-intake.logs.us5.datadoghq.com is currently
-          # blocked (Datadog logs agent — intentionally blocked).
-          # raw.githubusercontent.com was missed by audit-mode sampling
-          # (bullfrog v0.8.4 queues DNS replies; cached resolutions emit
-          # no further events — per agent/queue_audit.nft); required at
-          # runtime by .github/actions/build-plugin-config which fetches
-          # marketplace.json from raw for plugin discovery.
-          # Dropped (no empirical use): github.com / *.github.com (in
-          # bullfrog defaultDomains), claude.ai / *.claude.ai (OAuth path
-          # unused here; ANTHROPIC_API_KEY path), bun.sh (setup-bun uses
-          # github releases via *.githubusercontent.com), *.npmjs.org
-          # (registry.npmjs.org is the only subdomain used). Pinned
-          # githubusercontent to release-assets + raw subdomains.
+          # Per-workflow tightened allowlist. Audit-mode sampling missed
+          # several destinations because bullfrog v0.8.4 queues DNS *replies*
+          # (agent/queue_audit.nft) and cached resolutions emit no further
+          # events. Domains added below as block-mode CI failures revealed:
+          # - raw.githubusercontent.com: build-plugin-config fetches
+          #   marketplace.json from /Uniswap/ai-toolkit/next/.claude-plugin/.
+          # - claude.ai: Claude SDK install path (claude.ai/install.sh)
+          #   AND runtime telemetry/session lookup on API-key auth too.
+          # Dropped: github.com / *.github.com (in bullfrog defaultDomains),
+          # bun.sh (setup-bun uses github releases via release-assets.*),
+          # *.npmjs.org (registry.npmjs.org is the only subdomain used).
+          # Pinned githubusercontent to release-assets + raw subdomains.
           allowed-domains: |
             release-assets.githubusercontent.com
             raw.githubusercontent.com
             api.anthropic.com
+            claude.ai
             registry.npmjs.org
           enable-sudo: false
 

--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -300,10 +300,6 @@ jobs:
           #   marketplace.json from /Uniswap/ai-toolkit/next/.claude-plugin/.
           # - claude.ai: Claude SDK install path (claude.ai/install.sh)
           #   AND runtime telemetry/session lookup on API-key auth too.
-          # Dropped: github.com / *.github.com (in bullfrog defaultDomains),
-          # bun.sh (setup-bun uses github releases via release-assets.*),
-          # *.npmjs.org (registry.npmjs.org is the only subdomain used).
-          # Pinned githubusercontent to release-assets + raw subdomains.
           allowed-domains: |
             release-assets.githubusercontent.com
             raw.githubusercontent.com

--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -292,16 +292,20 @@ jobs:
         uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
         with:
           egress-policy: block
+          # Per-workflow tightened allowlist. Empirical data from block-mode
+          # logs shows only http-intake.logs.us5.datadoghq.com is currently
+          # blocked (Datadog logs agent — intentionally blocked). No
+          # legitimate destination is being blocked.
+          # Dropped (no empirical use): github.com / *.github.com (in
+          # bullfrog defaultDomains), claude.ai / *.claude.ai (OAuth path
+          # unused here; ANTHROPIC_API_KEY path), bun.sh (setup-bun uses
+          # github releases via *.githubusercontent.com), *.npmjs.org
+          # (registry.npmjs.org is the only subdomain used). Pinned
+          # githubusercontent to release-assets only.
           allowed-domains: |
-            github.com
-            *.github.com
-            *.githubusercontent.com
+            release-assets.githubusercontent.com
             api.anthropic.com
-            claude.ai
-            *.claude.ai
-            bun.sh
             registry.npmjs.org
-            *.npmjs.org
           enable-sudo: false
 
       # Validate toolkit_ref BEFORE any downstream step uses it to download

--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -294,16 +294,21 @@ jobs:
           egress-policy: block
           # Per-workflow tightened allowlist. Empirical data from block-mode
           # logs shows only http-intake.logs.us5.datadoghq.com is currently
-          # blocked (Datadog logs agent — intentionally blocked). No
-          # legitimate destination is being blocked.
+          # blocked (Datadog logs agent — intentionally blocked).
+          # raw.githubusercontent.com was missed by audit-mode sampling
+          # (bullfrog v0.8.4 queues DNS replies; cached resolutions emit
+          # no further events — per agent/queue_audit.nft); required at
+          # runtime by .github/actions/build-plugin-config which fetches
+          # marketplace.json from raw for plugin discovery.
           # Dropped (no empirical use): github.com / *.github.com (in
           # bullfrog defaultDomains), claude.ai / *.claude.ai (OAuth path
           # unused here; ANTHROPIC_API_KEY path), bun.sh (setup-bun uses
           # github releases via *.githubusercontent.com), *.npmjs.org
           # (registry.npmjs.org is the only subdomain used). Pinned
-          # githubusercontent to release-assets only.
+          # githubusercontent to release-assets + raw subdomains.
           allowed-domains: |
             release-assets.githubusercontent.com
+            raw.githubusercontent.com
             api.anthropic.com
             registry.npmjs.org
           enable-sudo: false

--- a/.github/workflows/_claude-docs-check.yml
+++ b/.github/workflows/_claude-docs-check.yml
@@ -223,9 +223,6 @@ jobs:
           #   marketplace.json (Uniswap/ai-toolkit/next/.claude-plugin/).
           # claude.ai: Claude SDK install path (https://claude.ai/install.sh)
           #   AND runtime telemetry/session lookup even on API-key auth.
-          # Dropped: github.com / *.github.com (in bullfrog defaultDomains),
-          # bun.sh (setup-bun via github releases), *.npmjs.org (only
-          # registry.npmjs.org used).
           allowed-domains: |
             release-assets.githubusercontent.com
             raw.githubusercontent.com

--- a/.github/workflows/_claude-docs-check.yml
+++ b/.github/workflows/_claude-docs-check.yml
@@ -214,17 +214,19 @@ jobs:
         uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
         with:
           egress-policy: block
-          # Per-workflow tightened allowlist. Empirical data: 12 successful
-          # block-mode runs show only http-intake.logs.us5.datadoghq.com is
-          # being blocked (Datadog logs agent — intentional). No legitimate
-          # destination is being blocked.
+          # Per-workflow tightened allowlist. Audit-mode sampling missed
+          # raw.githubusercontent.com because bullfrog v0.8.4 queues DNS
+          # *replies* (agent/queue_audit.nft) and cached resolutions emit
+          # no further events — observed in block-mode CI failure on this
+          # PR when build-plugin-config/action.yml fetches marketplace.json.
           # Dropped (no empirical use): github.com / *.github.com (in
           # bullfrog defaultDomains), claude.ai / *.claude.ai (OAuth path
           # unused; uses ANTHROPIC_API_KEY), bun.sh (setup-bun via
           # github releases), *.npmjs.org (only registry.npmjs.org used).
-          # Pinned githubusercontent to release-assets only.
+          # Pinned githubusercontent to release-assets + raw subdomains.
           allowed-domains: |
             release-assets.githubusercontent.com
+            raw.githubusercontent.com
             api.anthropic.com
             registry.npmjs.org
           enable-sudo: false

--- a/.github/workflows/_claude-docs-check.yml
+++ b/.github/workflows/_claude-docs-check.yml
@@ -231,6 +231,7 @@ jobs:
             raw.githubusercontent.com
             api.anthropic.com
             claude.ai
+            downloads.claude.ai
             registry.npmjs.org
           enable-sudo: false
 

--- a/.github/workflows/_claude-docs-check.yml
+++ b/.github/workflows/_claude-docs-check.yml
@@ -215,19 +215,22 @@ jobs:
         with:
           egress-policy: block
           # Per-workflow tightened allowlist. Audit-mode sampling missed
-          # raw.githubusercontent.com because bullfrog v0.8.4 queues DNS
-          # *replies* (agent/queue_audit.nft) and cached resolutions emit
-          # no further events — observed in block-mode CI failure on this
-          # PR when build-plugin-config/action.yml fetches marketplace.json.
-          # Dropped (no empirical use): github.com / *.github.com (in
-          # bullfrog defaultDomains), claude.ai / *.claude.ai (OAuth path
-          # unused; uses ANTHROPIC_API_KEY), bun.sh (setup-bun via
-          # github releases), *.npmjs.org (only registry.npmjs.org used).
-          # Pinned githubusercontent to release-assets + raw subdomains.
+          # several destinations (raw.githubusercontent.com, claude.ai)
+          # because bullfrog v0.8.4 queues DNS *replies*
+          # (agent/queue_audit.nft) and cached resolutions emit no further
+          # events. Add domains here as block-mode CI failures reveal them.
+          # raw.githubusercontent.com: build-plugin-config fetches
+          #   marketplace.json (Uniswap/ai-toolkit/next/.claude-plugin/).
+          # claude.ai: Claude SDK install path (https://claude.ai/install.sh)
+          #   AND runtime telemetry/session lookup even on API-key auth.
+          # Dropped: github.com / *.github.com (in bullfrog defaultDomains),
+          # bun.sh (setup-bun via github releases), *.npmjs.org (only
+          # registry.npmjs.org used).
           allowed-domains: |
             release-assets.githubusercontent.com
             raw.githubusercontent.com
             api.anthropic.com
+            claude.ai
             registry.npmjs.org
           enable-sudo: false
 

--- a/.github/workflows/_claude-docs-check.yml
+++ b/.github/workflows/_claude-docs-check.yml
@@ -214,16 +214,19 @@ jobs:
         uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
         with:
           egress-policy: block
+          # Per-workflow tightened allowlist. Empirical data: 12 successful
+          # block-mode runs show only http-intake.logs.us5.datadoghq.com is
+          # being blocked (Datadog logs agent — intentional). No legitimate
+          # destination is being blocked.
+          # Dropped (no empirical use): github.com / *.github.com (in
+          # bullfrog defaultDomains), claude.ai / *.claude.ai (OAuth path
+          # unused; uses ANTHROPIC_API_KEY), bun.sh (setup-bun via
+          # github releases), *.npmjs.org (only registry.npmjs.org used).
+          # Pinned githubusercontent to release-assets only.
           allowed-domains: |
-            github.com
-            *.github.com
-            *.githubusercontent.com
+            release-assets.githubusercontent.com
             api.anthropic.com
-            claude.ai
-            *.claude.ai
-            bun.sh
             registry.npmjs.org
-            *.npmjs.org
           enable-sudo: false
 
       # Validate toolkit_ref BEFORE any downstream step uses it to download

--- a/.github/workflows/_generate-pr-metadata.yml
+++ b/.github/workflows/_generate-pr-metadata.yml
@@ -179,17 +179,16 @@ jobs:
       # consume toolkit_ref, and the validation runs before any step that
       # downloads action.yml or post-*.ts content using it.
       #
-      # Empirical data: 15 audit-mode runs of this workflow show first-
-      # resolution destinations are only registry.npmjs.org (341 lines —
-      # bun install --production) and release-assets.githubusercontent.com
-      # (5 lines — setup-bun). Plus api.anthropic.com is required at
-      # runtime (invisible in audit logs due to DNS-reply coalescing,
-      # per agent/queue_audit.nft). raw.githubusercontent.com was also
-      # invisible in audit (cached resolution) but required at runtime by
-      # .github/actions/build-plugin-config (fetches marketplace.json).
-      # No Linear MCP, no OAuth — drops api.linear.app, claude.ai,
-      # *.claude.ai vs the sister workflows.
+      # Audit-mode sampling identified registry.npmjs.org (bun install)
+      # and release-assets.githubusercontent.com (setup-bun) as the only
+      # first-resolution destinations, BUT bullfrog v0.8.4 audit only
+      # queues DNS *replies* (agent/queue_audit.nft); cached resolutions
+      # emit no further events. Block-mode CI then revealed three more:
+      # api.anthropic.com (runtime API), raw.githubusercontent.com
+      # (build-plugin-config fetches marketplace.json), and claude.ai
+      # (Claude SDK install + runtime telemetry, even on API-key auth).
       # github.com / api.github.com are in bullfrog defaultDomains.
+      # Add destinations here as future block-mode CI failures reveal them.
       - name: Security Scan
         uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
         with:
@@ -198,6 +197,7 @@ jobs:
             release-assets.githubusercontent.com
             raw.githubusercontent.com
             api.anthropic.com
+            claude.ai
             registry.npmjs.org
           enable-sudo: false
 

--- a/.github/workflows/_generate-pr-metadata.yml
+++ b/.github/workflows/_generate-pr-metadata.yml
@@ -198,6 +198,7 @@ jobs:
             raw.githubusercontent.com
             api.anthropic.com
             claude.ai
+            downloads.claude.ai
             registry.npmjs.org
           enable-sudo: false
 

--- a/.github/workflows/_generate-pr-metadata.yml
+++ b/.github/workflows/_generate-pr-metadata.yml
@@ -184,8 +184,11 @@ jobs:
       # bun install --production) and release-assets.githubusercontent.com
       # (5 lines — setup-bun). Plus api.anthropic.com is required at
       # runtime (invisible in audit logs due to DNS-reply coalescing,
-      # per agent/queue_audit.nft). No Linear MCP, no OAuth — drops
-      # api.linear.app, claude.ai, *.claude.ai vs the sister workflows.
+      # per agent/queue_audit.nft). raw.githubusercontent.com was also
+      # invisible in audit (cached resolution) but required at runtime by
+      # .github/actions/build-plugin-config (fetches marketplace.json).
+      # No Linear MCP, no OAuth — drops api.linear.app, claude.ai,
+      # *.claude.ai vs the sister workflows.
       # github.com / api.github.com are in bullfrog defaultDomains.
       - name: Security Scan
         uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
@@ -193,6 +196,7 @@ jobs:
           egress-policy: block
           allowed-domains: |
             release-assets.githubusercontent.com
+            raw.githubusercontent.com
             api.anthropic.com
             registry.npmjs.org
           enable-sudo: false

--- a/.github/workflows/_generate-pr-metadata.yml
+++ b/.github/workflows/_generate-pr-metadata.yml
@@ -172,16 +172,30 @@ jobs:
       pull-requests: write # Required to update PR title and description
 
     steps:
-      # Security scanning (required for all workflows).
+      # Security scanning — flipped from audit to block.
       # Per .github/workflows/CLAUDE.md, bullfrog must be the FIRST step in
       # every job on a non-macOS runner ("no exceptions"), so it runs before
       # the toolkit_ref validation below. Ordering is safe: bullfrog does not
       # consume toolkit_ref, and the validation runs before any step that
       # downloads action.yml or post-*.ts content using it.
+      #
+      # Empirical data: 15 audit-mode runs of this workflow show first-
+      # resolution destinations are only registry.npmjs.org (341 lines —
+      # bun install --production) and release-assets.githubusercontent.com
+      # (5 lines — setup-bun). Plus api.anthropic.com is required at
+      # runtime (invisible in audit logs due to DNS-reply coalescing,
+      # per agent/queue_audit.nft). No Linear MCP, no OAuth — drops
+      # api.linear.app, claude.ai, *.claude.ai vs the sister workflows.
+      # github.com / api.github.com are in bullfrog defaultDomains.
       - name: Security Scan
         uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-domains: |
+            release-assets.githubusercontent.com
+            api.anthropic.com
+            registry.npmjs.org
+          enable-sudo: false
 
       # Validate toolkit_ref BEFORE any downstream step uses it to download
       # action.yml / post-*.ts script content from the ai-toolkit repo.


### PR DESCRIPTION
## Summary

Three workflows tightened based on bullfrog log analysis across all available successful runs over the last 30 days. Each workflow now has an allowlist that matches its actual observed egress instead of inheriting the shared 9-entry kitchen-sink list.

## Method

1. Pulled all available successful run logs per workflow:
   - `_claude-code-review.yml`: 2 logs (block mode)
   - `_claude-docs-check.yml`: 12 logs (block mode)
   - `_generate-pr-metadata.yml`: 15 logs (audit mode)
2. Extracted bullfrog `Unauthorized request to ...` (audit) and `Blocked DNS request to ...` (block) lines from each.
3. Aggregated distinct destinations per workflow.
4. Cross-referenced with each workflow's runtime code for hosts invisible to audit (DNS-reply coalescing per `agent/queue_audit.nft`).
5. Verified bullfrog wildcard semantics via source (`agent/agent.go:181-192` uses Go `path.Match`, which matches multi-level — so `*.foo.com` covers any subdomain depth, making explicit subdomain entries alongside the wildcard redundant; we pin to exact subdomains empirically observed).

## Empirical findings per workflow

### `_claude-code-review.yml` (block mode)
2 runs, only blocked destination was `http-intake.logs.us5.datadoghq.com` (Datadog logs agent, intentionally blocked). All listed allowlist entries were either unused or used at first-resolution only.

### `_claude-docs-check.yml` (block mode)
12 runs, same finding — only Datadog blocked, no false negatives.

### `_generate-pr-metadata.yml` (audit mode → block)
15 runs of audit data showed exactly two destinations:
- `registry.npmjs.org` (341 lines, `bun install --production`)
- `release-assets.githubusercontent.com` (5 lines, `setup-bun` resolving the bun binary URL)

No Linear MCP, no OAuth path.

## Changes

| File | Before (9 entries) | After (3 entries each) |
|---|---|---|
| `_claude-code-review.yml` | github.com, *.github.com, *.githubusercontent.com, api.anthropic.com, claude.ai, *.claude.ai, bun.sh, registry.npmjs.org, *.npmjs.org | release-assets.githubusercontent.com, api.anthropic.com, registry.npmjs.org |
| `_claude-docs-check.yml` | (same as above) | release-assets.githubusercontent.com, api.anthropic.com, registry.npmjs.org |
| `_generate-pr-metadata.yml` | (audit mode, no allowlist) | release-assets.githubusercontent.com, api.anthropic.com, registry.npmjs.org (flipped to **block** mode) |

## Cross-cutting drops vs the previous shared allowlist

- **`github.com` / `*.github.com`** — in bullfrog's `defaultDomains` (`agent/agent.go:18`); 0 audit lines across all 17 audit-mode runs sampled.
- **`claude.ai` / `*.claude.ai`** — only used by `CLAUDE_CODE_OAUTH_TOKEN` OAuth path; all three workflows use `ANTHROPIC_API_KEY` path; 0 audit lines.
- **`bun.sh`** — `setup-bun` fetches from github releases via `*.githubusercontent.com`; verified by 15 `_generate-pr-metadata` setup-bun runs showing 0 `bun.sh` audit lines.
- **`*.githubusercontent.com`** — only `release-assets.githubusercontent.com` is empirically used; pinned to the specific subdomain.
- **`*.npmjs.org`** — only `registry.npmjs.org` is used; pinned to the specific subdomain.

## Not touched (insufficient data)

- **`_claude-main.yml`** — 0 runs in 30d. Can't validate empirically. Leaving the existing allowlist as-is until runs exist.
- **`_update-action-versions-worker.yml`** — 0 runs in 30d (weekly cron fired outside the window).

## Test plan

If a legitimate destination is missing from any tightened allowlist, the next run of that workflow will surface it via `bullfrog -> Blocked DNS request to <host>` in the job log. Monitor:
- `Uniswap/ai-toolkit/actions/workflows/claude-code-review.yml` (~5/day)
- `Uniswap/ai-toolkit/actions/workflows/claude-docs-check.yml` (~1/day)
- `Uniswap/ai-toolkit/actions/workflows/generate-pr-title-description.yml` (~3/day)

If a block appears for a host that should be allowed, add it to that workflow's allowlist and surface the missed-case in this PR's review thread.

## Related PRs (per-workflow tightening across the org)

- [Uniswap/default-token-list#2485](https://github.com/Uniswap/default-token-list/pull/2485) — dtl Task Worker (uses `registry.yarnpkg.com` instead of npmjs)
- [Uniswap/ai-toolkit#514](https://github.com/Uniswap/ai-toolkit/pull/514) — aitk Task Worker (adds `api.linear.app` for Linear MCP)

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Three reusable workflows tightened to per-workflow allowlists matching their actual observed egress, instead of inheriting the shared 9-entry kitchen-sink list. `_generate-pr-metadata.yml` is also flipped from `audit` to `block` mode.
The first commit derived the allowlists from 30 days of audit-mode logs. Block-mode CI on this PR then surfaced three additional destinations that audit had not captured — added in subsequent commits.
## Why audit sampling missed destinations
bullfrog v0.8.4's audit mode queues DNS *replies* via `agent/queue_audit.nft` — once a name has been resolved and cached, subsequent uses emit no further events. The 30-day audit corpus therefore under-reported real first-resolution destinations. Block-mode CI fills the gap by failing loudly on the first unallowed lookup.
## Method
1. Pulled all available successful run logs per workflow over the last 30 days:
   - `_claude-code-review.yml`: 2 logs (block mode)
   - `_claude-docs-check.yml`: 12 logs (block mode)
   - `_generate-pr-metadata.yml`: 15 logs (audit mode)
2. Extracted bullfrog `Unauthorized request to ...` (audit) and `Blocked DNS request to ...` (block) lines.
3. Cross-referenced with each workflow's runtime code for hosts invisible to audit (DNS-reply queuing in `agent/queue_audit.nft`).
4. Verified bullfrog wildcard semantics via source (`agent/agent.go:181-192` uses Go `path.Match`, which matches multi-level — so `*.foo.com` covers any subdomain depth, making explicit subdomain entries alongside the wildcard redundant; we pin to exact subdomains empirically observed).
5. Iterated on block-mode CI failures to surface destinations the audit corpus missed.
## Final per-workflow allowlists
All three workflows converge on the same 6 destinations:
```
release-assets.githubusercontent.com
raw.githubusercontent.com
api.anthropic.com
claude.ai
downloads.claude.ai
registry.npmjs.org
```
`_generate-pr-metadata.yml` additionally flips `egress-policy: audit` → `block`.
## Destinations added by commit
| Commit | Domain(s) added | Reason |
|---|---|---|
| `9276275` (tighten from empirical egress) | initial baseline — see below | 30-day audit-log aggregation |
| `6ad5cfc` | `raw.githubusercontent.com` | `build-plugin-config` fetches `marketplace.json` from `/Uniswap/ai-toolkit/next/.claude-plugin/` |
| `ee4b31d` | `claude.ai` | Claude SDK install + runtime telemetry/session lookup (fires even on `ANTHROPIC_API_KEY` auth, not just OAuth) |
| `c29488e` | `downloads.claude.ai` | Claude CLI binary install — separate host from `claude.ai` |
## Cross-cutting drops vs the previous shared 9-entry allowlist
- **`github.com` / `*.github.com`** — in bullfrog's `defaultDomains` (`agent/agent.go:18`); 0 audit lines across all 17 audit-mode runs sampled.
- **`bun.sh`** — `setup-bun` fetches from github releases via `release-assets.githubusercontent.com`; verified by 15 `_generate-pr-metadata` setup-bun runs showing 0 `bun.sh` audit lines.
- **`*.githubusercontent.com`** — pinned to the two specific subdomains actually used (`release-assets`, `raw`).
- **`*.npmjs.org`** — only `registry.npmjs.org` is used; pinned to the specific subdomain.
- **`*.claude.ai`** — replaced with the two exact subdomains observed (`claude.ai`, `downloads.claude.ai`).
## Test plan
- [x] Audit-log aggregation per workflow (see Method)
- [x] Iterative block-mode CI runs surfaced the three additional destinations
- [x] Inline comments in each touched file document why each domain is present and why audit sampling can miss new ones — so future maintainers extend the list rather than reverting to a wildcard
- [ ] Next runs of each workflow stay green on the tightened allowlist:
  - `Uniswap/ai-toolkit/actions/workflows/claude-code-review.yml` (~5/day)
  - `Uniswap/ai-toolkit/actions/workflows/claude-docs-check.yml` (~1/day)
  - `Uniswap/ai-toolkit/actions/workflows/generate-pr-title-description.yml` (~3/day)
If a block appears for a host that should be allowed, add it to that workflow's allowlist and note the missed-case in this PR's review thread.
## Not touched (insufficient data)
- **`_claude-main.yml`** — 0 runs in 30d. Can't validate empirically; existing allowlist left as-is until runs exist.
- **`_update-action-versions-worker.yml`** — 0 runs in 30d (weekly cron fired outside the window).
## Related PRs (per-workflow tightening across the org)
- [Uniswap/default-token-list#2485](https://github.com/Uniswap/default-token-list/pull/2485) — dtl Task Worker (uses `registry.yarnpkg.com` instead of npmjs)
- [Uniswap/ai-toolkit#514](https://github.com/Uniswap/ai-toolkit/pull/514) — aitk Task Worker (adds `api.linear.app` for Linear MCP)

</details>
<!-- claude-pr-description-end -->