### PR TITLE
fix(slack-oauth-backend): use fresh bot token, drop SLACK_BOT_TOKEN

### DIFF
--- a/apps/slack-oauth-backend/.env.example
+++ b/apps/slack-oauth-backend/.env.example
@@ -15,14 +15,10 @@ SLACK_CLIENT_SECRET=your_slack_client_secret_here
 # Example: https://your-domain.com/slack/oauth/callback
 SLACK_REDIRECT_URI=http://localhost:3000/slack/oauth/callback
 
-# Slack Bot Token (OPTIONAL)
-# NOTE: With token rotation enabled, there is no static bot token.
-# This is only needed if you want the server to send DMs or look up user info.
-# If not set, the server runs in "token rotation mode" - tokens are displayed
-# in the browser instead of being sent via DM.
-# Get this from https://api.slack.com/apps -> Your App -> OAuth & Permissions
-# Should start with xoxb-
-# SLACK_BOT_TOKEN=xoxb-your-bot-token-here
+# NOTE: There is no SLACK_BOT_TOKEN. With token rotation enabled, bot tokens
+# expire (~12h) and a static env var would silently go stale. Post-install
+# actions (DMs, user lookup) use the freshly-issued bot token from each OAuth
+# exchange instead. No bot-token configuration is required.
 
 # Security
 # Generate a secure random string for session secret

--- a/apps/slack-oauth-backend/.env.vercel.example
+++ b/apps/slack-oauth-backend/.env.vercel.example
@@ -5,7 +5,8 @@
 # Required Slack Configuration
 SLACK_CLIENT_ID=your_slack_client_id_here
 SLACK_CLIENT_SECRET=your_slack_client_secret_here
-SLACK_BOT_TOKEN=xoxb-your-bot-token-here
+# No SLACK_BOT_TOKEN: with token rotation, bot tokens expire (~12h); the server
+# uses the freshly-issued bot token from each OAuth exchange instead.
 
 # OAuth Redirect URI (will be auto-set after deployment)
 # Format: https://your-project-name.vercel.app/slack/oauth/callback

--- a/apps/slack-oauth-backend/DEPLOYMENT.md
+++ b/apps/slack-oauth-backend/DEPLOYMENT.md
@@ -45,9 +45,10 @@ Add these environment variables in the Vercel dashboard:
 | --------------------- | -------------------------------------------------------- | --------- |
 | `SLACK_CLIENT_ID`     | Your Slack app client ID                                 | No        |
 | `SLACK_CLIENT_SECRET` | Your Slack app client secret                             | Yes ✓     |
-| `SLACK_BOT_TOKEN`     | Bot user OAuth token (xoxb-...)                          | Yes ✓     |
 | `SESSION_SECRET`      | 32+ character random string                              | Yes ✓     |
 | `SLACK_REDIRECT_URI`  | `https://[your-project].vercel.app/slack/oauth/callback` | No        |
+
+> Note: there is no `SLACK_BOT_TOKEN`. With token rotation enabled, bot tokens expire (~12h), so the server authenticates post-install actions (DM delivery, user lookup) with the freshly-issued bot token from each OAuth exchange rather than a static env var.
 
 #### Optional Variables
 

--- a/apps/slack-oauth-backend/README.md
+++ b/apps/slack-oauth-backend/README.md
@@ -83,7 +83,6 @@ Edit `.env` with your credentials:
 # Required Slack Configuration
 SLACK_CLIENT_ID=your_client_id_here
 SLACK_CLIENT_SECRET=your_client_secret_here
-SLACK_BOT_TOKEN=xoxb-your-bot-token
 SLACK_REDIRECT_URI=http://localhost:3000/slack/oauth/callback
 
 # Security (generate with: openssl rand -hex 32)
@@ -316,7 +315,6 @@ The service is configured for Vercel deployment from an Nx monorepo. The configu
 
    - `SLACK_CLIENT_ID`
    - `SLACK_CLIENT_SECRET`
-   - `SLACK_BOT_TOKEN`
    - `SLACK_REDIRECT_URI` (use your Vercel deployment URL)
    - `SESSION_SECRET`
 
@@ -355,7 +353,6 @@ The service is configured for Vercel deployment from an Nx monorepo. The configu
    # Set environment variables
    heroku config:set SLACK_CLIENT_ID=xxx
    heroku config:set SLACK_CLIENT_SECRET=xxx
-   heroku config:set SLACK_BOT_TOKEN=xxx
    heroku config:set SLACK_REDIRECT_URI=https://your-app.herokuapp.com/slack/oauth/callback
 
    # Deploy
@@ -381,7 +378,6 @@ The service is configured for Vercel deployment from an Nx monorepo. The configu
      environment:
        SLACK_CLIENT_ID: ${env:SLACK_CLIENT_ID}
        SLACK_CLIENT_SECRET: ${env:SLACK_CLIENT_SECRET}
-       SLACK_BOT_TOKEN: ${env:SLACK_BOT_TOKEN}
        SLACK_REDIRECT_URI: ${env:SLACK_REDIRECT_URI}
 
    functions:
@@ -453,7 +449,6 @@ gcloud run deploy slack-oauth-backend \
 | --------------------- | -------- | ----------------------- | ------------------------------------------ |
 | `SLACK_CLIENT_ID`     | ✅       | Slack app client ID     | `123456789.987654321`                      |
 | `SLACK_CLIENT_SECRET` | ✅       | Slack app client secret | `abcdef123456`                             |
-| `SLACK_BOT_TOKEN`     | ✅       | Bot user OAuth token    | `xoxb-123456789`                           |
 | `SLACK_REDIRECT_URI`  | ✅       | OAuth redirect URL      | `https://example.com/slack/oauth/callback` |
 | `SESSION_SECRET`      | ✅       | Session encryption key  | 32+ character random string                |
 | `PORT`                | ❌       | Server port             | `3000` (default)                           |

--- a/apps/slack-oauth-backend/src/config/index.ts
+++ b/apps/slack-oauth-backend/src/config/index.ts
@@ -18,9 +18,6 @@ export interface Config {
   slackClientSecret: string;
   slackRedirectUri: string;
 
-  // Slack Bot configuration (optional - not available with token rotation)
-  slackBotToken?: string;
-
   // Security
   sessionSecret: string;
 
@@ -42,9 +39,7 @@ class ConfigurationError extends Error {
 function getRequiredEnv(key: string): string {
   const value = process.env[key];
   if (!value) {
-    throw new ConfigurationError(
-      `Missing required environment variable: ${key}`
-    );
+    throw new ConfigurationError(`Missing required environment variable: ${key}`);
   }
   return value;
 }
@@ -65,9 +60,6 @@ function createConfig(): Config {
       slackClientSecret: getRequiredEnv('SLACK_CLIENT_SECRET'),
       slackRedirectUri: getRequiredEnv('SLACK_REDIRECT_URI'),
 
-      // Slack Bot configuration (optional - not available with token rotation)
-      slackBotToken: process.env['SLACK_BOT_TOKEN'],
-
       // Security
       sessionSecret: getRequiredEnv('SESSION_SECRET'),
 
@@ -84,9 +76,7 @@ function createConfig(): Config {
   } catch (error) {
     if (error instanceof ConfigurationError) {
       console.error(`Configuration Error: ${error.message}`);
-      console.error(
-        'Please ensure all required environment variables are set.'
-      );
+      console.error('Please ensure all required environment variables are set.');
       console.error('See .env.example for required variables.');
       process.exit(1);
     }

--- a/apps/slack-oauth-backend/src/oauth/handler.spec.ts
+++ b/apps/slack-oauth-backend/src/oauth/handler.spec.ts
@@ -11,7 +11,6 @@ jest.mock('../config', () => ({
     slackClientId: 'test-client-id',
     slackClientSecret: 'test-client-secret',
     slackRedirectUri: 'https://example.com/callback',
-    slackBotToken: 'xoxb-test-bot-token',
   },
 }));
 
@@ -28,21 +27,19 @@ describe('SlackOAuthHandler', () => {
     mockUsersInfo = jest.fn();
 
     // Mock WebClient constructor and methods
-    (WebClient as jest.MockedClass<typeof WebClient>).mockImplementation(
-      (_token?: string) => {
-        const client = {
-          oauth: {
-            v2: {
-              access: mockOAuthV2Access,
-            },
+    (WebClient as jest.MockedClass<typeof WebClient>).mockImplementation((_token?: string) => {
+      const client = {
+        oauth: {
+          v2: {
+            access: mockOAuthV2Access,
           },
-          users: {
-            info: mockUsersInfo,
-          },
-        } as any;
-        return client;
-      }
-    );
+        },
+        users: {
+          info: mockUsersInfo,
+        },
+      } as any;
+      return client;
+    });
 
     handler = new SlackOAuthHandler({
       clientId: 'test-client-id',
@@ -59,9 +56,7 @@ describe('SlackOAuthHandler', () => {
 
       expect(authUrl).toContain('https://slack.com/oauth/v2/authorize');
       expect(authUrl).toContain('client_id=test-client-id');
-      expect(authUrl).toContain(
-        'redirect_uri=https%3A%2F%2Fexample.com%2Fcallback'
-      );
+      expect(authUrl).toContain('redirect_uri=https%3A%2F%2Fexample.com%2Fcallback');
       expect(authUrl).toContain('state=test-state-123456789');
       expect(authUrl).toContain('scope=chat%3Awrite%2Cusers%3Aread');
     });
@@ -145,6 +140,8 @@ describe('SlackOAuthHandler', () => {
 
         expect(result.success).toBe(true);
         expect(result.accessToken).toBe('xoxp-user-token');
+        // Bot token from the exchange is surfaced for post-install DM auth.
+        expect(result.botAccessToken).toBe('xoxp-user-token');
         expect(result.user).toEqual({
           id: 'U123456',
           name: 'testuser',

--- a/apps/slack-oauth-backend/src/oauth/handler.spec.ts
+++ b/apps/slack-oauth-backend/src/oauth/handler.spec.ts
@@ -100,7 +100,8 @@ describe('SlackOAuthHandler', () => {
 
       const mockTokenResponse = {
         ok: true,
-        access_token: 'xoxp-user-token',
+        // Distinct from the user slot below so assertions prove bot-slot sourcing.
+        access_token: 'xoxb-bot-token',
         token_type: 'user',
         scope: 'chat:write,users:read',
         team: { id: 'T123456', name: 'Test Team' },
@@ -139,9 +140,11 @@ describe('SlackOAuthHandler', () => {
         const result = await handler.handleCallback(validParams);
 
         expect(result.success).toBe(true);
+        // Selected token prefers the user token (authed_user.access_token).
         expect(result.accessToken).toBe('xoxp-user-token');
-        // Bot token from the exchange is surfaced for post-install DM auth.
-        expect(result.botAccessToken).toBe('xoxp-user-token');
+        // Bot token is sourced from the bot slot (tokenResponse.access_token),
+        // distinct from the user token, and surfaced for post-install DM auth.
+        expect(result.botAccessToken).toBe('xoxb-bot-token');
         expect(result.user).toEqual({
           id: 'U123456',
           name: 'testuser',
@@ -186,7 +189,10 @@ describe('SlackOAuthHandler', () => {
         const result = await handler.handleCallback(validParams);
 
         expect(result.success).toBe(true);
-        expect(result.accessToken).toBe('xoxp-user-token');
+        // No user token in the response, so the selected token falls back to
+        // the bot token (tokenResponse.access_token).
+        expect(result.accessToken).toBe('xoxb-bot-token');
+        expect(result.botAccessToken).toBe('xoxb-bot-token');
         expect(result.user).toBeUndefined();
         expect(mockUsersInfo).not.toHaveBeenCalled();
       });

--- a/apps/slack-oauth-backend/src/oauth/handler.ts
+++ b/apps/slack-oauth-backend/src/oauth/handler.ts
@@ -124,14 +124,14 @@ export class SlackOAuthHandler implements OAuthHandler {
         enterpriseId: tokenResponse.enterprise?.id,
       });
 
-      // Get user information using the bot token (if available)
-      // With token rotation, bot token may not be available
+      // Enrich with user info using the bot token freshly issued by THIS
+      // exchange. A static SLACK_BOT_TOKEN env var is incompatible with token
+      // rotation (xoxe tokens expire ~12h) and dies on every reinstall, which
+      // surfaced as `account_inactive` from users.info. The just-minted token
+      // is always valid and carries users:read.
       let userInfo: SlackUserInfo | undefined;
-      if (tokenResponse.authed_user?.id && config.slackBotToken) {
-        userInfo = await this.getUserInfo(
-          tokenResponse.authed_user.id,
-          config.slackBotToken // Use bot token to get user info
-        );
+      if (tokenResponse.authed_user?.id && tokenResponse.access_token) {
+        userInfo = await this.getUserInfo(tokenResponse.authed_user.id, tokenResponse.access_token);
       }
 
       // Prefer the User OAuth Token (xoxp) if present; otherwise fall back to the Bot token
@@ -147,6 +147,9 @@ export class SlackOAuthHandler implements OAuthHandler {
         success: true,
         accessToken: selectedToken,
         refreshToken: selectedRefreshToken,
+        // Surface the fresh bot token so the route can authenticate post-install
+        // actions (DM delivery) without a static, rotation-incompatible token.
+        botAccessToken: tokenResponse.access_token,
         user: userInfo,
         details: {
           team: tokenResponse.team,

--- a/apps/slack-oauth-backend/src/oauth/types.ts
+++ b/apps/slack-oauth-backend/src/oauth/types.ts
@@ -97,6 +97,13 @@ export interface OAuthResult {
   accessToken?: string;
   /** Refresh token if successful (when token rotation is enabled) */
   refreshToken?: string;
+  /**
+   * Bot access token freshly issued by this exchange. Used for post-install
+   * actions that must authenticate as the bot (e.g. DM delivery). Undefined if
+   * Slack did not issue a bot token for this install. Never persisted: with
+   * token rotation these expire (~12h), so callers must use it inline.
+   */
+  botAccessToken?: string;
   /** User information if successful */
   user?: SlackUserInfo;
   /** Error message if failed */

--- a/apps/slack-oauth-backend/src/routes/oauth.ts
+++ b/apps/slack-oauth-backend/src/routes/oauth.ts
@@ -86,7 +86,9 @@ router.get(
       let dmSent = false;
       try {
         if (result.user?.id && result.accessToken) {
-          const slackClient = createSlackClient();
+          // Authenticate the DM with the bot token freshly issued by this
+          // exchange (not a static env var, which dies under token rotation).
+          const slackClient = createSlackClient(undefined, result.botAccessToken);
           const tokenMessage = formatTokenMessage(
             result.accessToken,
             result.user.name,

--- a/apps/slack-oauth-backend/src/slack/client.spec.ts
+++ b/apps/slack-oauth-backend/src/slack/client.spec.ts
@@ -1,10 +1,5 @@
 import { WebClient } from '@slack/web-api';
-import {
-  SlackClient,
-  SlackApiError,
-  createSlackClient,
-  clearSlackCaches,
-} from './client';
+import { SlackClient, SlackApiError, createSlackClient, clearSlackCaches } from './client';
 
 // Mock the Slack WebClient
 jest.mock('@slack/web-api');
@@ -15,9 +10,13 @@ jest.mock('../config', () => ({
     slackClientId: 'test-client-id',
     slackClientSecret: 'test-client-secret',
     slackRedirectUri: 'https://example.com/callback',
-    slackBotToken: 'xoxb-test-bot-token',
   },
 }));
+
+// Bot token is supplied per-request by the caller (the fresh token from the
+// OAuth exchange), not read from config. Tests pass it explicitly to the
+// SlackClient constructor to exercise the bot-client code paths.
+const TEST_BOT_TOKEN = 'xoxb-test-bot-token';
 
 describe('SlackClient', () => {
   let client: SlackClient;
@@ -41,36 +40,34 @@ describe('SlackClient', () => {
     mockAuthTest = jest.fn();
 
     // Mock WebClient constructor and methods
-    (WebClient as jest.MockedClass<typeof WebClient>).mockImplementation(
-      (_token?: string) => {
-        const webClient = {
-          oauth: {
-            v2: {
-              access: mockOAuthV2Access,
-            },
+    (WebClient as jest.MockedClass<typeof WebClient>).mockImplementation((_token?: string) => {
+      const webClient = {
+        oauth: {
+          v2: {
+            access: mockOAuthV2Access,
           },
-          conversations: {
-            open: mockConversationsOpen,
-          },
-          chat: {
-            postMessage: mockChatPostMessage,
-          },
-          users: {
-            info: mockUsersInfo,
-          },
-          auth: {
-            test: mockAuthTest,
-          },
-        } as any;
-        return webClient;
-      }
-    );
+        },
+        conversations: {
+          open: mockConversationsOpen,
+        },
+        chat: {
+          postMessage: mockChatPostMessage,
+        },
+        users: {
+          info: mockUsersInfo,
+        },
+        auth: {
+          test: mockAuthTest,
+        },
+      } as any;
+      return webClient;
+    });
 
-    client = new SlackClient();
+    client = new SlackClient(undefined, TEST_BOT_TOKEN);
   });
 
   describe('constructor', () => {
-    it('should create two WebClient instances with proper configuration', () => {
+    it('should create two WebClient instances when given a bot token', () => {
       expect(WebClient).toHaveBeenCalledTimes(2);
 
       // First call for oauth client (no token)
@@ -87,10 +84,10 @@ describe('SlackClient', () => {
         })
       );
 
-      // Second call for bot client (with bot token)
+      // Second call for bot client (with the bot token passed to the constructor)
       expect(WebClient).toHaveBeenNthCalledWith(
         2,
-        'xoxb-test-bot-token',
+        TEST_BOT_TOKEN,
         expect.objectContaining({
           retryConfig: {
             retries: 3,
@@ -102,22 +99,23 @@ describe('SlackClient', () => {
       );
     });
 
-    it('should accept an optional token parameter', () => {
+    it('should create only the oauth client when no bot token is given', () => {
+      jest.clearAllMocks();
+      new SlackClient('xoxp-user-token');
+
+      // No bot token => only the oauth client is constructed.
+      expect(WebClient).toHaveBeenCalledTimes(1);
+      expect(WebClient).toHaveBeenNthCalledWith(1, 'xoxp-user-token', expect.any(Object));
+    });
+
+    it('should accept user and bot token parameters', () => {
       const customToken = 'xoxp-user-token';
-      new SlackClient(customToken);
+      new SlackClient(customToken, TEST_BOT_TOKEN);
 
       // beforeEach creates a client (calls 1-2), then this test creates another (calls 3-4)
       // Check that calls 3-4 used the custom token and bot token
-      expect(WebClient).toHaveBeenNthCalledWith(
-        3,
-        customToken,
-        expect.any(Object)
-      );
-      expect(WebClient).toHaveBeenNthCalledWith(
-        4,
-        'xoxb-test-bot-token',
-        expect.any(Object)
-      );
+      expect(WebClient).toHaveBeenNthCalledWith(3, customToken, expect.any(Object));
+      expect(WebClient).toHaveBeenNthCalledWith(4, TEST_BOT_TOKEN, expect.any(Object));
     });
   });
 
@@ -160,9 +158,7 @@ describe('SlackClient', () => {
         error: 'invalid_code',
       });
 
-      await expect(client.exchangeCode('invalid-code')).rejects.toThrow(
-        SlackApiError
-      );
+      await expect(client.exchangeCode('invalid-code')).rejects.toThrow(SlackApiError);
       await expect(client.exchangeCode('invalid-code')).rejects.toMatchObject({
         message: 'invalid_code',
         code: 'EXCHANGE_FAILED',
@@ -172,9 +168,7 @@ describe('SlackClient', () => {
     it('should handle network errors during token exchange', async () => {
       mockOAuthV2Access.mockRejectedValue(new Error('Network error'));
 
-      await expect(client.exchangeCode('valid-code')).rejects.toThrow(
-        SlackApiError
-      );
+      await expect(client.exchangeCode('valid-code')).rejects.toThrow(SlackApiError);
       await expect(client.exchangeCode('valid-code')).rejects.toMatchObject({
         message: 'Failed to exchange authorization code',
         code: 'EXCHANGE_ERROR',
@@ -221,9 +215,7 @@ describe('SlackClient', () => {
     it('should successfully send a direct message', async () => {
       const userId = 'U123456';
       const message = 'Test message';
-      const blocks = [
-        { type: 'section', text: { type: 'mrkdwn', text: message } },
-      ];
+      const blocks = [{ type: 'section', text: { type: 'mrkdwn', text: message } }];
 
       const result = await client.sendDirectMessage(userId, message, blocks);
 
@@ -261,12 +253,8 @@ describe('SlackClient', () => {
         error: 'user_not_found',
       });
 
-      await expect(client.sendDirectMessage('U999999', 'Test')).rejects.toThrow(
-        SlackApiError
-      );
-      await expect(
-        client.sendDirectMessage('U999999', 'Test')
-      ).rejects.toMatchObject({
+      await expect(client.sendDirectMessage('U999999', 'Test')).rejects.toThrow(SlackApiError);
+      await expect(client.sendDirectMessage('U999999', 'Test')).rejects.toMatchObject({
         message: 'Failed to open direct message channel',
         code: 'OPEN_DM_FAILED',
       });
@@ -278,12 +266,8 @@ describe('SlackClient', () => {
         error: 'channel_not_found',
       });
 
-      await expect(client.sendDirectMessage('U123456', 'Test')).rejects.toThrow(
-        SlackApiError
-      );
-      await expect(
-        client.sendDirectMessage('U123456', 'Test')
-      ).rejects.toMatchObject({
+      await expect(client.sendDirectMessage('U123456', 'Test')).rejects.toThrow(SlackApiError);
+      await expect(client.sendDirectMessage('U123456', 'Test')).rejects.toMatchObject({
         message: 'channel_not_found',
         code: 'SEND_MESSAGE_FAILED',
       });
@@ -292,12 +276,8 @@ describe('SlackClient', () => {
     it('should handle network errors when opening conversation', async () => {
       mockConversationsOpen.mockRejectedValue(new Error('Network timeout'));
 
-      await expect(client.sendDirectMessage('U123456', 'Test')).rejects.toThrow(
-        SlackApiError
-      );
-      await expect(
-        client.sendDirectMessage('U123456', 'Test')
-      ).rejects.toMatchObject({
+      await expect(client.sendDirectMessage('U123456', 'Test')).rejects.toThrow(SlackApiError);
+      await expect(client.sendDirectMessage('U123456', 'Test')).rejects.toMatchObject({
         message: 'Failed to send direct message',
         code: 'DM_ERROR',
       });
@@ -306,12 +286,8 @@ describe('SlackClient', () => {
     it('should handle network errors when sending message', async () => {
       mockChatPostMessage.mockRejectedValue(new Error('Network timeout'));
 
-      await expect(client.sendDirectMessage('U123456', 'Test')).rejects.toThrow(
-        SlackApiError
-      );
-      await expect(
-        client.sendDirectMessage('U123456', 'Test')
-      ).rejects.toMatchObject({
+      await expect(client.sendDirectMessage('U123456', 'Test')).rejects.toThrow(SlackApiError);
+      await expect(client.sendDirectMessage('U123456', 'Test')).rejects.toMatchObject({
         message: 'Failed to send direct message',
         code: 'DM_ERROR',
       });
@@ -382,9 +358,7 @@ describe('SlackClient', () => {
         error: 'user_not_found',
       });
 
-      await expect(client.getUserInfo('U999999')).rejects.toThrow(
-        SlackApiError
-      );
+      await expect(client.getUserInfo('U999999')).rejects.toThrow(SlackApiError);
       await expect(client.getUserInfo('U999999')).rejects.toMatchObject({
         message: 'Failed to get user information',
         code: 'USER_INFO_FAILED',
@@ -394,9 +368,7 @@ describe('SlackClient', () => {
     it('should handle network errors', async () => {
       mockUsersInfo.mockRejectedValue(new Error('Network error'));
 
-      await expect(client.getUserInfo('U123456')).rejects.toThrow(
-        SlackApiError
-      );
+      await expect(client.getUserInfo('U123456')).rejects.toThrow(SlackApiError);
       await expect(client.getUserInfo('U123456')).rejects.toMatchObject({
         message: 'Failed to get user information',
         code: 'USER_INFO_ERROR',
@@ -480,23 +452,29 @@ describe('SlackClient', () => {
       const client = createSlackClient('xoxp-user-token');
 
       expect(client).toBeInstanceOf(SlackClient);
-      // beforeEach creates a client (calls 1-2), then this test creates another (calls 3-4)
-      expect(WebClient).toHaveBeenNthCalledWith(
-        3,
-        'xoxp-user-token',
-        expect.any(Object)
-      );
-      expect(WebClient).toHaveBeenNthCalledWith(
-        4,
-        'xoxb-test-bot-token',
-        expect.any(Object)
-      );
+      // beforeEach creates a client (calls 1-2), then this test creates another.
+      // Without a bot token, only the oauth client is constructed.
+      expect(WebClient).toHaveBeenNthCalledWith(3, 'xoxp-user-token', expect.any(Object));
+    });
+
+    it('should return a fresh non-singleton instance when a bot token is given', () => {
+      const singletonA = createSlackClient();
+      const singletonB = createSlackClient();
+      // Tokenless calls share the singleton.
+      expect(singletonA).toBe(singletonB);
+
+      // A per-request bot token must not be cached in the singleton, so each
+      // botToken call returns a fresh instance.
+      const withBotA = createSlackClient(undefined, TEST_BOT_TOKEN);
+      const withBotB = createSlackClient(undefined, TEST_BOT_TOKEN);
+      expect(withBotA).not.toBe(singletonA);
+      expect(withBotA).not.toBe(withBotB);
     });
   });
 
   describe('retry and timeout configuration', () => {
     it('should configure WebClient with retry settings', () => {
-      new SlackClient();
+      new SlackClient(undefined, TEST_BOT_TOKEN);
 
       // Verify both WebClient instances were created with retry config
       const expectedConfig = {
@@ -508,10 +486,7 @@ describe('SlackClient', () => {
         timeout: 10000,
       };
 
-      expect(WebClient).toHaveBeenCalledWith(
-        undefined,
-        expect.objectContaining(expectedConfig)
-      );
+      expect(WebClient).toHaveBeenCalledWith(undefined, expect.objectContaining(expectedConfig));
       expect(WebClient).toHaveBeenCalledWith(
         'xoxb-test-bot-token',
         expect.objectContaining(expectedConfig)

--- a/apps/slack-oauth-backend/src/slack/client.ts
+++ b/apps/slack-oauth-backend/src/slack/client.ts
@@ -21,7 +21,7 @@ export class SlackClient {
   private readonly botClient?: WebClient;
   private static instance?: SlackClient;
 
-  constructor(token?: string) {
+  constructor(token?: string, botToken?: string) {
     // Configure client options with retry, timeout, and connection pooling
     const clientOptions: WebClientOptions = {
       retryConfig: {
@@ -36,9 +36,13 @@ export class SlackClient {
     // Client for OAuth operations (no token needed)
     this.client = new WebClient(token, clientOptions);
 
-    // Bot client for sending messages (optional - not available with token rotation)
-    if (config.slackBotToken) {
-      this.botClient = new WebClient(config.slackBotToken, clientOptions);
+    // Bot client for post-install actions (e.g. DMs). The token is supplied
+    // per-request by the caller (the fresh bot token from the OAuth exchange),
+    // never a static env var: with token rotation a stored bot token expires
+    // (~12h) and dies on reinstall. Absent token => no bot client, and bot
+    // operations skip gracefully (token rotation mode).
+    if (botToken) {
+      this.botClient = new WebClient(botToken, clientOptions);
     }
   }
 
@@ -87,11 +91,9 @@ export class SlackClient {
         throw error;
       }
 
-      throw new SlackApiError(
-        'Failed to exchange authorization code',
-        'EXCHANGE_ERROR',
-        { originalError: error }
-      );
+      throw new SlackApiError('Failed to exchange authorization code', 'EXCHANGE_ERROR', {
+        originalError: error,
+      });
     }
   }
 
@@ -174,7 +176,9 @@ export class SlackClient {
   async getUserInfo(userId: string): Promise<UserInfoResponse | null> {
     // Skip if no bot client (token rotation mode)
     if (!this.botClient) {
-      logger.info('Skipping user info lookup - bot token not configured (token rotation mode)', { userId });
+      logger.info('Skipping user info lookup - bot token not configured (token rotation mode)', {
+        userId,
+      });
       return null;
     }
 
@@ -188,11 +192,7 @@ export class SlackClient {
         });
 
         if (!response.ok || !response.user) {
-          throw new SlackApiError(
-            'Failed to get user information',
-            'USER_INFO_FAILED',
-            response
-          );
+          throw new SlackApiError('Failed to get user information', 'USER_INFO_FAILED', response);
         }
 
         const user = response.user as any;
@@ -218,11 +218,9 @@ export class SlackClient {
           throw error;
         }
 
-        throw new SlackApiError(
-          'Failed to get user information',
-          'USER_INFO_ERROR',
-          { originalError: error }
-        );
+        throw new SlackApiError('Failed to get user information', 'USER_INFO_ERROR', {
+          originalError: error,
+        });
       }
     });
   }
@@ -242,11 +240,7 @@ export class SlackClient {
       const response = await this.botClient.auth.test();
 
       if (!response.ok) {
-        throw new SlackApiError(
-          'Authentication test failed',
-          'AUTH_TEST_FAILED',
-          response
-        );
+        throw new SlackApiError('Authentication test failed', 'AUTH_TEST_FAILED', response);
       }
 
       return {
@@ -262,11 +256,9 @@ export class SlackClient {
         throw error;
       }
 
-      throw new SlackApiError(
-        'Failed to test authentication',
-        'AUTH_TEST_ERROR',
-        { originalError: error }
-      );
+      throw new SlackApiError('Failed to test authentication', 'AUTH_TEST_ERROR', {
+        originalError: error,
+      });
     }
   }
 
@@ -338,7 +330,13 @@ export interface AuthTestResponse {
 /**
  * Create a configured Slack client instance (uses singleton for better connection reuse)
  */
-export function createSlackClient(token?: string): SlackClient {
+export function createSlackClient(token?: string, botToken?: string): SlackClient {
+  // A per-request bot token (fresh from an OAuth exchange) must never be cached
+  // in the singleton, or a later request would reuse an earlier install's token.
+  // Only the tokenless OAuth client is safe to share across requests.
+  if (botToken) {
+    return new SlackClient(token, botToken);
+  }
   return SlackClient.getInstance(token);
 }
 

--- a/apps/slack-oauth-backend/tests/integration/oauth-flow.spec.ts
+++ b/apps/slack-oauth-backend/tests/integration/oauth-flow.spec.ts
@@ -15,7 +15,6 @@ jest.mock('../../src/config', () => ({
     slackClientId: 'test-client-id',
     slackClientSecret: 'test-client-secret',
     slackRedirectUri: 'https://example.com/callback',
-    slackBotToken: 'xoxb-test-bot-token',
     notionDocUrl: 'https://notion.so/setup-docs',
     environment: 'test',
   },
@@ -40,9 +39,7 @@ jest.mock('../../src/utils/logger', () => ({
 // Mock security middleware to prevent rate limiting in tests
 // We only mock the rate limiter, keep validation middleware working
 jest.mock('../../src/middleware/security', () => {
-  const actual = jest.requireActual(
-    '../../src/middleware/security'
-  ) as typeof SecurityMiddleware;
+  const actual = jest.requireActual('../../src/middleware/security') as typeof SecurityMiddleware;
   return {
     ...actual,
     oauthRateLimiter: (_req: any, _res: any, next: any) => next(),
@@ -77,27 +74,25 @@ describe('OAuth Flow Integration Tests', () => {
     mockUsersInfo = jest.fn();
 
     // Mock WebClient constructor and methods
-    (WebClient as jest.MockedClass<typeof WebClient>).mockImplementation(
-      (_token?: string) => {
-        const client = {
-          oauth: {
-            v2: {
-              access: mockOAuthV2Access,
-            },
+    (WebClient as jest.MockedClass<typeof WebClient>).mockImplementation((_token?: string) => {
+      const client = {
+        oauth: {
+          v2: {
+            access: mockOAuthV2Access,
           },
-          conversations: {
-            open: mockConversationsOpen,
-          },
-          chat: {
-            postMessage: mockChatPostMessage,
-          },
-          users: {
-            info: mockUsersInfo,
-          },
-        } as any;
-        return client;
-      }
-    );
+        },
+        conversations: {
+          open: mockConversationsOpen,
+        },
+        chat: {
+          postMessage: mockChatPostMessage,
+        },
+        users: {
+          info: mockUsersInfo,
+        },
+      } as any;
+      return client;
+    });
   });
 
   describe('GET /slack/oauth/callback - Success Flow', () => {
@@ -307,13 +302,9 @@ describe('OAuth Flow Integration Tests', () => {
 
   describe('GET /slack/oauth/authorize', () => {
     it('should generate OAuth URL and redirect', async () => {
-      const response = await request(app)
-        .get('/slack/oauth/authorize')
-        .expect(302);
+      const response = await request(app).get('/slack/oauth/authorize').expect(302);
 
-      expect(response.headers.location).toContain(
-        'https://slack.com/oauth/v2/authorize'
-      );
+      expect(response.headers.location).toContain('https://slack.com/oauth/v2/authorize');
       expect(response.headers.location).toContain('client_id=test-client-id');
       expect(response.headers.location).toContain(
         'redirect_uri=https%3A%2F%2Fexample.com%2Fcallback'


### PR DESCRIPTION
## Summary

Fixes the `account_inactive` error observed in Vercel logs during the OAuth callback, and removes the static `SLACK_BOT_TOKEN` env var entirely.

**Root cause:** `users.info` enrichment (and DM delivery) authenticated with the static `SLACK_BOT_TOKEN` env var. With `token_rotation_enabled: true`, bot tokens are short-lived (`xoxe`, ~12h) and a static env var goes stale; it also dies on every reinstall. Slack returned `account_inactive` for `users.info`, leaving `OAuthResult.user` undefined.

**Fix:** both consumers run during the callback, when the fresh bot token from the exchange (`tokenResponse.access_token`) is in hand. Use it directly instead of a stored copy.

## Changes

- **`handler.ts`** — enrich `users.info` with the fresh exchange token; surface it as `OAuthResult.botAccessToken`.
- **`routes/oauth.ts`** — pass `botAccessToken` into `createSlackClient` so the DM authenticates with the fresh token.
- **`client.ts`** — `SlackClient` constructor takes a per-request `botToken` instead of reading `config.slackBotToken`. `createSlackClient(token, botToken)` bypasses the singleton when a bot token is given, so a per-request token is never cached across installs.
- **`config/index.ts`** — remove `slackBotToken` field + env read.
- **`types.ts`** — add `botAccessToken?` to `OAuthResult` (documented as never-persisted).
- **docs/env** — `.env.example`, `.env.vercel.example`, `README.md`, `DEPLOYMENT.md` updated to note there is no static bot token.

`/health`'s `testAuth()` already degrades gracefully to `token_rotation` mode when no bot token is present — unchanged.

## Verification

- `nx test slack-oauth-backend` — **74/74 pass** (added 2 tests: oauth-only constructor path + singleton-bypass factory behavior)
- `nx typecheck` — clean
- `nx lint` — 0 errors (38 pre-existing `any` warnings in untouched files)
- The existing integration test `should complete full OAuth flow successfully` now exercises the fresh-token DM path (its fixture's `access_token` flows through `botAccessToken`).

## Test plan (post-deploy)

- [ ] Vercel preview deploys cleanly
- [ ] Complete an OAuth flow on the preview; confirm no `account_inactive` error in logs and `Slack OAuth exchange complete` shows the user populated
- [ ] Confirm the token DM is delivered (previously fell back to the success page)

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Fixes the `account_inactive` error observed in Vercel logs during the OAuth callback, and removes the static `SLACK_BOT_TOKEN` env var entirely.
**Root cause:** `users.info` enrichment (and DM delivery) authenticated with the static `SLACK_BOT_TOKEN` env var. With `token_rotation_enabled: true`, bot tokens are short-lived (`xoxe`, ~12h) and a static env var goes stale; it also dies on every reinstall. Slack returned `account_inactive` for `users.info`, leaving `OAuthResult.user` undefined.
**Fix:** both consumers run during the callback, when the fresh bot token from the exchange (`tokenResponse.access_token`) is in hand. Use it directly instead of a stored copy.
## Changes
- **`handler.ts`** — enrich `users.info` with the fresh exchange token; surface it as `OAuthResult.botAccessToken`.
- **`routes/oauth.ts`** — pass `botAccessToken` into `createSlackClient` so the DM authenticates with the fresh token.
- **`client.ts`** — `SlackClient` constructor takes a per-request `botToken` instead of reading `config.slackBotToken`. `createSlackClient(token, botToken)` bypasses the singleton when a bot token is given, so a per-request token is never cached across installs.
- **`config/index.ts`** — remove `slackBotToken` field + env read.
- **`types.ts`** — add `botAccessToken?` to `OAuthResult` (documented as never-persisted).
- **docs/env** — `.env.example`, `.env.vercel.example`, `README.md`, `DEPLOYMENT.md` updated to note there is no static bot token.
`/health`'s `testAuth()` already degrades gracefully to `token_rotation` mode when no bot token is present — unchanged.
## Verification
- `nx test slack-oauth-backend` — **74/74 pass** (added 2 tests: oauth-only constructor path + singleton-bypass factory behavior)
- `nx typecheck` — clean
- `nx lint` — 0 errors (38 pre-existing `any` warnings in untouched files)
- The existing integration test `should complete full OAuth flow successfully` now exercises the fresh-token DM path (its fixture's `access_token` flows through `botAccessToken`).
## Test plan (post-deploy)
- [ ] Vercel preview deploys cleanly
- [ ] Complete an OAuth flow on the preview; confirm no `account_inactive` error in logs and `Slack OAuth exchange complete` shows the user populated
- [ ] Confirm the token DM is delivered (previously fell back to the success page)

</details>
<!-- claude-pr-description-end -->