### PR TITLE
fix(workflows): harden reusable Claude workflows vs silent failures

### DIFF
--- a/.github/REUSABLE_WORKFLOWS.md
+++ b/.github/REUSABLE_WORKFLOWS.md
@@ -1022,20 +1022,20 @@ This workflow does not have outputs (reviews are submitted directly to GitHub PR
 
 **Note**: You must provide either `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`. The secrets must be passed explicitly from the calling workflow.
 
-#### Permissions Required (Fixed)
+#### Permissions Required (caller must grant these)
 
-These permissions are **fixed** in the reusable workflow and cannot be overridden:
+The **calling** workflow must grant its calling job at least these permissions. A reusable workflow cannot be granted more than its caller provides, so granting fewer (for example `contents: read` here) makes GitHub reject the run with a silent `startup_failure` (a ~1s run with no logs):
 
 ```yaml
 permissions:
   id-token: write # Required for OIDC authentication
-  contents: read # Required to read repository code
+  contents: write # Required to read code AND push commits when auto_fix is enabled
   pull-requests: write # Required to comment and submit reviews
   issues: read # Required to read PR discussions
   actions: read # Required to check CI status
 ```
 
-**Note**: You do NOT need to specify these permissions in your calling workflow - they are automatically set by the reusable workflow.
+**Note**: These must be declared on the calling job. See `.github/workflows/examples/08-claude-code-review-basic.yml` for a complete caller.
 
 #### Fixed Settings (Cannot be Overridden)
 

--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -37,8 +37,10 @@ name: "[claude] Claude Code Review"
 # event when re-requesting reviews from bot accounts. Use the comment trigger
 # or manual workflow_dispatch instead.
 #
-# PERMISSIONS REQUIRED (calling workflow must grant these):
-#   contents: read
+# PERMISSIONS REQUIRED (the calling workflow must grant its calling job at least these;
+# a reusable workflow cannot be granted more than its caller provides, so granting fewer
+# causes a silent startup_failure: a ~1s run with no logs):
+#   contents: write       # read code AND push commits when auto_fix is enabled
 #   pull-requests: write
 #   issues: read
 #   actions: read
@@ -270,7 +272,11 @@ jobs:
       NODE_OPTIONS: ""
       NPM_CONFIG_REGISTRY: ""
       NODE_PATH: ""
-    # Fixed permissions (cannot be overridden by calling workflow)
+    # Permissions the CALLING workflow must grant its calling job (matching or higher).
+    # A reusable workflow cannot be granted more than its caller provides, so a caller that
+    # declares fewer (e.g. contents: read when this needs contents: write for auto_fix pushes)
+    # makes GitHub reject the run with a silent startup_failure: a ~1s run with no logs.
+    # See .github/workflows/examples/08-claude-code-review-basic.yml for a correct caller.
     permissions:
       id-token: write # Required for OIDC
       contents: write # Required to read code and push fixes when auto_fix is enabled

--- a/.github/workflows/_generate-pr-metadata.yml
+++ b/.github/workflows/_generate-pr-metadata.yml
@@ -23,9 +23,12 @@ name: "[claude] Generate PR Title & Description"
 # - Pattern learning from repository history
 # - Custom prompt support
 #
-# PERMISSIONS:
-# This workflow defines its own job-level permissions (contents: read,
-# pull-requests: write). Calling workflows do NOT need to grant these.
+# PERMISSIONS REQUIRED (the calling workflow must grant its calling job at least these;
+# a reusable workflow cannot be granted more than its caller provides, so granting fewer
+# causes a silent startup_failure: a ~1s run with no logs):
+#   id-token: write
+#   contents: read
+#   pull-requests: write
 
 on:
   workflow_call:
@@ -165,7 +168,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout_minutes }}
 
-    # Fixed permissions (cannot be overridden by calling workflow)
+    # Permissions the CALLING workflow must grant its calling job (matching or higher).
+    # A reusable workflow cannot be granted more than its caller provides, so a caller that
+    # declares fewer makes GitHub reject the run with a silent startup_failure: a ~1s run with
+    # no logs. See .github/workflows/examples/12-generate-pr-metadata-basic.yml for a correct caller.
     permissions:
       id-token: write # Required to create ID tokens for Claude Code Action
       contents: read # Required to read repository code

--- a/.github/workflows/examples/08-claude-code-review-basic.yml
+++ b/.github/workflows/examples/08-claude-code-review-basic.yml
@@ -33,6 +33,15 @@ jobs:
       !contains(github.head_ref, 'gh-readonly-queue/') &&
       (github.event.pull_request.draft == false || github.event.action == 'ready_for_review')
 
+    # Required: the calling job must grant at least what the reusable workflow declares, or
+    # GitHub rejects the run with a silent startup_failure (a ~1s run with no logs).
+    permissions:
+      id-token: write # OIDC for Claude Code Action
+      contents: write # read code; the reusable workflow also pushes commits when auto_fix is on
+      pull-requests: write # comment and submit the review
+      issues: read # read PR discussions
+      actions: read # check CI status
+
     uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@main
     with:
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/examples/09-claude-code-review-with-custom-prompt.yml
+++ b/.github/workflows/examples/09-claude-code-review-with-custom-prompt.yml
@@ -37,6 +37,15 @@ jobs:
       !contains(github.head_ref, 'gh-readonly-queue/') &&
       (github.event.pull_request.draft == false || github.event.action == 'ready_for_review')
 
+    # Required: the calling job must grant at least what the reusable workflow declares, or
+    # GitHub rejects the run with a silent startup_failure (a ~1s run with no logs).
+    permissions:
+      id-token: write # OIDC for Claude Code Action
+      contents: write # read code; the reusable workflow also pushes commits when auto_fix is on
+      pull-requests: write # comment and submit the review
+      issues: read # read PR discussions
+      actions: read # check CI status
+
     uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@main
     with:
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/examples/10-claude-code-review-advanced.yml
+++ b/.github/workflows/examples/10-claude-code-review-advanced.yml
@@ -38,6 +38,16 @@ jobs:
       !contains(github.head_ref, 'gh-readonly-queue/') &&
       (github.event.pull_request.draft == false || github.event.action == 'ready_for_review')
 
+    # Required: the calling job must grant at least what the reusable workflow declares, or
+    # GitHub rejects the run with a silent startup_failure (a ~1s run with no logs).
+    # contents: write is needed here because auto_fix (below) pushes commits.
+    permissions:
+      id-token: write # OIDC for Claude Code Action
+      contents: write # read code AND push auto_fix commits
+      pull-requests: write # comment and submit the review
+      issues: read # read PR discussions
+      actions: read # check CI status
+
     uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@main
     with:
       pr_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Corrects misleading permission documentation on the two reusable Claude workflows (`_claude-code-review.yml`, `_generate-pr-metadata.yml`) and adds the required `permissions:` blocks to the example callers.

The reusable workflows carried comments stating their permissions were "Fixed (cannot be overridden by calling workflow)" and that "Calling workflows do NOT need to grant these." That is false and actively harmful: a reusable workflow can never be granted *more* than its caller provides, so a caller that declares *fewer* permissions than the reusable job needs makes GitHub reject the run with a silent `startup_failure` (a ~1s run with no logs). That is the exact failure mode that ate a real debugging session.

## What changed

- `_claude-code-review.yml`, `_generate-pr-metadata.yml`: replace the "fixed / cannot be overridden / you do NOT need to grant" comments with accurate guidance — the calling job must grant at least the listed permissions, and granting fewer causes a silent `startup_failure`. Each comment points to a correct example caller.
- `.github/REUSABLE_WORKFLOWS.md`: the same correction in the consumer-facing docs; `contents: read` → `contents: write` for the review workflow (it pushes commits when `auto_fix` is on).
- `examples/08`, `examples/09`, `examples/10`: add the required `permissions:` block to each example caller so consumers copying them do not hit the silent failure.

**No behavior change.** The reusable workflows' actual `permissions:` blocks are unchanged; this PR only corrects the documentation/comments and the example callers.

## Dropped from this PR

An earlier revision also changed the `toolkit_ref` default to empty, resolving runtime assets from the running commit via `job.workflow_sha` to prevent asset drift. That was dropped. On a `pull_request`, the running commit is the merge commit, so the workflow would fetch a same-repo PR author's *unmerged* edits to `post-review.ts` / prompt files and execute them with secrets — a surface the old `main` default (which fetches already-merged code) does not have. Asset-drift prevention can be revisited separately, decoupled from this doc fix.

## Test plan

- Documentation/comment-only change to the reusable workflows, plus `permissions:` blocks on the example callers. No runtime behavior change.
- Reusable workflows' `permissions:` blocks unchanged (verified via diff against `next`).
- CI: `claude-review` and `generate-metadata` run green on this PR.

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Hardens the reusable PR-review (`_claude-code-review.yml`) and PR-metadata (`_generate-pr-metadata.yml`) workflows against the two silent failure modes uncovered while fixing [Uniswap/hooks#7](https://github.com/Uniswap/hooks/pull/7): a 404 from `toolkit_ref` drift, and a `startup_failure` / 403 from under-granted caller permissions. Three focused commits across 6 files (+51 / -11).
## What changed
### 1. Kill `toolkit_ref` asset drift at the source
These workflows fetch runtime assets (post-review/build-prompt scripts, prompt section files, the `validate-claude-auth` action, the default metadata prompt) from `Uniswap/ai-toolkit` at `toolkit_ref`, which defaulted to `main`. When a caller pinned the workflow to a specific SHA via `uses: ...@<SHA>` but left `toolkit_ref` unset, assets were fetched from a different commit than the workflow YAML, producing a 404 whenever an asset existed on one ref but not the other. That broke hooks#7 (the `validate-claude-auth` action did not exist at the old `toolkit_ref`).
Fix: default `toolkit_ref` to `""` and add a `Resolve ai-toolkit asset source` step that resolves the fetch repo+ref to **this workflow's own commit** via `job.workflow_repository` / `job.workflow_sha`. Assets now always match the workflow YAML that is running. An explicit `toolkit_ref` still overrides (for testing unreleased ai-toolkit changes). The resolve step fails loudly if `job.workflow_*` is empty (e.g. GitHub Enterprise Server) instead of silently fetching the wrong ref. Also aligns the metadata default-prompt fetch, which previously always hit the default branch with no ref pin.
### 2. Correct the misleading "fixed permissions" docs
The workflows described their job permissions as "fixed (cannot be overridden by calling workflow)", and the review workflow's header even listed `contents: read` for callers while its job requires `contents: write`. This is backwards: a reusable workflow can never be granted **more** than its caller provides, so a caller granting fewer permissions makes GitHub reject the run with a silent `startup_failure` (a ~1s run, no logs). That mismatch was the second half of the hooks#7 failure.
Rewrites the in-workflow comments and header docs to state the calling workflow must grant at least these permissions, fixes the review workflow's documented `contents` value (`read` → `write`), fixes the metadata header that wrongly said callers do not need to grant permissions, and fixes the same in `REUSABLE_WORKFLOWS.md`.
### 3. Add the required permissions block to PR-review example callers
Example callers `08`/`09`/`10` had no `permissions:` block, so a copy-paste user inherits the org-default read-only `GITHUB_TOKEN` and hits the `startup_failure` above. Adds the full required block to each, matching what the reusable workflow declares. (Metadata examples `12`/`13` already had a correct block.)
## Changes
| File | Change |
|------|--------|
| `.github/workflows/_claude-code-review.yml` | Default `toolkit_ref` to `""`; add `Resolve ai-toolkit asset source` step; rewrite permissions docs |
| `.github/workflows/_generate-pr-metadata.yml` | Same `toolkit_ref` resolution pattern; align default-prompt fetch to resolved ref; correct permissions docs |
| `.github/REUSABLE_WORKFLOWS.md` | Correct "fixed permissions" prose for both workflows; fix `contents: read` → `write` for review |
| `.github/workflows/examples/08-claude-code-review-basic.yml` | Add required `permissions:` block |
| `.github/workflows/examples/09-claude-code-review-with-custom-prompt.yml` | Add required `permissions:` block |
| `.github/workflows/examples/10-claude-code-review-advanced.yml` | Add required `permissions:` block |
Total diff: +51 / -11 across 6 files.
## Notes on the original phrasing
Grounding the prevention items against the actual ai-toolkit code changed two of the three from how they were originally phrased:
- The proposed "update the `sync-claude-code-action` job to bump `toolkit_ref` in lockstep with the workflow SHA" referenced a job that does not exist in ai-toolkit (`sync-claude-code-action` was the hooks-side branch name). The drift is better killed at the source than synced after the fact.
- The proposed "add a permission-preflight step that fails fast instead of `startup_failure`" cannot work — a preflight **step** cannot catch `startup_failure` because the job never starts when a caller under-grants permissions. The fix therefore lives in the caller template (examples) plus accurate docs, where it can actually prevent the failure.
## Caveat
`job.workflow_*` is not available on GitHub Enterprise Server. ai-toolkit and its downstream consumers run on github.com, and the resolve step fails loudly (rather than fetching a wrong ref) if those values are empty.
## Test plan
- [x] lefthook pre-commit gate (format, lint, markdown-lint, test, typecheck, lockfile) ran green on each of the three commits
- [x] `actionlint` clean on examples `08`/`09`/`10`
- [x] `actionlint` on the two reusable workflows reports only 2 `[expression]` warnings each, both on `job.workflow_repository` / `job.workflow_sha` — false positives from actionlint 1.7.11's stale `job` context schema (properties are real per the GitHub contexts reference; actionlint is not part of this repo's CI)
- [ ] Downstream caller pinned to a non-`main` SHA fetches assets matching that SHA (not `main`)
- [ ] Downstream caller missing `pull-requests: write` surfaces an actionable error path
## Possible follow-ups (not in this PR)
- The same `toolkit_ref` default-to-own-SHA pattern applies to the other reusable workflows that fetch assets (`_claude-docs-check.yml`, `_claude-task-worker.yml`, `_update-action-versions-worker.yml`, `_claude-main.yml`).
- The "cannot be overridden" permissions prose also appears in the `_claude-main.yml` / `_claude-welcome.yml` sections of `REUSABLE_WORKFLOWS.md`.

</details>
<!-- claude-pr-description-end -->