### PR TITLE
chore(slack-oauth-backend): log OAuth request and Slack-granted scopes

### DIFF
--- a/apps/slack-oauth-backend/src/oauth/handler.ts
+++ b/apps/slack-oauth-backend/src/oauth/handler.ts
@@ -106,6 +106,22 @@ export class SlackOAuthHandler implements OAuthHandler {
         );
       }
 
+      // Debug: log the scopes Slack actually granted on the issued tokens.
+      // Token values themselves are deliberately omitted; only scope strings and
+      // presence flags are recorded so the log is safe to surface in Vercel.
+      logger.info('Slack OAuth exchange complete', {
+        botScopesGranted: tokenResponse.scope,
+        userScopesGranted: tokenResponse.authed_user?.scope,
+        hasBotToken: !!tokenResponse.access_token,
+        hasUserToken: !!tokenResponse.authed_user?.access_token,
+        hasBotRefreshToken: !!tokenResponse.refresh_token,
+        hasUserRefreshToken: !!tokenResponse.authed_user?.refresh_token,
+        botTokenType: tokenResponse.token_type,
+        userTokenType: tokenResponse.authed_user?.token_type,
+        teamId: tokenResponse.team?.id,
+        enterpriseId: tokenResponse.enterprise?.id,
+      });
+
       // Get user information using the bot token (if available)
       // With token rotation, bot token may not be available
       let userInfo: SlackUserInfo | undefined;

--- a/apps/slack-oauth-backend/src/oauth/handler.ts
+++ b/apps/slack-oauth-backend/src/oauth/handler.ts
@@ -106,9 +106,11 @@ export class SlackOAuthHandler implements OAuthHandler {
         );
       }
 
-      // Debug: log the scopes Slack actually granted on the issued tokens.
-      // Token values themselves are deliberately omitted; only scope strings and
-      // presence flags are recorded so the log is safe to surface in Vercel.
+      // Observability: record the scopes Slack actually granted on the issued
+      // tokens, plus presence flags useful for diagnosing token-type confusion
+      // and refresh-token availability. Token values themselves are deliberately
+      // omitted; only scope strings and booleans are recorded, so this log is
+      // safe to leave on in production.
       logger.info('Slack OAuth exchange complete', {
         botScopesGranted: tokenResponse.scope,
         userScopesGranted: tokenResponse.authed_user?.scope,

--- a/apps/slack-oauth-backend/src/routes/oauth.ts
+++ b/apps/slack-oauth-backend/src/routes/oauth.ts
@@ -155,6 +155,10 @@ router.get(
     const oauthHandler = createOAuthHandler();
     const authUrl = oauthHandler.generateAuthUrl(state);
 
+    // Debug: log the redirect URL so we can confirm which scopes are being
+    // requested in each `scope=` and `user_scope=` query param.
+    logger.info('Slack OAuth authorize redirect', { authUrl });
+
     // In production, store state in session or database
     // For now, just redirect
     res.redirect(authUrl);

--- a/apps/slack-oauth-backend/src/routes/oauth.ts
+++ b/apps/slack-oauth-backend/src/routes/oauth.ts
@@ -155,9 +155,15 @@ router.get(
     const oauthHandler = createOAuthHandler();
     const authUrl = oauthHandler.generateAuthUrl(state);
 
-    // Debug: log the redirect URL so we can confirm which scopes are being
-    // requested in each `scope=` and `user_scope=` query param.
-    logger.info('Slack OAuth authorize redirect', { authUrl });
+    // Observability: record the scopes being requested on this install
+    // attempt. Parse params out of the URL so the `state` CSRF nonce
+    // doesn't end up in logs alongside the scope data.
+    const parsedUrl = new URL(authUrl);
+    logger.info('Slack OAuth authorize redirect', {
+      scope: parsedUrl.searchParams.get('scope'),
+      userScope: parsedUrl.searchParams.get('user_scope'),
+      redirectUri: parsedUrl.searchParams.get('redirect_uri'),
+    });
 
     // In production, store state in session or database
     // For now, just redirect


### PR DESCRIPTION
## Summary

Adds two diagnostic `logger.info` calls so we can debug Slack OAuth scope-grant behavior from Vercel logs instead of trial-and-error reinstalls.

**`handler.ts`** — after `exchangeCodeForToken()` returns, logs what Slack put on the issued tokens:
- `botScopesGranted` (string) — scopes on the bot token
- `userScopesGranted` (string) — scopes on the user token
- `hasBotToken`, `hasUserToken`, `hasBotRefreshToken`, `hasUserRefreshToken` (boolean presence flags)
- `botTokenType`, `userTokenType`
- `teamId`, `enterpriseId`

Token values themselves are deliberately omitted; only scope strings and presence flags are logged so the entries are safe to leave in production Vercel logs.

**`routes/oauth.ts`** — in the `/slack/oauth/authorize` redirect handler, logs the full URL we send the user to, including `scope=` and `user_scope=` query params. This makes the request side observable independently of Slack's response.

## Why now

We've been debugging install failures (`Invalid permissions requested`, silently dropped scopes via the consent screen). Knowing the OAuth request URL and Slack's response side-by-side eliminates speculation between "code didn't request it" and "Slack didn't grant it".

## Test plan

- [ ] Vercel preview deploys cleanly
- [ ] Hit `/slack/oauth/authorize` on the preview URL and observe a `"Slack OAuth authorize redirect"` entry in Vercel logs with the full URL
- [ ] Complete an OAuth flow against the preview and observe a `"Slack OAuth exchange complete"` entry with the granted scope strings
- [ ] Confirm no token values appear in the logs

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Adds two diagnostic `logger.info` calls so we can debug Slack OAuth scope-grant behavior from Vercel logs instead of trial-and-error reinstalls. Both logs deliberately exclude secrets (token values, CSRF state nonce) so they are safe to leave on in production.
## What changed
**`apps/slack-oauth-backend/src/oauth/handler.ts`** — after `exchangeCodeForToken()` returns, logs what Slack put on the issued tokens:
- `botScopesGranted` (`tokenResponse.scope`) — scopes on the bot token
- `userScopesGranted` (`tokenResponse.authed_user?.scope`) — scopes on the user token
- `hasBotToken`, `hasUserToken`, `hasBotRefreshToken`, `hasUserRefreshToken` — boolean presence flags (useful for diagnosing token-type confusion and refresh-token availability)
- `botTokenType`, `userTokenType`
- `teamId`, `enterpriseId`
Token values themselves are deliberately omitted; only scope strings and booleans are recorded.
**`apps/slack-oauth-backend/src/routes/oauth.ts`** — in the `/slack/oauth/authorize` redirect handler, parses the generated `authUrl` and logs only `scope`, `user_scope`, and `redirect_uri`. The full URL is **not** logged so the `state` CSRF nonce stays out of logs while the request side of the OAuth flow remains observable.
## Why now
We've been debugging install failures (`Invalid permissions requested`, silently dropped scopes via the consent screen — follow-up to #517 / #518). Knowing the OAuth request scopes and Slack's response side-by-side eliminates speculation between "code didn't request it" and "Slack didn't grant it".
## Changes
| File | Change |
|------|--------|
| `apps/slack-oauth-backend/src/oauth/handler.ts` | `logger.info('Slack OAuth exchange complete', {...})` after `exchangeCodeForToken()` — granted scope strings + token presence flags, no token values |
| `apps/slack-oauth-backend/src/routes/oauth.ts` | `logger.info('Slack OAuth authorize redirect', { scope, userScope, redirectUri })` in `/slack/oauth/authorize` handler — parsed out of `authUrl` so the `state` nonce isn't logged |
Total diff: +28 / -0 lines across 2 files. No behavioral changes — pure observability.
## Test plan
- [ ] Vercel preview deploys cleanly
- [ ] Hit `/slack/oauth/authorize` on the preview URL and observe a `"Slack OAuth authorize redirect"` entry in Vercel logs with `scope`, `userScope`, and `redirectUri` fields (and **no** `state` value)
- [ ] Complete an OAuth flow against the preview and observe a `"Slack OAuth exchange complete"` entry with the granted scope strings and presence flags
- [ ] Confirm no token values appear in either log entry

</details>
<!-- claude-pr-description-end -->