### PR TITLE
fix(slack-oauth-backend): drop incoming-webhook bot scope

### DIFF
--- a/apps/slack-oauth-backend/src/oauth/handler.ts
+++ b/apps/slack-oauth-backend/src/oauth/handler.ts
@@ -241,7 +241,6 @@ export function createOAuthHandler(
       'im:history',
       'im:read',
       'im:write',
-      'incoming-webhook',
       'mpim:history',
       'mpim:read',
       'reactions:read',


### PR DESCRIPTION
## Summary

Follow-up to #517 addressing [review comment on line 244](https://github.com/Uniswap/ai-toolkit/pull/517#discussion_r3277824672).

`incoming-webhook` was added to mirror the Slack app manifest, but the OAuth callback handler discards `tokenResponse.incoming_webhook` — only `team`, `enterprise`, `scopes`, and `bot_user_id` flow through `OAuthResult.details`. The app doesn't consume the webhook URL, so requesting the scope adds a channel-picker step to install for no functional benefit.

## Follow-up

Update the Slack app manifest to remove `incoming-webhook` from `oauth_config.scopes.bot` so the two stay in sync per the source-of-truth comment.

## Note on the other review comment

[Comment on line 282](https://github.com/Uniswap/ai-toolkit/pull/517#discussion_r3277824676) flagged the broad `search:read` as redundant with the granular `search:read.*` family. The manifest includes both intentionally, so the code is kept aligned; no change here.

## Test plan

- [ ] Vercel preview deploys cleanly
- [ ] Hit the OAuth start endpoint on the preview, copy the redirect URL, decode the `scope=` (bot) param, confirm `incoming-webhook` is gone and the other 14 bot scopes remain
- [ ] Confirm install flow no longer prompts for a channel

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Follow-up to #517 addressing [review comment on line 244](https://github.com/Uniswap/ai-toolkit/pull/517#discussion_r3277824672).
`incoming-webhook` was added to mirror the Slack app manifest, but the OAuth callback handler discards `tokenResponse.incoming_webhook` — only `team`, `enterprise`, `scopes`, and `bot_user_id` flow through `OAuthResult.details`. The app doesn't consume the webhook URL, so requesting the scope adds a channel-picker step to install for no functional benefit.
## Changes
| File | Change |
|------|--------|
| `apps/slack-oauth-backend/src/oauth/handler.ts` | Remove `incoming-webhook` from `botScopes` array (line 244) |
Total diff: -1 line across 1 file. Bot scopes go from 15 → 14; user scopes unchanged.
## Follow-up
Update the Slack app manifest to remove `incoming-webhook` from `oauth_config.scopes.bot` so the two stay in sync per the source-of-truth comment.
## Note on the other review comment
[Comment on line 282](https://github.com/Uniswap/ai-toolkit/pull/517#discussion_r3277824676) flagged the broad `search:read` as redundant with the granular `search:read.*` family. The manifest includes both intentionally, so the code is kept aligned; no change here.
## Test plan
- [ ] Vercel preview deploys cleanly
- [ ] Hit the OAuth start endpoint on the preview, copy the redirect URL, decode the `scope=` (bot) param, confirm `incoming-webhook` is gone and the other 14 bot scopes remain
- [ ] Confirm install flow no longer prompts for a channel

</details>
<!-- claude-pr-description-end -->