### PR TITLE
chore(deps): maintain Claude Code Action workflows (v1.0.133)

### DIFF
--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -1169,7 +1169,7 @@ jobs:
       - name: Run Claude Code Review
         if: steps.cache-check.outputs.cache-hit != 'true' && steps.diff-size.outputs.is_too_large != 'true'
         id: claude
-        uses: anthropics/claude-code-action@476e359e6203e73dad705c8b322e333fabbd7416 # v1.0.119
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           # Authentication: provide either API key or OAuth token (validated in earlier step)
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -1662,7 +1662,7 @@ jobs:
       - name: Run Claude Auto-Fix
         id: claude-fix
         if: steps.auto-fix-check.outputs.should_fix == 'true' && steps.pr-branch.outputs.repo_full_name == github.repository
-        uses: anthropics/claude-code-action@476e359e6203e73dad705c8b322e333fabbd7416 # v1.0.119
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/_claude-docs-check.yml
+++ b/.github/workflows/_claude-docs-check.yml
@@ -650,7 +650,7 @@ jobs:
       # Run Claude
       - name: Run Claude Docs Check
         id: claude
-        uses: anthropics/claude-code-action@476e359e6203e73dad705c8b322e333fabbd7416 # v1.0.119
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -972,7 +972,7 @@ jobs:
       - name: Run Claude Auto-Fix
         id: claude-fix
         if: steps.auto-fix-check.outputs.should_fix == 'true' && steps.pr-branch.outputs.repo_full_name == github.repository
-        uses: anthropics/claude-code-action@476e359e6203e73dad705c8b322e333fabbd7416 # v1.0.119
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/_claude-main.yml
+++ b/.github/workflows/_claude-main.yml
@@ -80,7 +80,7 @@ on:
           Available models:
           - claude-sonnet-4-6 (default, recommended) - Latest Sonnet model with best balance of speed and capability
           - claude-opus-4-7 - Most capable model for complex tasks
-          - claude-haiku-4-5 - Fast, cost-effective model for simpler tasks
+          - claude-haiku-4-5-20251001 - Fast, cost-effective model for simpler tasks
 
           Default: claude-sonnet-4-6
         required: false
@@ -426,7 +426,7 @@ jobs:
       # Supports both API key and OAuth token authentication (validated in earlier step)
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@476e359e6203e73dad705c8b322e333fabbd7416 # v1.0.119
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           # Authentication: provide either API key or OAuth token (validated in earlier step)
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/_claude-task-worker.yml
+++ b/.github/workflows/_claude-task-worker.yml
@@ -89,7 +89,7 @@ on:
       model:
         description: |
           Claude model to use.
-          Options: claude-sonnet-4-6, claude-opus-4-7, claude-haiku-4-5
+          Options: claude-sonnet-4-6, claude-opus-4-7, claude-haiku-4-5-20251001
         required: false
         type: string
         default: "claude-opus-4-7"
@@ -514,7 +514,7 @@ jobs:
           GIT_AUTHOR_EMAIL: "github-actions[bot]@users.noreply.github.com"
           GIT_COMMITTER_NAME: "github-actions[bot]"
           GIT_COMMITTER_EMAIL: "github-actions[bot]@users.noreply.github.com"
-        uses: anthropics/claude-code-action@476e359e6203e73dad705c8b322e333fabbd7416 # v1.0.119
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/_generate-pr-metadata.yml
+++ b/.github/workflows/_generate-pr-metadata.yml
@@ -431,7 +431,7 @@ jobs:
           steps.quality-gate-prep.outputs.has_user_content == 'true'
         id: quality-gate-eval
         continue-on-error: true
-        uses: anthropics/claude-code-action@476e359e6203e73dad705c8b322e333fabbd7416 # v1.0.119
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -465,10 +465,7 @@ jobs:
 
             Write ONLY the single word "PASS" or "FAIL" to /tmp/quality-gate-verdict.txt.
             No explanation, no other text — just the verdict word.
-          allowed_tools: |
-            Read
-            Write
-          claude_args: '--model claude-haiku-4-5 --max-turns 3'
+          claude_args: '--model claude-haiku-4-5-20251001 --max-turns 3'
           track_progress: false
 
       - name: Parse Quality Gate Verdict
@@ -884,7 +881,7 @@ jobs:
       - name: Run Claude Code Generation
         if: steps.cache-check.outputs.cache-hit != 'true' && steps.quality-gate.outputs.should_skip != 'true'
         id: claude
-        uses: anthropics/claude-code-action@476e359e6203e73dad705c8b322e333fabbd7416 # v1.0.119
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/_update-action-versions-worker.yml
+++ b/.github/workflows/_update-action-versions-worker.yml
@@ -404,7 +404,7 @@ jobs:
       # Supports both API key and OAuth token authentication (OAuth takes precedence)
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@476e359e6203e73dad705c8b322e333fabbd7416 # v1.0.119
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/dev-ai-newsletter.yml
+++ b/.github/workflows/dev-ai-newsletter.yml
@@ -385,7 +385,7 @@ jobs:
       # Run Claude Code with MCP servers
       - name: Generate newsletter with Claude
         id: claude
-        uses: anthropics/claude-code-action@476e359e6203e73dad705c8b322e333fabbd7416 # v1.0.119
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |


### PR DESCRIPTION
## Summary

Maintenance pass on Claude Code Action workflows. Applies three classes of edit atomically:

- **claude-code-action:** `v1.0.133` (`787c5a0`) — see https://github.com/anthropics/claude-code-action/releases/tag/v1.0.133
- **ai-toolkit reusable workflows:** `824dfc1` (Uniswap/ai-toolkit `next` HEAD)
- **Models:**
  - `haiku` → `claude-haiku-4-5-20251001`
  - `opus` → `claude-opus-4-7`
  - `sonnet` → `claude-sonnet-4-6`

### Per-file changes

#### `.github/workflows/_claude-code-review.yml`
- SHA bump `anthropics/claude-code-action`: `476e359` → `787c5a0` (v1.0.133)
- SHA bump `anthropics/claude-code-action`: `476e359` → `787c5a0` (v1.0.133)

#### `.github/workflows/_claude-docs-check.yml`
- SHA bump `anthropics/claude-code-action`: `476e359` → `787c5a0` (v1.0.133)
- SHA bump `anthropics/claude-code-action`: `476e359` → `787c5a0` (v1.0.133)

#### `.github/workflows/_claude-main.yml`
- SHA bump `anthropics/claude-code-action`: `476e359` → `787c5a0` (v1.0.133)
- Model bump: `claude-haiku-4-5` → `claude-haiku-4-5-20251001`

#### `.github/workflows/_claude-task-worker.yml`
- SHA bump `anthropics/claude-code-action`: `476e359` → `787c5a0` (v1.0.133)
- Model bump: `claude-haiku-4-5` → `claude-haiku-4-5-20251001`

#### `.github/workflows/_generate-pr-metadata.yml`
- SHA bump `anthropics/claude-code-action`: `476e359` → `787c5a0` (v1.0.133)
- SHA bump `anthropics/claude-code-action`: `476e359` → `787c5a0` (v1.0.133)
- **Breaking-change auto-fix:** removed deprecated input `allowed_tools` (no longer in anthropics/claude-code-action at the new SHA)
- Model bump: `claude-haiku-4-5` → `claude-haiku-4-5-20251001`

#### `.github/workflows/_update-action-versions-worker.yml`
- SHA bump `anthropics/claude-code-action`: `476e359` → `787c5a0` (v1.0.133)

#### `.github/workflows/dev-ai-newsletter.yml`
- SHA bump `anthropics/claude-code-action`: `476e359` → `787c5a0` (v1.0.133)



_Opened by the `sync-claude-code-action` maintenance job. The job runs weekly and bumps SHAs + applies known migrations; review the diff before merging._

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Maintenance pass on Claude Code Action workflows. Applies three classes of edit atomically:
- **claude-code-action:** `v1.0.133` (`787c5a0`) — see https://github.com/anthropics/claude-code-action/releases/tag/v1.0.133
- **ai-toolkit reusable workflows:** `824dfc1` (Uniswap/ai-toolkit `next` HEAD)
- **Models:**
  - `haiku` → `claude-haiku-4-5-20251001`
  - `opus` → `claude-opus-4-7`
  - `sonnet` → `claude-sonnet-4-6`
### Per-file changes
#### `.github/workflows/_claude-code-review.yml`
- SHA bump `anthropics/claude-code-action`: `476e359` → `787c5a0` (v1.0.133)
- SHA bump `anthropics/claude-code-action`: `476e359` → `787c5a0` (v1.0.133)
#### `.github/workflows/_claude-docs-check.yml`
- SHA bump `anthropics/claude-code-action`: `476e359` → `787c5a0` (v1.0.133)
- SHA bump `anthropics/claude-code-action`: `476e359` → `787c5a0` (v1.0.133)
#### `.github/workflows/_claude-main.yml`
- SHA bump `anthropics/claude-code-action`: `476e359` → `787c5a0` (v1.0.133)
- Model bump: `claude-haiku-4-5` → `claude-haiku-4-5-20251001`
#### `.github/workflows/_claude-task-worker.yml`
- SHA bump `anthropics/claude-code-action`: `476e359` → `787c5a0` (v1.0.133)
- Model bump: `claude-haiku-4-5` → `claude-haiku-4-5-20251001`
#### `.github/workflows/_generate-pr-metadata.yml`
- SHA bump `anthropics/claude-code-action`: `476e359` → `787c5a0` (v1.0.133)
- SHA bump `anthropics/claude-code-action`: `476e359` → `787c5a0` (v1.0.133)
- **Breaking-change auto-fix:** removed deprecated input `allowed_tools` (no longer in anthropics/claude-code-action at the new SHA)
- Model bump: `claude-haiku-4-5` → `claude-haiku-4-5-20251001`
#### `.github/workflows/_update-action-versions-worker.yml`
- SHA bump `anthropics/claude-code-action`: `476e359` → `787c5a0` (v1.0.133)
#### `.github/workflows/dev-ai-newsletter.yml`
- SHA bump `anthropics/claude-code-action`: `476e359` → `787c5a0` (v1.0.133)
---
_Opened by the `sync-claude-code-action` maintenance job. The job runs weekly and bumps SHAs + applies known migrations; review the diff before merging._

</details>
<!-- claude-pr-description-end -->