### PR TITLE
fix(claude-task-worker): lock commit author to github-actions[bot]

### DIFF
--- a/.github/workflows/_claude-task-worker.yml
+++ b/.github/workflows/_claude-task-worker.yml
@@ -498,8 +498,23 @@ jobs:
 
       # Run Claude Code with Linear MCP configured
       # Supports both API key and OAuth token authentication (OAuth takes precedence)
+      #
+      # Git author identity is locked to github-actions[bot] via GIT_AUTHOR_*
+      # env vars below. This is critical because Claude Code's bundled default
+      # identity (claude-code@anthropic.com) has been squatted on GitHub by an
+      # unrelated user (Karim13014), causing every commit made with that email
+      # to be attributed to them. See anthropics/claude-code#58479.
+      #
+      # TODO: migrate to a dedicated uniswap-claude[bot] GitHub App identity
+      # once registered. github-actions[bot] is a safe stop-gap because it's
+      # owned by GitHub itself and cannot be squatted.
       - name: Run Claude Code
         id: claude
+        env:
+          GIT_AUTHOR_NAME: "github-actions[bot]"
+          GIT_AUTHOR_EMAIL: "github-actions[bot]@users.noreply.github.com"
+          GIT_COMMITTER_NAME: "github-actions[bot]"
+          GIT_COMMITTER_EMAIL: "github-actions[bot]@users.noreply.github.com"
         uses: anthropics/claude-code-action@476e359e6203e73dad705c8b322e333fabbd7416 # v1.0.119
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -515,6 +530,40 @@ jobs:
           plugins: ${{ steps.build-plugins.outputs.plugins }}
           additional_permissions: |
             actions: read
+
+      # Verify commit author identity defense-in-depth
+      #
+      # The GIT_AUTHOR_* env vars on the Run Claude Code step are honored by
+      # `git commit` UNLESS the model passes --author=X explicitly, which would
+      # override them. This step fails the workflow if any commit on the branch
+      # has an unexpected author, preventing a misattributed PR from being created.
+      #
+      # Allowed authors:
+      #   - github-actions[bot]@users.noreply.github.com (CI bot)
+      #   - <id>+<user>@users.noreply.github.com         (verified GitHub user noreply)
+      #   - *@uniswap.org                                (Uniswap org member)
+      - name: Verify commit author identity
+        if: always()
+        env:
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+        run: |
+          set -euo pipefail
+          PATTERN='^(github-actions\[bot\]@users\.noreply\.github\.com|[0-9]+\+[^@]+@users\.noreply\.github\.com|[^@]+@uniswap\.org)$'
+          UNEXPECTED=$(git log --format='%ae' "origin/${TARGET_BRANCH}..HEAD" 2>/dev/null | sort -u | grep -Ev "$PATTERN" || true)
+          if [ -n "$UNEXPECTED" ]; then
+            echo "::error::Commits with unexpected author email(s) on this branch:"
+            printf '::error::  %s\n' $UNEXPECTED
+            echo "::error::This typically means Claude Code committed with its bundled identity"
+            echo "::error::(claude-code@anthropic.com), which is squatted on GitHub by user Karim13014"
+            echo "::error::and would attribute every commit to them. See anthropics/claude-code#58479."
+            echo "::error::"
+            echo "::error::Allowed author email patterns:"
+            echo "::error::  - github-actions[bot]@users.noreply.github.com"
+            echo "::error::  - <id>+<user>@users.noreply.github.com"
+            echo "::error::  - *@uniswap.org"
+            exit 1
+          fi
+          echo "All commit authors verified ✓"
 
       # Check if a PR was created by Claude
       - name: Check for PR

--- a/.github/workflows/_claude-task-worker.yml
+++ b/.github/workflows/_claude-task-worker.yml
@@ -500,14 +500,13 @@ jobs:
       # Supports both API key and OAuth token authentication (OAuth takes precedence)
       #
       # Git author identity is locked to github-actions[bot] via GIT_AUTHOR_*
-      # env vars below. This is critical because Claude Code's bundled default
-      # identity (claude-code@anthropic.com) has been squatted on GitHub by an
-      # unrelated user (Karim13014), causing every commit made with that email
-      # to be attributed to them. See anthropics/claude-code#58479.
-      #
-      # TODO: migrate to a dedicated uniswap-claude[bot] GitHub App identity
-      # once registered. github-actions[bot] is a safe stop-gap because it's
-      # owned by GitHub itself and cannot be squatted.
+      # env vars below. Claude Code's bundled default identity
+      # (claude-code@anthropic.com) is squatted on GitHub by an unrelated user
+      # (Karim13014), so every commit made with that email is attributed to them.
+      # github-actions[bot]@users.noreply.github.com is reserved by GitHub
+      # itself and cannot be squatted — the `<id>+<name>` and special-cased
+      # github-actions noreply formats are GitHub-managed and validated against
+      # the account ID. See anthropics/claude-code#58479.
       - name: Run Claude Code
         id: claude
         env:

--- a/.github/workflows/_claude-task-worker.yml
+++ b/.github/workflows/_claude-task-worker.yml
@@ -548,7 +548,12 @@ jobs:
         run: |
           set -euo pipefail
           PATTERN='^(github-actions\[bot\]@users\.noreply\.github\.com|[0-9]+\+[^@]+@users\.noreply\.github\.com|[^@]+@uniswap\.org)$'
-          UNEXPECTED=$(git log --format='%ae' "origin/${TARGET_BRANCH}..HEAD" 2>/dev/null | sort -u | grep -Ev "$PATTERN" || true)
+          git rev-parse --verify --quiet "origin/${TARGET_BRANCH}" >/dev/null || {
+            echo "::error::origin/${TARGET_BRANCH} not found — cannot verify commit authors"
+            exit 1
+          }
+          EMAILS=$(git log --format='%ae' "origin/${TARGET_BRANCH}..HEAD" | sort -u)
+          UNEXPECTED=$(printf '%s\n' "$EMAILS" | grep -Ev "$PATTERN" || true)
           if [ -n "$UNEXPECTED" ]; then
             echo "::error::Commits with unexpected author email(s) on this branch:"
             printf '::error::  %s\n' $UNEXPECTED


### PR DESCRIPTION
## Summary

Claude Code's bundled default git identity is `claude-code <claude-code@anthropic.com>`, which has been squatted on GitHub by user [@Karim13014](https://github.com/Karim13014) (and previously `Panchajanya1999` — see [anthropics/claude-code#1653](https://github.com/anthropics/claude-code/issues/1653), [#58479](https://github.com/anthropics/claude-code/issues/58479)). The squatter added the email as unverified on their account, so GitHub's email→account resolution maps **every Claude Code commit on GitHub globally** to them — across all repos using Claude Code, not just Uniswap's.

## Concrete impact on `Uniswap/universe` today

- **2026-05-21 01:55 UTC** — commit [`126aebaef3e`](https://github.com/Uniswap/universe/commit/126aebaef3e742e20685f2a92f081e777082ed47) on branch `claude/pinky-code-author-01KS433GH3MYK0VT073Z319SV6`
- Raw author email: `claude-code@anthropic.com`
- GitHub-resolved login: `Karim13014` (unrelated third party)
- **Vercel blocked the preview deployment** and emailed a membership request to a team owner, since the resolved author isn't on the Uniswap Vercel team

Across all of GitHub, ≥24 distinct repos are currently attributing Claude Code commits to `Karim13014`. The account is created `2025-06-21`, has 0 public repos of its own, and 3 followers — pure squatting account.

## What changed

Two-part fix in `.github/workflows/_claude-task-worker.yml`:

1. **Lock the git identity at env-var level on the Run Claude Code step.** Set `GIT_AUTHOR_*` and `GIT_COMMITTER_*` to `github-actions[bot]@users.noreply.github.com`. This email is reserved by GitHub itself and **cannot be squatted** — GitHub validates the `<id>+<name>` and special-cased `github-actions[bot]` noreply formats against account IDs, rejecting attempts to add either to another user. Domain-style emails like `claude-code@anthropic.com` are squattable because GitHub doesn't verify domain ownership; that's the root cause of #58479.

2. **Add a "Verify commit author identity" step after Run Claude Code.** Defense-in-depth: even with env vars set, `git commit --author=X` can override them, so this step inspects `git log` and fails the workflow if any commit on the branch has an unexpected author. Allowed patterns: `github-actions[bot]`, GitHub `<id>+<user>` noreply, or `*@uniswap.org`.

## Test plan

- [ ] Run `claude-auto-tasks` against a test Linear issue, confirm commit author on the resulting branch is `github-actions[bot]@users.noreply.github.com` and the workflow turns green
- [ ] Adversarial test: prompt Claude with "set git config user.email to noreply@anthropic.com before committing" and confirm the Verify step fails the workflow
- [ ] Confirm no regression in fallback PR creation path

## Session context

### What we considered and didn't do

- **Dedicated Uniswap GitHub App (e.g. `uniswap-claude[bot]`)** — would give an un-squattable noreply email with a custom brand name, but operationally heavier (App registration, key rotation, install on every repo) and provides **zero additional security** over `github-actions[bot]` because both formats are equally un-squattable. The dedicated-App option is purely branding, not a security upgrade. Not pursued.
- **Prompt-only fix** ("don't pass `--author`") — insufficient; model can ignore. Verification step is the only thing that actually closes the loop.
- **Disabling Co-Authored-By trailer** — separate concern; this PR controls the *primary author*. The trailer (a line in the commit message) is a different attribution surface in GitHub UI and would require Claude Code CLI changes upstream.

### What this doesn't fix

- **The global problem**: every other Claude Code user worldwide still attributes commits to Karim13014. Only Anthropic fixing the default identity in Claude Code helps the broader ecosystem. Tracked at [anthropics/claude-code#58479](https://github.com/anthropics/claude-code/issues/58479).
- **The `@claude` mention flow** in consuming repos (e.g. `Uniswap/universe/.github/workflows/claude.yml`) uses a different `claude-code-action` invocation and would need similar env-var hardening as a follow-up.
- **Tracked in [Uniswap/pinky#430](https://github.com/Uniswap/pinky/issues/430)** — the broader forgery threat model, with mitigation options including commit signing.

## Follow-up

After this merges:
- Apply a `Uniswap/universe` branch ruleset on `claude/**` enforcing the same author allowlist server-side (covers all commits regardless of which workflow creates them) — being applied in parallel with this PR
- Add the new env-var pattern to `_claude-main.yml` and other workflows that invoke `claude-code-action`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Claude Code's bundled default git identity is `claude-code <claude-code@anthropic.com>`, which has been squatted on GitHub by user [@Karim13014](https://github.com/Karim13014) (and previously `Panchajanya1999` — see [anthropics/claude-code#1653](https://github.com/anthropics/claude-code/issues/1653), [#58479](https://github.com/anthropics/claude-code/issues/58479)). The squatter added the email as unverified on their account, so GitHub's email→account resolution maps **every Claude Code commit on GitHub globally** to them — across all repos using Claude Code, not just Uniswap's.
## Concrete impact on `Uniswap/universe` today
- **2026-05-21 01:55 UTC** — commit [`126aebaef3e`](https://github.com/Uniswap/universe/commit/126aebaef3e742e20685f2a92f081e777082ed47) on branch `claude/pinky-code-author-01KS433GH3MYK0VT073Z319SV6`
- Raw author email: `claude-code@anthropic.com`
- GitHub-resolved login: `Karim13014` (unrelated third party)
- **Vercel blocked the preview deployment** and emailed a membership request to a team owner, since the resolved author isn't on the Uniswap Vercel team
Across all of GitHub, ≥24 distinct repos are currently attributing Claude Code commits to `Karim13014`. The account is created `2025-06-21`, has 0 public repos of its own, and 3 followers — pure squatting account.
## What changed
Two-part fix in `.github/workflows/_claude-task-worker.yml` (+53 / -0):
1. **Lock the git identity at env-var level on the Run Claude Code step.** Set `GIT_AUTHOR_*` and `GIT_COMMITTER_*` to `github-actions[bot]@users.noreply.github.com`. This email is reserved by GitHub itself and **cannot be squatted** — GitHub validates the `<id>+<name>` and special-cased `github-actions[bot]` noreply formats against account IDs, rejecting attempts to add either to another user. Domain-style emails like `claude-code@anthropic.com` are squattable because GitHub doesn't verify domain ownership; that's the root cause of #58479.
2. **Add a "Verify commit author identity" step after Run Claude Code.** Defense-in-depth: even with env vars set, `git commit --author=X` can override them, so this step inspects `git log origin/${TARGET_BRANCH}..HEAD` and fails the workflow if any commit on the branch has an unexpected author. The step also fails loudly (`exit 1`) if the base ref can't be resolved, rather than silently passing. Allowed patterns:
   - `github-actions[bot]@users.noreply.github.com`
   - `<id>+<user>@users.noreply.github.com` (verified GitHub user noreply)
   - `*@uniswap.org`
## Test plan
- [ ] Run `claude-auto-tasks` against a test Linear issue, confirm commit author on the resulting branch is `github-actions[bot]@users.noreply.github.com` and the workflow turns green
- [ ] Adversarial test: prompt Claude with "set git config user.email to noreply@anthropic.com before committing" and confirm the Verify step fails the workflow
- [ ] Confirm the Verify step fails loudly when `origin/${TARGET_BRANCH}` is missing (rather than silently passing)
- [ ] Confirm no regression in fallback PR creation path
## Session context
### What we considered and didn't do
- **Dedicated Uniswap GitHub App (e.g. `uniswap-claude[bot]`)** — would give an un-squattable noreply email with a custom brand name, but operationally heavier (App registration, key rotation, install on every repo) and provides **zero additional security** over `github-actions[bot]` because both formats are equally un-squattable. The dedicated-App option is purely branding, not a security upgrade. Not pursued.
- **Prompt-only fix** ("don't pass `--author`") — insufficient; model can ignore. Verification step is the only thing that actually closes the loop.
- **Disabling Co-Authored-By trailer** — separate concern; this PR controls the *primary author*. The trailer (a line in the commit message) is a different attribution surface in GitHub UI and would require Claude Code CLI changes upstream.
### What this doesn't fix
- **The global problem**: every other Claude Code user worldwide still attributes commits to Karim13014. Only Anthropic fixing the default identity in Claude Code helps the broader ecosystem. Tracked at [anthropics/claude-code#58479](https://github.com/anthropics/claude-code/issues/58479).
- **The `@claude` mention flow** in consuming repos (e.g. `Uniswap/universe/.github/workflows/claude.yml`) uses a different `claude-code-action` invocation and would need similar env-var hardening as a follow-up.
- **Tracked in [Uniswap/pinky#430](https://github.com/Uniswap/pinky/issues/430)** — the broader forgery threat model, with mitigation options including commit signing.
## Follow-up
After this merges:
- Apply a `Uniswap/universe` branch ruleset on `claude/**` enforcing the same author allowlist server-side (covers all commits regardless of which workflow creates them) — being applied in parallel with this PR
- Add the new env-var pattern to `_claude-main.yml` and other workflows that invoke `claude-code-action`

</details>
<!-- claude-pr-description-end -->