### PR TITLE
fix(security): close 6 OAuth backend + nx-claude script scan findings

### DIFF
--- a/apps/slack-oauth-backend/src/oauth/state.spec.ts
+++ b/apps/slack-oauth-backend/src/oauth/state.spec.ts
@@ -1,0 +1,63 @@
+// Mock the config module with a deterministic session secret
+jest.mock('../config', () => ({
+  config: {
+    sessionSecret: 'test-session-secret-deterministic',
+  },
+}));
+
+import { generateState, validateState } from './state';
+
+describe('OAuth State Token', () => {
+  describe('generateState', () => {
+    it('should produce a base64url token with no padding or unsafe chars', () => {
+      const state = generateState();
+      expect(state).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(state).not.toContain('=');
+    });
+
+    it('should stay well under the 500-char callback limit', () => {
+      const state = generateState();
+      expect(state.length).toBeGreaterThanOrEqual(16);
+      expect(state.length).toBeLessThan(500);
+    });
+
+    it('should produce a different token on each call', () => {
+      expect(generateState()).not.toEqual(generateState());
+    });
+  });
+
+  describe('validateState', () => {
+    it('should validate a freshly generated state', () => {
+      const state = generateState();
+      expect(validateState(state)).toBe(true);
+    });
+
+    it('should reject an arbitrary 16+ char string', () => {
+      expect(validateState('aaaaaaaaaaaaaaaa')).toBe(false);
+    });
+
+    it('should reject a tampered token (flipped char)', () => {
+      const state = generateState();
+      const idx = Math.floor(state.length / 2);
+      const original = state[idx];
+      const replacement = original === 'A' ? 'B' : 'A';
+      const tampered = state.slice(0, idx) + replacement + state.slice(idx + 1);
+      expect(validateState(tampered)).toBe(false);
+    });
+
+    it('should reject an expired token via a tiny maxAgeMs', async () => {
+      const state = generateState();
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      expect(validateState(state, 1)).toBe(false);
+    });
+
+    it('should reject an empty string', () => {
+      expect(validateState('')).toBe(false);
+    });
+
+    it('should reject malformed base64url that does not decode to 3 parts', () => {
+      const malformed = Buffer.from('not-three-parts', 'utf8').toString('base64url');
+      expect(validateState(malformed)).toBe(false);
+    });
+  });
+});

--- a/apps/slack-oauth-backend/src/oauth/state.spec.ts
+++ b/apps/slack-oauth-backend/src/oauth/state.spec.ts
@@ -5,59 +5,105 @@ jest.mock('../config', () => ({
   },
 }));
 
-import { generateState, validateState } from './state';
+import { generateState, validateState, generateBrowserNonce } from './state';
 
 describe('OAuth State Token', () => {
+  describe('generateBrowserNonce', () => {
+    it('should produce a base64url nonce with no padding or unsafe chars', () => {
+      const nonce = generateBrowserNonce();
+      expect(nonce).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(nonce).not.toContain('=');
+    });
+
+    it('should produce a different nonce on each call', () => {
+      expect(generateBrowserNonce()).not.toEqual(generateBrowserNonce());
+    });
+  });
+
   describe('generateState', () => {
     it('should produce a base64url token with no padding or unsafe chars', () => {
-      const state = generateState();
+      const state = generateState(generateBrowserNonce());
       expect(state).toMatch(/^[A-Za-z0-9_-]+$/);
       expect(state).not.toContain('=');
     });
 
     it('should stay well under the 500-char callback limit', () => {
-      const state = generateState();
+      const state = generateState(generateBrowserNonce());
       expect(state.length).toBeGreaterThanOrEqual(16);
       expect(state.length).toBeLessThan(500);
     });
 
-    it('should produce a different token on each call', () => {
-      expect(generateState()).not.toEqual(generateState());
+    it('should produce a different token on each call even with the same browser nonce', () => {
+      const browserNonce = generateBrowserNonce();
+      expect(generateState(browserNonce)).not.toEqual(generateState(browserNonce));
     });
   });
 
   describe('validateState', () => {
-    it('should validate a freshly generated state', () => {
-      const state = generateState();
-      expect(validateState(state)).toBe(true);
+    it('should validate a freshly generated state with the matching browser nonce', () => {
+      const browserNonce = generateBrowserNonce();
+      const state = generateState(browserNonce);
+      expect(validateState(state, browserNonce)).toBe(true);
+    });
+
+    it('should reject a valid state presented with a different browser nonce (CSRF)', () => {
+      const browserNonce = generateBrowserNonce();
+      const state = generateState(browserNonce);
+      const attackerNonce = generateBrowserNonce();
+      expect(attackerNonce).not.toEqual(browserNonce);
+      // The signed state is genuine, but the browser cookie nonce does not match
+      // the one bound into the token, so the double-submit check rejects it.
+      expect(validateState(state, attackerNonce)).toBe(false);
+    });
+
+    it('should reject when the browser nonce is missing/empty', () => {
+      const browserNonce = generateBrowserNonce();
+      const state = generateState(browserNonce);
+      expect(validateState(state, '')).toBe(false);
+      // @ts-expect-error exercising the runtime guard for a non-string nonce
+      expect(validateState(state, undefined)).toBe(false);
     });
 
     it('should reject an arbitrary 16+ char string', () => {
-      expect(validateState('aaaaaaaaaaaaaaaa')).toBe(false);
+      expect(validateState('aaaaaaaaaaaaaaaa', generateBrowserNonce())).toBe(false);
     });
 
     it('should reject a tampered token (flipped char)', () => {
-      const state = generateState();
+      const browserNonce = generateBrowserNonce();
+      const state = generateState(browserNonce);
       const idx = Math.floor(state.length / 2);
       const original = state[idx];
       const replacement = original === 'A' ? 'B' : 'A';
       const tampered = state.slice(0, idx) + replacement + state.slice(idx + 1);
-      expect(validateState(tampered)).toBe(false);
+      expect(validateState(tampered, browserNonce)).toBe(false);
     });
 
     it('should reject an expired token via a tiny maxAgeMs', async () => {
-      const state = generateState();
+      const browserNonce = generateBrowserNonce();
+      const state = generateState(browserNonce);
       await new Promise((resolve) => setTimeout(resolve, 5));
-      expect(validateState(state, 1)).toBe(false);
+      expect(validateState(state, browserNonce, 1)).toBe(false);
     });
 
     it('should reject an empty string', () => {
-      expect(validateState('')).toBe(false);
+      expect(validateState('', generateBrowserNonce())).toBe(false);
     });
 
-    it('should reject malformed base64url that does not decode to 3 parts', () => {
-      const malformed = Buffer.from('not-three-parts', 'utf8').toString('base64url');
-      expect(validateState(malformed)).toBe(false);
+    it('should reject malformed base64url that does not decode to 4 parts', () => {
+      const malformed = Buffer.from('not-four-parts', 'utf8').toString('base64url');
+      expect(validateState(malformed, generateBrowserNonce())).toBe(false);
+    });
+
+    it('should reject a token whose signed browser nonce was swapped (forgery)', () => {
+      // A token forged by signing with a different secret cannot pass: build a
+      // structurally valid 4-part token under a wrong secret and confirm the
+      // signature check rejects it even when the browser nonce matches.
+      const browserNonce = generateBrowserNonce();
+      const decoyPayload = `nonce.${Date.now()}.${browserNonce}`;
+      const decoyToken = Buffer.from(`${decoyPayload}.not-a-valid-signature`, 'utf8').toString(
+        'base64url'
+      );
+      expect(validateState(decoyToken, browserNonce)).toBe(false);
     });
   });
 });

--- a/apps/slack-oauth-backend/src/oauth/state.ts
+++ b/apps/slack-oauth-backend/src/oauth/state.ts
@@ -2,15 +2,26 @@ import { createHmac, randomBytes, timingSafeEqual } from 'crypto';
 import { config } from '../config';
 
 /**
- * Stateless, signed OAuth state tokens.
+ * Stateless, signed, browser-bound OAuth state tokens.
  *
- * The token is `nonce.timestamp.signature`, HMAC-SHA256 signed with
- * `config.sessionSecret`, then base64url-encoded with no padding. This works on
- * serverless (no shared store needed): /authorize signs the token and /callback
- * verifies the signature, so a forged or replayed state is rejected without any
- * cross-instance state. base64url (A-Za-z0-9-_) satisfies the callback
- * validator's /^[a-zA-Z0-9_-]+$/ length 16..500 check.
+ * The token is `nonce.timestamp.browserNonce.signature`, HMAC-SHA256 signed
+ * with `config.sessionSecret`, then base64url-encoded with no padding. This
+ * works on serverless (no shared store needed): /authorize signs the token and
+ * /callback verifies the signature, so a forged or replayed state is rejected
+ * without any cross-instance state. base64url (A-Za-z0-9-_) satisfies the
+ * callback validator's /^[a-zA-Z0-9_-]+$/ length 16..500 check.
+ *
+ * CSRF hardening (double-submit cookie pattern): the signed token also embeds a
+ * per-browser `browserNonce`. /authorize sets that nonce in an HttpOnly cookie
+ * AND folds it into the signature; /callback re-reads it from the cookie and
+ * requires it to match the signed copy. A signed state alone is therefore
+ * useless to an attacker who did not also receive the victim browser's cookie,
+ * which proves the browser hitting /callback is the same one that started the
+ * flow.
  */
+
+/** Cookie name carrying the per-browser nonce that binds a state token to a browser. */
+export const OAUTH_STATE_COOKIE = 'oauth_browser_nonce';
 
 const DEFAULT_MAX_AGE_MS = 10 * 60 * 1000;
 const SEPARATOR = '.';
@@ -20,43 +31,81 @@ function sign(payload: string): string {
 }
 
 /**
- * Build a signed state token from a CSPRNG nonce and the current timestamp.
+ * Constant-time string comparison that never throws and is length-safe.
+ * Returns false for unequal lengths without leaking which side differed.
  */
-export function generateState(): string {
+function constantTimeEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, 'utf8');
+  const bBuf = Buffer.from(b, 'utf8');
+  if (aBuf.length !== bBuf.length) {
+    return false;
+  }
+  return timingSafeEqual(aBuf, bBuf);
+}
+
+/**
+ * Generate a CSPRNG per-browser nonce. Stored in an HttpOnly cookie by
+ * /authorize and bound into the signed state token.
+ */
+export function generateBrowserNonce(): string {
+  return randomBytes(16).toString('base64url');
+}
+
+/**
+ * Build a signed state token bound to the given per-browser nonce, from a fresh
+ * CSPRNG nonce and the current timestamp.
+ */
+export function generateState(browserNonce: string): string {
   const nonce = randomBytes(16).toString('base64url');
   const timestamp = Date.now().toString();
-  const payload = `${nonce}${SEPARATOR}${timestamp}`;
+  const payload = `${nonce}${SEPARATOR}${timestamp}${SEPARATOR}${browserNonce}`;
   const signature = sign(payload);
   const token = `${payload}${SEPARATOR}${signature}`;
   return Buffer.from(token, 'utf8').toString('base64url');
 }
 
 /**
- * Verify a state token's HMAC signature and freshness. Never throws; returns
- * false on any decode error, signature mismatch, malformed structure, or if the
- * embedded timestamp is older than maxAgeMs.
+ * Verify a state token's HMAC signature, freshness, and browser binding. Never
+ * throws; returns false on any decode error, signature mismatch, malformed
+ * structure, an expired timestamp, or a `browserNonce` that does not match the
+ * one signed into the token (the double-submit cookie check).
  */
-export function validateState(state: string, maxAgeMs: number = DEFAULT_MAX_AGE_MS): boolean {
+export function validateState(
+  state: string,
+  browserNonce: string,
+  maxAgeMs: number = DEFAULT_MAX_AGE_MS
+): boolean {
   try {
     if (typeof state !== 'string' || state.length === 0) {
+      return false;
+    }
+    // A missing/empty cookie nonce can never match a signed one; reject early so
+    // a stripped cookie cannot bypass the binding.
+    if (typeof browserNonce !== 'string' || browserNonce.length === 0) {
       return false;
     }
 
     const decoded = Buffer.from(state, 'base64url').toString('utf8');
     const parts = decoded.split(SEPARATOR);
-    if (parts.length !== 3) {
+    if (parts.length !== 4) {
       return false;
     }
 
-    const [nonce, timestamp, signature] = parts;
-    if (!nonce || !timestamp || !signature) {
+    const [nonce, timestamp, signedBrowserNonce, signature] = parts;
+    if (!nonce || !timestamp || !signedBrowserNonce || !signature) {
       return false;
     }
 
-    const expectedSignature = sign(`${nonce}${SEPARATOR}${timestamp}`);
-    const provided = Buffer.from(signature, 'utf8');
-    const expected = Buffer.from(expectedSignature, 'utf8');
-    if (provided.length !== expected.length || !timingSafeEqual(provided, expected)) {
+    const expectedSignature = sign(
+      `${nonce}${SEPARATOR}${timestamp}${SEPARATOR}${signedBrowserNonce}`
+    );
+    if (!constantTimeEqual(signature, expectedSignature)) {
+      return false;
+    }
+
+    // Double-submit cookie check: the nonce presented by the browser cookie must
+    // match the one bound into the signed token. Compared in constant time.
+    if (!constantTimeEqual(browserNonce, signedBrowserNonce)) {
       return false;
     }
 

--- a/apps/slack-oauth-backend/src/oauth/state.ts
+++ b/apps/slack-oauth-backend/src/oauth/state.ts
@@ -1,0 +1,77 @@
+import { createHmac, randomBytes, timingSafeEqual } from 'crypto';
+import { config } from '../config';
+
+/**
+ * Stateless, signed OAuth state tokens.
+ *
+ * The token is `nonce.timestamp.signature`, HMAC-SHA256 signed with
+ * `config.sessionSecret`, then base64url-encoded with no padding. This works on
+ * serverless (no shared store needed): /authorize signs the token and /callback
+ * verifies the signature, so a forged or replayed state is rejected without any
+ * cross-instance state. base64url (A-Za-z0-9-_) satisfies the callback
+ * validator's /^[a-zA-Z0-9_-]+$/ length 16..500 check.
+ */
+
+const DEFAULT_MAX_AGE_MS = 10 * 60 * 1000;
+const SEPARATOR = '.';
+
+function sign(payload: string): string {
+  return createHmac('sha256', config.sessionSecret).update(payload).digest('base64url');
+}
+
+/**
+ * Build a signed state token from a CSPRNG nonce and the current timestamp.
+ */
+export function generateState(): string {
+  const nonce = randomBytes(16).toString('base64url');
+  const timestamp = Date.now().toString();
+  const payload = `${nonce}${SEPARATOR}${timestamp}`;
+  const signature = sign(payload);
+  const token = `${payload}${SEPARATOR}${signature}`;
+  return Buffer.from(token, 'utf8').toString('base64url');
+}
+
+/**
+ * Verify a state token's HMAC signature and freshness. Never throws; returns
+ * false on any decode error, signature mismatch, malformed structure, or if the
+ * embedded timestamp is older than maxAgeMs.
+ */
+export function validateState(state: string, maxAgeMs: number = DEFAULT_MAX_AGE_MS): boolean {
+  try {
+    if (typeof state !== 'string' || state.length === 0) {
+      return false;
+    }
+
+    const decoded = Buffer.from(state, 'base64url').toString('utf8');
+    const parts = decoded.split(SEPARATOR);
+    if (parts.length !== 3) {
+      return false;
+    }
+
+    const [nonce, timestamp, signature] = parts;
+    if (!nonce || !timestamp || !signature) {
+      return false;
+    }
+
+    const expectedSignature = sign(`${nonce}${SEPARATOR}${timestamp}`);
+    const provided = Buffer.from(signature, 'utf8');
+    const expected = Buffer.from(expectedSignature, 'utf8');
+    if (provided.length !== expected.length || !timingSafeEqual(provided, expected)) {
+      return false;
+    }
+
+    const issuedAt = Number(timestamp);
+    if (!Number.isInteger(issuedAt) || issuedAt <= 0) {
+      return false;
+    }
+
+    const age = Date.now() - issuedAt;
+    if (age < 0 || age > maxAgeMs) {
+      return false;
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/slack-oauth-backend/src/routes/oauth.spec.ts
+++ b/apps/slack-oauth-backend/src/routes/oauth.spec.ts
@@ -1,0 +1,211 @@
+import request from 'supertest';
+import express from 'express';
+
+// Deterministic config so the real signed-state lib (not mocked) produces
+// verifiable tokens, and so cookies are not marked Secure under test.
+jest.mock('../config', () => ({
+  config: {
+    sessionSecret: 'test-session-secret-deterministic',
+    slackClientId: 'test-client-id',
+    slackClientSecret: 'test-client-secret',
+    slackRedirectUri: 'https://example.com/slack/oauth/callback',
+    // formatErrorPage / formatSuccessPage read config.notionDocUrl; omitting it
+    // makes escapeHtml(undefined) throw and surfaces as a 500.
+    notionDocUrl: 'https://notion.so/setup-docs',
+    nodeEnv: 'test',
+  },
+}));
+
+// Silence logging.
+jest.mock('../utils/logger', () => ({
+  logger: {
+    warn: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+    child: jest.fn().mockReturnThis(),
+  },
+}));
+
+// Avoid real Slack DM delivery on the success path.
+const mockSendDirectMessage = jest.fn().mockResolvedValue({ ok: true });
+jest.mock('../slack/client', () => ({
+  createSlackClient: jest.fn(() => ({
+    sendDirectMessage: mockSendDirectMessage,
+  })),
+}));
+
+// Mock only the rate limiter so repeated supertest requests from the same IP
+// don't trip express-rate-limit; keep the validation middleware real so the
+// route is exercised end-to-end.
+import type * as SecurityMiddleware from '../middleware/security';
+jest.mock('../middleware/security', () => {
+  const actual = jest.requireActual('../middleware/security') as typeof SecurityMiddleware;
+  return {
+    ...actual,
+    oauthRateLimiter: (_req: any, _res: any, next: any) => next(),
+  };
+});
+
+// Mock the Slack Web API used by the OAuth handler's code exchange.
+import { WebClient } from '@slack/web-api';
+jest.mock('@slack/web-api');
+
+const COOKIE_NAME = 'oauth_browser_nonce';
+
+const tokenExchangeResponse = {
+  ok: true,
+  access_token: 'xoxb-bot-token',
+  token_type: 'bot',
+  scope: 'chat:write,users:read',
+  team: { id: 'T123456', name: 'Test Team' },
+  authed_user: {
+    id: 'U123456',
+    scope: 'chat:write',
+    access_token: 'xoxp-user-token',
+    token_type: 'user',
+  },
+  bot_user_id: 'B123456',
+};
+
+const userInfoResponse = {
+  ok: true,
+  user: { id: 'U123456', name: 'testuser', team_id: 'T123456' },
+};
+
+function createTestApp(): express.Application {
+  const app = express();
+  // DISABLE_SECURITY-style minimal app: just the router under test.
+  jest.isolateModules(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const freshRouter = require('./oauth').default;
+    app.use('/slack/oauth', freshRouter);
+  });
+  // Surface any next(error) as a response instead of an opaque framework 500,
+  // so a real failure is visible in the assertion rather than masked.
+  app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    res.status(err.status || 500).json({ error: err.message });
+  });
+  return app;
+}
+
+/** Pull a named cookie's value out of a `set-cookie` header array. */
+function getSetCookie(setCookie: string[] | undefined, name: string): string | undefined {
+  if (!setCookie) {
+    return undefined;
+  }
+  const entry = setCookie.find((c) => c.startsWith(`${name}=`));
+  if (!entry) {
+    return undefined;
+  }
+  const valueAndAttrs = entry.slice(name.length + 1);
+  return valueAndAttrs.split(';')[0];
+}
+
+function getSetCookieRaw(setCookie: string[] | undefined, name: string): string | undefined {
+  return setCookie?.find((c) => c.startsWith(`${name}=`));
+}
+
+describe('OAuth routes — browser-bound state (double-submit cookie)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSendDirectMessage.mockResolvedValue({ ok: true });
+
+    (WebClient as jest.MockedClass<typeof WebClient>).mockImplementation(
+      () =>
+        ({
+          oauth: { v2: { access: jest.fn().mockResolvedValue(tokenExchangeResponse) } },
+          users: { info: jest.fn().mockResolvedValue(userInfoResponse) },
+        } as any)
+    );
+  });
+
+  describe('GET /authorize', () => {
+    it('redirects to Slack and sets an HttpOnly, SameSite=Lax browser-nonce cookie', async () => {
+      const app = createTestApp();
+      const res = await request(app).get('/slack/oauth/authorize').expect(302);
+
+      expect(res.headers['location']).toContain('https://slack.com/oauth/v2/authorize');
+
+      const rawCookie = getSetCookieRaw(
+        res.headers['set-cookie'] as unknown as string[],
+        COOKIE_NAME
+      );
+      expect(rawCookie).toBeDefined();
+      expect(rawCookie).toMatch(/HttpOnly/i);
+      expect(rawCookie).toMatch(/SameSite=Lax/i);
+      // Under nodeEnv=test the cookie must NOT be Secure (so local HTTP works).
+      expect(rawCookie).not.toMatch(/Secure/i);
+
+      const nonce = getSetCookie(res.headers['set-cookie'] as unknown as string[], COOKIE_NAME);
+      expect(nonce).toBeTruthy();
+    });
+  });
+
+  describe('GET /callback', () => {
+    // Drive a real /authorize first to obtain a genuinely-signed state plus the
+    // matching browser-nonce cookie, then replay them against /callback.
+    async function startFlow(app: express.Application) {
+      const res = await request(app).get('/slack/oauth/authorize').expect(302);
+      const setCookie = res.headers['set-cookie'] as unknown as string[];
+      const nonce = getSetCookie(setCookie, COOKIE_NAME) as string;
+      const location = res.headers['location'] as string;
+      const state = new URL(location).searchParams.get('state') as string;
+      return { nonce, state };
+    }
+
+    it('succeeds when the cookie nonce matches the signed state, and clears the cookie (one-time use)', async () => {
+      const app = createTestApp();
+      const { nonce, state } = await startFlow(app);
+
+      const res = await request(app)
+        .get('/slack/oauth/callback')
+        .query({ code: 'valid-auth-code', state })
+        .set('Cookie', `${COOKIE_NAME}=${nonce}`)
+        .expect(200);
+
+      // Success page rendered (not the error page).
+      expect(res.text).not.toContain('state_mismatch');
+
+      // Cookie is cleared on callback (one-time use): an expired Set-Cookie.
+      const cleared = getSetCookieRaw(
+        res.headers['set-cookie'] as unknown as string[],
+        COOKIE_NAME
+      );
+      expect(cleared).toBeDefined();
+      expect(cleared).toMatch(/Expires=Thu, 01 Jan 1970/i);
+    });
+
+    it('rejects a valid signed state replayed with a DIFFERENT browser cookie (CSRF)', async () => {
+      const app = createTestApp();
+      const { state } = await startFlow(app);
+
+      // Attacker has a genuine state but not the victim's cookie nonce.
+      const res = await request(app)
+        .get('/slack/oauth/callback')
+        .query({ code: 'valid-auth-code', state })
+        .set('Cookie', `${COOKIE_NAME}=attacker-controlled-nonce`)
+        .expect(400);
+
+      // The state_mismatch code renders the friendly error page.
+      expect(res.text).toContain('Authorization Failed');
+      expect(res.text).toContain('Security validation failed.');
+      // The code must never be exchanged when the binding check fails.
+      expect(mockSendDirectMessage).not.toHaveBeenCalled();
+    });
+
+    it('rejects a valid signed state replayed with NO cookie at all', async () => {
+      const app = createTestApp();
+      const { state } = await startFlow(app);
+
+      const res = await request(app)
+        .get('/slack/oauth/callback')
+        .query({ code: 'valid-auth-code', state })
+        .expect(400);
+
+      // The state_mismatch code renders the friendly error page.
+      expect(res.text).toContain('Authorization Failed');
+      expect(res.text).toContain('Security validation failed.');
+      expect(mockSendDirectMessage).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/slack-oauth-backend/src/routes/oauth.ts
+++ b/apps/slack-oauth-backend/src/routes/oauth.ts
@@ -119,7 +119,7 @@ router.get(
           Pragma: 'no-cache',
           Expires: '0',
         });
-        res.status(400).send(errorPage);
+        res.status(400).send(errorPage); // nosemgrep: javascript.express.security.audit.xss.direct-response-write.direct-response-write -- Safe: formatErrorPage escapes all user-controlled input via escapeHtml() (formatter.ts:462); semgrep cannot trace escaping across the function boundary.
         return;
       }
 
@@ -177,7 +177,7 @@ router.get(
         Pragma: 'no-cache',
         Expires: '0',
       });
-      res.send(successPage);
+      res.send(successPage); // nosemgrep: javascript.express.security.audit.xss.direct-response-write.direct-response-write -- Safe: formatSuccessPage escapes all user-controlled input via escapeHtml() (formatter.ts:253-256); semgrep cannot trace escaping across the function boundary.
     } catch (error) {
       requestLogger.error('OAuth callback error', error);
 
@@ -193,7 +193,7 @@ router.get(
           Pragma: 'no-cache',
           Expires: '0',
         });
-        res.status(400).send(errorPage);
+        res.status(400).send(errorPage); // nosemgrep: javascript.express.security.audit.xss.direct-response-write.direct-response-write -- Safe: formatErrorPage escapes all user-controlled input via escapeHtml() (formatter.ts:462); semgrep cannot trace escaping across the function boundary.
         return;
       }
 

--- a/apps/slack-oauth-backend/src/routes/oauth.ts
+++ b/apps/slack-oauth-backend/src/routes/oauth.ts
@@ -1,10 +1,17 @@
 import type { Request, Response, NextFunction } from 'express';
 import { Router } from 'express';
 import { createOAuthHandler } from '../oauth/handler';
-import { generateState, validateState } from '../oauth/state';
+import {
+  generateState,
+  validateState,
+  generateBrowserNonce,
+  OAUTH_STATE_COOKIE,
+} from '../oauth/state';
 import { createSlackClient } from '../slack/client';
 import { formatTokenMessage, formatSuccessPage, formatErrorPage } from '../messages/formatter';
 import { logger } from '../utils/logger';
+import { readCookie } from '../utils/cookies';
+import { config } from '../config';
 import { OAuthError, ValidationError } from '../utils/errors';
 import type { OAuthCallbackParams } from '../oauth/types';
 import {
@@ -14,6 +21,28 @@ import {
 } from '../middleware/security';
 
 const router = Router();
+
+const STATE_MAX_AGE_MS = 10 * 60 * 1000;
+
+/**
+ * Cookie options for the per-browser nonce that binds a state token to the
+ * browser that started the flow (double-submit cookie CSRF defense).
+ *
+ * - HttpOnly: not readable by page JS, so XSS cannot exfiltrate it.
+ * - SameSite=Lax: still sent on the top-level GET redirect back from Slack.
+ * - Secure: only in non-dev/test, mirroring the HTTPS enforcement in
+ *   middleware/security.ts so local HTTP testing still works.
+ * - path scoped to /slack/oauth: the cookie is only attached on OAuth routes.
+ *
+ * The same options (minus maxAge) must be passed to clearCookie for the browser
+ * to actually drop the cookie on /callback.
+ */
+const browserNonceCookieBaseOptions = {
+  httpOnly: true,
+  secure: config.nodeEnv !== 'development' && config.nodeEnv !== 'test',
+  sameSite: 'lax' as const,
+  path: '/slack/oauth',
+};
 
 /**
  * OAuth callback endpoint
@@ -55,9 +84,22 @@ router.get(
         throw new ValidationError('Missing authorization code', 'code');
       }
 
-      // Create OAuth handler with signed-state validation (CSRF protection)
+      // Read the per-browser nonce set by /authorize. Clearing it now (before
+      // any branch returns) enforces one-time use: a leaked state is useless on
+      // a second callback because the cookie is already gone.
+      const browserNonce = readCookie(req.headers.cookie, OAUTH_STATE_COOKIE);
+      res.clearCookie(OAUTH_STATE_COOKIE, browserNonceCookieBaseOptions);
+
+      // Create OAuth handler with signed-state validation (CSRF protection).
+      // The signed state must verify AND be bound to this browser's nonce
+      // (double-submit cookie), proving the callback browser is the one that
+      // started the flow.
       const oauthHandler = createOAuthHandler((state) => {
-        return typeof state === 'string' && validateState(state);
+        return (
+          typeof state === 'string' &&
+          typeof browserNonce === 'string' &&
+          validateState(state, browserNonce, STATE_MAX_AGE_MS)
+        );
       });
 
       // Handle OAuth callback
@@ -170,7 +212,18 @@ router.get(
   oauthRateLimiter,
   validateOAuthAuthorize,
   (_req: Request, res: Response) => {
-    const state = generateState();
+    // Bind this OAuth flow to the initiating browser: mint a per-browser nonce,
+    // sign it into the state token, AND set it in an HttpOnly cookie. /callback
+    // requires the cookie nonce to match the signed one (double-submit cookie),
+    // so a state minted here is useless to anyone who lacks this browser's
+    // cookie.
+    const browserNonce = generateBrowserNonce();
+    res.cookie(OAUTH_STATE_COOKIE, browserNonce, {
+      ...browserNonceCookieBaseOptions,
+      maxAge: STATE_MAX_AGE_MS,
+    });
+
+    const state = generateState(browserNonce);
     const oauthHandler = createOAuthHandler();
     const authUrl = oauthHandler.generateAuthUrl(state);
 

--- a/apps/slack-oauth-backend/src/routes/oauth.ts
+++ b/apps/slack-oauth-backend/src/routes/oauth.ts
@@ -1,6 +1,7 @@
 import type { Request, Response, NextFunction } from 'express';
 import { Router } from 'express';
 import { createOAuthHandler } from '../oauth/handler';
+import { generateState, validateState } from '../oauth/state';
 import { createSlackClient } from '../slack/client';
 import { formatTokenMessage, formatSuccessPage, formatErrorPage } from '../messages/formatter';
 import { logger } from '../utils/logger';
@@ -54,11 +55,9 @@ router.get(
         throw new ValidationError('Missing authorization code', 'code');
       }
 
-      // Create OAuth handler with state validation
+      // Create OAuth handler with signed-state validation (CSRF protection)
       const oauthHandler = createOAuthHandler((state) => {
-        // In production, validate state against session or database
-        // For now, just ensure it exists and has minimum length
-        return typeof state === 'string' && state.length >= 16;
+        return typeof state === 'string' && validateState(state);
       });
 
       // Handle OAuth callback
@@ -73,6 +72,11 @@ router.get(
         // Send error page
         const errorPage = formatErrorPage(result.errorCode || 'unknown', result.error);
 
+        res.set({
+          'Cache-Control': 'no-store, no-cache, must-revalidate, private',
+          Pragma: 'no-cache',
+          Expires: '0',
+        });
         res.status(400).send(errorPage);
         return;
       }
@@ -117,12 +121,20 @@ router.get(
       // Send success page with token displayed if DM failed
       // Generate refresh URL based on request host
       const refreshUrl = `${req.protocol}://${req.get('host')}/slack/refresh`;
+      // Never render the refresh token in HTML; the page can be cached by
+      // intermediaries. The access-token fallback display is the accepted
+      // compromise so the user can still copy a token if the DM failed.
       const successPage = formatSuccessPage(
         result.user?.name,
         dmSent ? undefined : result.accessToken,
-        dmSent ? undefined : result.refreshToken,
+        undefined,
         dmSent ? undefined : refreshUrl
       );
+      res.set({
+        'Cache-Control': 'no-store, no-cache, must-revalidate, private',
+        Pragma: 'no-cache',
+        Expires: '0',
+      });
       res.send(successPage);
     } catch (error) {
       requestLogger.error('OAuth callback error', error);
@@ -134,6 +146,11 @@ router.get(
           error.message
         );
 
+        res.set({
+          'Cache-Control': 'no-store, no-cache, must-revalidate, private',
+          Pragma: 'no-cache',
+          Expires: '0',
+        });
         res.status(400).send(errorPage);
         return;
       }
@@ -162,12 +179,5 @@ router.get(
     res.redirect(authUrl);
   }
 );
-
-/**
- * Generate a random state parameter
- */
-function generateState(): string {
-  return `state_${Date.now()}_${Math.random().toString(36).substring(2, 15)}`;
-}
 
 export default router;

--- a/apps/slack-oauth-backend/src/routes/oauth.ts
+++ b/apps/slack-oauth-backend/src/routes/oauth.ts
@@ -119,7 +119,7 @@ router.get(
           Pragma: 'no-cache',
           Expires: '0',
         });
-        res.status(400).send(errorPage); // nosemgrep: javascript.express.security.audit.xss.direct-response-write.direct-response-write -- Safe: formatErrorPage escapes all user-controlled input via escapeHtml() (formatter.ts:462); semgrep cannot trace escaping across the function boundary.
+        res.status(400).send(errorPage);
         return;
       }
 
@@ -177,7 +177,7 @@ router.get(
         Pragma: 'no-cache',
         Expires: '0',
       });
-      res.send(successPage); // nosemgrep: javascript.express.security.audit.xss.direct-response-write.direct-response-write -- Safe: formatSuccessPage escapes all user-controlled input via escapeHtml() (formatter.ts:253-256); semgrep cannot trace escaping across the function boundary.
+      res.send(successPage);
     } catch (error) {
       requestLogger.error('OAuth callback error', error);
 
@@ -193,7 +193,7 @@ router.get(
           Pragma: 'no-cache',
           Expires: '0',
         });
-        res.status(400).send(errorPage); // nosemgrep: javascript.express.security.audit.xss.direct-response-write.direct-response-write -- Safe: formatErrorPage escapes all user-controlled input via escapeHtml() (formatter.ts:462); semgrep cannot trace escaping across the function boundary.
+        res.status(400).send(errorPage);
         return;
       }
 
@@ -218,8 +218,14 @@ router.get(
     // so a state minted here is useless to anyone who lacks this browser's
     // cookie.
     const browserNonce = generateBrowserNonce();
+    // Cookie flags are inlined (not spread) so Semgrep's matcher can see
+    // secure/httpOnly/sameSite at the call site. These MUST stay in sync with
+    // browserNonceCookieBaseOptions, which clearCookie() below uses to clear it.
     res.cookie(OAUTH_STATE_COOKIE, browserNonce, {
-      ...browserNonceCookieBaseOptions,
+      httpOnly: true,
+      secure: config.nodeEnv !== 'development' && config.nodeEnv !== 'test',
+      sameSite: 'lax' as const,
+      path: '/slack/oauth',
       maxAge: STATE_MAX_AGE_MS,
     });
 

--- a/apps/slack-oauth-backend/src/routes/refresh.ts
+++ b/apps/slack-oauth-backend/src/routes/refresh.ts
@@ -14,7 +14,7 @@ const router = Router();
  */
 const refreshRateLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
-  max: 10, // limit each IP to 10 requests per minute
+  max: 5, // limit each IP to 5 requests per minute
   message: 'Too many token refresh attempts, please try again later.',
   standardHeaders: true,
   legacyHeaders: false,
@@ -96,8 +96,18 @@ const validateRefreshRequest = (req: Request, res: Response, next: NextFunction)
  * Token refresh endpoint
  * POST /slack/refresh
  *
- * Exchanges a refresh token for a new access token
- * This keeps the client secret server-side for security
+ * Exchanges a refresh token for a new access token, keeping the client secret
+ * server-side.
+ *
+ * Threat model: there is no per-caller auth here, and that is intentional. The
+ * refresh_token IS the bearer credential, so possessing it is the authorization.
+ * This flow is stateless and serverless (no shared session/cookie store across
+ * Vercel instances), so a per-caller session check cannot be added without new
+ * infra. Defense is layered instead: the client_secret never leaves the server,
+ * the endpoint is IP rate-limited, and the main token-leak vector (OAuth tokens
+ * in a cacheable HTML response) is closed by the callback's no-store headers and
+ * by never rendering the refresh token in HTML. The no-store header below keeps
+ * the JSON token response out of intermediary caches as well.
  */
 router.post(
   '/',
@@ -176,6 +186,10 @@ router.post(
       });
 
       // Return the new tokens
+      res.set({
+        'Cache-Control': 'no-store',
+        Pragma: 'no-cache',
+      });
       res.json({
         ok: true,
         access_token: accessToken,

--- a/apps/slack-oauth-backend/src/utils/cookies.spec.ts
+++ b/apps/slack-oauth-backend/src/utils/cookies.spec.ts
@@ -1,0 +1,37 @@
+import { readCookie } from './cookies';
+
+describe('readCookie', () => {
+  it('reads a single cookie value by name', () => {
+    expect(readCookie('oauth_browser_nonce=abc123', 'oauth_browser_nonce')).toBe('abc123');
+  });
+
+  it('reads the right value from a multi-cookie header', () => {
+    const header = 'foo=1; oauth_browser_nonce=abc123; bar=2';
+    expect(readCookie(header, 'oauth_browser_nonce')).toBe('abc123');
+  });
+
+  it('tolerates surrounding whitespace between cookies', () => {
+    expect(readCookie('a=1;   oauth_browser_nonce=xyz', 'oauth_browser_nonce')).toBe('xyz');
+  });
+
+  it('URL-decodes the value', () => {
+    expect(readCookie('n=a%2Bb%2Fc', 'n')).toBe('a+b/c');
+  });
+
+  it('falls back to the raw value on malformed encoding', () => {
+    expect(readCookie('n=%E0%A4%A', 'n')).toBe('%E0%A4%A');
+  });
+
+  it('returns undefined when the cookie is absent', () => {
+    expect(readCookie('foo=1; bar=2', 'oauth_browser_nonce')).toBeUndefined();
+  });
+
+  it('returns undefined for an undefined or empty header', () => {
+    expect(readCookie(undefined, 'n')).toBeUndefined();
+    expect(readCookie('', 'n')).toBeUndefined();
+  });
+
+  it('does not match a name that is only a substring of another cookie', () => {
+    expect(readCookie('oauth_browser_nonce_extra=zzz', 'oauth_browser_nonce')).toBeUndefined();
+  });
+});

--- a/apps/slack-oauth-backend/src/utils/cookies.ts
+++ b/apps/slack-oauth-backend/src/utils/cookies.ts
@@ -1,0 +1,43 @@
+/**
+ * Minimal request-cookie reader.
+ *
+ * Express's `res.cookie()` / `res.clearCookie()` need no middleware to WRITE
+ * cookies, but `req.cookies` is only populated by the `cookie-parser`
+ * middleware, which this app deliberately does not install. This helper parses
+ * the raw `Cookie` request header so we can read a single cookie value without
+ * pulling in an extra dependency.
+ */
+
+/**
+ * Read a single cookie value from a raw `Cookie` header string.
+ *
+ * Returns the decoded value of the first matching cookie, or `undefined` if the
+ * header is absent/empty or the name is not present. Values are
+ * `decodeURIComponent`-decoded; a malformed encoding falls back to the raw
+ * value rather than throwing.
+ */
+export function readCookie(cookieHeader: string | undefined, name: string): string | undefined {
+  if (typeof cookieHeader !== 'string' || cookieHeader.length === 0) {
+    return undefined;
+  }
+
+  const pairs = cookieHeader.split(';');
+  for (const pair of pairs) {
+    const eqIndex = pair.indexOf('=');
+    if (eqIndex === -1) {
+      continue;
+    }
+    const key = pair.slice(0, eqIndex).trim();
+    if (key !== name) {
+      continue;
+    }
+    const rawValue = pair.slice(eqIndex + 1).trim();
+    try {
+      return decodeURIComponent(rawValue);
+    } catch {
+      return rawValue;
+    }
+  }
+
+  return undefined;
+}

--- a/apps/slack-oauth-backend/tests/integration/oauth-flow.spec.ts
+++ b/apps/slack-oauth-backend/tests/integration/oauth-flow.spec.ts
@@ -3,7 +3,7 @@ import type { Express } from 'express';
 import express from 'express';
 import { WebClient } from '@slack/web-api';
 import oauthRouter from '../../src/routes/oauth';
-import { generateState } from '../../src/oauth/state';
+import { OAUTH_STATE_COOKIE } from '../../src/oauth/state';
 import { clearSlackCaches } from '../../src/slack/client';
 import type * as SecurityMiddleware from '../../src/middleware/security';
 
@@ -18,7 +18,9 @@ jest.mock('../../src/config', () => ({
     slackRedirectUri: 'https://example.com/callback',
     sessionSecret: 'test-session-secret-deterministic-32chars',
     notionDocUrl: 'https://notion.so/setup-docs',
-    environment: 'test',
+    // nodeEnv=test keeps the browser-nonce cookie non-Secure so supertest (HTTP)
+    // round-trips it; the route reads config.nodeEnv for the Secure flag.
+    nodeEnv: 'test',
   },
 }));
 
@@ -97,9 +99,22 @@ describe('OAuth Flow Integration Tests', () => {
     });
   });
 
+  /**
+   * Drive a real /authorize to obtain a genuinely-signed, browser-bound state
+   * plus the matching nonce cookie. The callback now requires the cookie nonce
+   * to match the one signed into the state (double-submit cookie CSRF defense),
+   * so tests must replay both together.
+   */
+  async function startFlow(): Promise<{ state: string; cookie: string }> {
+    const res = await request(app).get('/slack/oauth/authorize').expect(302);
+    const setCookie = res.headers['set-cookie'] as unknown as string[];
+    const nonceEntry = setCookie.find((c) => c.startsWith(`${OAUTH_STATE_COOKIE}=`)) as string;
+    const cookie = nonceEntry.split(';')[0];
+    const state = new URL(res.headers.location as string).searchParams.get('state') as string;
+    return { state, cookie };
+  }
+
   describe('GET /slack/oauth/callback - Success Flow', () => {
-    // A real HMAC-signed state, the only kind the callback now accepts.
-    const validState = generateState();
     const validCode = 'valid-auth-code';
 
     const mockTokenResponse = {
@@ -149,9 +164,10 @@ describe('OAuth Flow Integration Tests', () => {
     });
 
     it('should complete full OAuth flow successfully', async () => {
-      const response = await request(app).get('/slack/oauth/callback').query({
+      const { state, cookie } = await startFlow();
+      const response = await request(app).get('/slack/oauth/callback').set('Cookie', cookie).query({
         code: validCode,
-        state: validState,
+        state,
       });
 
       expect(response.status).toBe(200);
@@ -184,9 +200,10 @@ describe('OAuth Flow Integration Tests', () => {
         authed_user: undefined,
       });
 
-      const response = await request(app).get('/slack/oauth/callback').query({
+      const { state, cookie } = await startFlow();
+      const response = await request(app).get('/slack/oauth/callback').set('Cookie', cookie).query({
         code: validCode,
-        state: validState,
+        state,
       });
 
       expect(response.status).toBe(200);
@@ -201,9 +218,10 @@ describe('OAuth Flow Integration Tests', () => {
     it('should continue flow even if DM sending fails', async () => {
       mockConversationsOpen.mockRejectedValue(new Error('DM failed'));
 
-      const response = await request(app).get('/slack/oauth/callback').query({
+      const { state, cookie } = await startFlow();
+      const response = await request(app).get('/slack/oauth/callback').set('Cookie', cookie).query({
         code: validCode,
-        state: validState,
+        state,
       });
 
       // Should still return success page
@@ -217,14 +235,49 @@ describe('OAuth Flow Integration Tests', () => {
     it('should handle DM message posting failure gracefully', async () => {
       mockChatPostMessage.mockRejectedValue(new Error('Message post failed'));
 
-      const response = await request(app).get('/slack/oauth/callback').query({
+      const { state, cookie } = await startFlow();
+      const response = await request(app).get('/slack/oauth/callback').set('Cookie', cookie).query({
         code: validCode,
-        state: validState,
+        state,
       });
 
       // Should still return success page
       expect(response.status).toBe(200);
       expect(response.text).toContain('Success, testuser!');
+    });
+
+    it('rejects a genuine signed state replayed with a foreign browser cookie (CSRF)', async () => {
+      const { state } = await startFlow();
+
+      const response = await request(app)
+        .get('/slack/oauth/callback')
+        .set('Cookie', `${OAUTH_STATE_COOKIE}=attacker-controlled-nonce`)
+        .query({
+          code: validCode,
+          state,
+        });
+
+      expect(response.status).toBe(400);
+      // The state_mismatch error code renders as the friendly "Security
+      // validation failed." message on the Authorization Failed page.
+      expect(response.text).toContain('Authorization Failed');
+      expect(response.text).toContain('Security validation failed.');
+      // The authorization code must never be exchanged when binding fails.
+      expect(mockOAuthV2Access).not.toHaveBeenCalled();
+    });
+
+    it('rejects a genuine signed state replayed with no cookie (one-time-use / stripped cookie)', async () => {
+      const { state } = await startFlow();
+
+      const response = await request(app).get('/slack/oauth/callback').query({
+        code: validCode,
+        state,
+      });
+
+      expect(response.status).toBe(400);
+      expect(response.text).toContain('Authorization Failed');
+      expect(response.text).toContain('Security validation failed.');
+      expect(mockOAuthV2Access).not.toHaveBeenCalled();
     });
   });
 
@@ -271,9 +324,10 @@ describe('OAuth Flow Integration Tests', () => {
         error: 'invalid_code',
       });
 
-      const response = await request(app).get('/slack/oauth/callback').query({
+      const { state, cookie } = await startFlow();
+      const response = await request(app).get('/slack/oauth/callback').set('Cookie', cookie).query({
         code: 'invalid-code',
-        state: generateState(),
+        state,
       });
 
       expect(response.status).toBe(400);
@@ -283,9 +337,10 @@ describe('OAuth Flow Integration Tests', () => {
     it('should handle network errors during token exchange', async () => {
       mockOAuthV2Access.mockRejectedValue(new Error('Network timeout'));
 
-      const response = await request(app).get('/slack/oauth/callback').query({
+      const { state, cookie } = await startFlow();
+      const response = await request(app).get('/slack/oauth/callback').set('Cookie', cookie).query({
         code: 'valid-code',
-        state: generateState(),
+        state,
       });
 
       expect(response.status).toBe(400);
@@ -369,9 +424,10 @@ describe('OAuth Flow Integration Tests', () => {
         ts: '9999999999.999999',
       });
 
-      const response = await request(app).get('/slack/oauth/callback').query({
+      const { state, cookie } = await startFlow();
+      const response = await request(app).get('/slack/oauth/callback').set('Cookie', cookie).query({
         code: 'complete-auth-code',
-        state: generateState(),
+        state,
       });
 
       expect(response.status).toBe(200);
@@ -413,9 +469,10 @@ describe('OAuth Flow Integration Tests', () => {
         ts: '7777777777.777777',
       });
 
-      const response = await request(app).get('/slack/oauth/callback').query({
+      const { state, cookie } = await startFlow();
+      const response = await request(app).get('/slack/oauth/callback').set('Cookie', cookie).query({
         code: 'partial-auth-code',
-        state: generateState(),
+        state,
       });
 
       // Should still succeed overall

--- a/apps/slack-oauth-backend/tests/integration/oauth-flow.spec.ts
+++ b/apps/slack-oauth-backend/tests/integration/oauth-flow.spec.ts
@@ -3,6 +3,7 @@ import type { Express } from 'express';
 import express from 'express';
 import { WebClient } from '@slack/web-api';
 import oauthRouter from '../../src/routes/oauth';
+import { generateState } from '../../src/oauth/state';
 import { clearSlackCaches } from '../../src/slack/client';
 import type * as SecurityMiddleware from '../../src/middleware/security';
 
@@ -15,6 +16,7 @@ jest.mock('../../src/config', () => ({
     slackClientId: 'test-client-id',
     slackClientSecret: 'test-client-secret',
     slackRedirectUri: 'https://example.com/callback',
+    sessionSecret: 'test-session-secret-deterministic-32chars',
     notionDocUrl: 'https://notion.so/setup-docs',
     environment: 'test',
   },
@@ -96,7 +98,8 @@ describe('OAuth Flow Integration Tests', () => {
   });
 
   describe('GET /slack/oauth/callback - Success Flow', () => {
-    const validState = '1234567890123456789';
+    // A real HMAC-signed state, the only kind the callback now accepts.
+    const validState = generateState();
     const validCode = 'valid-auth-code';
 
     const mockTokenResponse = {
@@ -270,7 +273,7 @@ describe('OAuth Flow Integration Tests', () => {
 
       const response = await request(app).get('/slack/oauth/callback').query({
         code: 'invalid-code',
-        state: '1234567890123456',
+        state: generateState(),
       });
 
       expect(response.status).toBe(400);
@@ -282,7 +285,7 @@ describe('OAuth Flow Integration Tests', () => {
 
       const response = await request(app).get('/slack/oauth/callback').query({
         code: 'valid-code',
-        state: '1234567890123456',
+        state: generateState(),
       });
 
       expect(response.status).toBe(400);
@@ -309,7 +312,9 @@ describe('OAuth Flow Integration Tests', () => {
       expect(response.headers.location).toContain(
         'redirect_uri=https%3A%2F%2Fexample.com%2Fcallback'
       );
-      expect(response.headers.location).toContain('state=state_');
+      // State is now an HMAC-signed base64url token (A-Za-z0-9-_), not the old
+      // predictable `state_<ts>_<rand>` format.
+      expect(response.headers.location).toMatch(/state=[A-Za-z0-9_-]{16,}/);
     });
   });
 
@@ -366,7 +371,7 @@ describe('OAuth Flow Integration Tests', () => {
 
       const response = await request(app).get('/slack/oauth/callback').query({
         code: 'complete-auth-code',
-        state: 'complete_state_1234567890',
+        state: generateState(),
       });
 
       expect(response.status).toBe(200);
@@ -410,7 +415,7 @@ describe('OAuth Flow Integration Tests', () => {
 
       const response = await request(app).get('/slack/oauth/callback').query({
         code: 'partial-auth-code',
-        state: 'partial_state_1234567890',
+        state: generateState(),
       });
 
       // Should still succeed overall

--- a/packages/ai-toolkit-nx-claude/scripts/reset-prerelease-version.sh
+++ b/packages/ai-toolkit-nx-claude/scripts/reset-prerelease-version.sh
@@ -3,6 +3,15 @@
 # Script to reset version for prerelease on next branch
 # This helps fix the issue where next branch has same version as latest
 
+# Source numeric validation helper to guard values that flow into bash arithmetic
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VALIDATE_NUMERIC_LIB="$SCRIPT_DIR/../../../.github/scripts/validate-numeric.sh"
+if [[ ! -f "$VALIDATE_NUMERIC_LIB" ]]; then
+    echo "❌ Required helper not found: $VALIDATE_NUMERIC_LIB" >&2
+    exit 1
+fi
+source "$VALIDATE_NUMERIC_LIB"
+
 PACKAGE_NAME="@uniswap/ai-toolkit-nx-claude"
 CURRENT_VERSION=$(jq -r '.version' packages/ai-toolkit-nx-claude/package.json)
 
@@ -43,6 +52,7 @@ fi
 # Determine target version for next branch
 if [[ "$MAJOR.$MINOR.$PATCH" == "$LATEST_MAJOR.$LATEST_MINOR.$LATEST_PATCH" ]]; then
     # Same version, need to bump for next
+    MINOR=$(validate_numeric "$MINOR" "minor") || exit 1
     NEW_MINOR=$((MINOR + 1))
     TARGET_VERSION="$MAJOR.$NEW_MINOR.0"
 else
@@ -59,6 +69,7 @@ if [[ -n "$EXISTING_PRERELEASES" ]]; then
     # Extract the prerelease number if it matches our target
     if [[ "$EXISTING_PRERELEASES" == "$TARGET_VERSION-next."* ]]; then
         PRERELEASE_NUM=${EXISTING_PRERELEASES##*-next.}
+        PRERELEASE_NUM=$(validate_numeric "$PRERELEASE_NUM" "prerelease number") || exit 1
         NEXT_PRERELEASE=$((PRERELEASE_NUM + 1))
     else
         NEXT_PRERELEASE=0

--- a/packages/ai-toolkit-nx-claude/src/scripts/claude-plus/slack-setup.ts
+++ b/packages/ai-toolkit-nx-claude/src/scripts/claude-plus/slack-setup.ts
@@ -21,6 +21,17 @@ interface SlackCredentials {
 }
 
 /**
+ * Wrap a value in single quotes for safe interpolation into a sourced bash file.
+ *
+ * Single-quoting makes `$`, backticks, `"`, and `\` all literal/inert when the
+ * file is sourced. Embedded single quotes are handled with the POSIX idiom:
+ * close the quote, emit an escaped quote, then reopen. e.g. `a'b` -> `'a'\''b'`.
+ */
+export function shSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
  * Create a readline interface for user input
  */
 function createReadlineInterface(): readline.Interface {
@@ -129,8 +140,8 @@ function createSlackEnvFile(credentials: SlackCredentials): void {
 #
 # Or set these as environment variables in your shell profile.
 
-export SLACK_REFRESH_URL="${credentials.refreshUrl}"
-export SLACK_REFRESH_TOKEN="${credentials.refreshToken}"
+export SLACK_REFRESH_URL=${shSingleQuote(credentials.refreshUrl)}
+export SLACK_REFRESH_TOKEN=${shSingleQuote(credentials.refreshToken)}
 `;
 
   // Write file with restricted permissions

--- a/packages/ai-toolkit-nx-claude/src/scripts/claude-plus/slack-token.ts
+++ b/packages/ai-toolkit-nx-claude/src/scripts/claude-plus/slack-token.ts
@@ -11,7 +11,7 @@ import * as https from 'https';
 import * as http from 'http';
 import * as os from 'os';
 import { displaySuccess, displayWarning, displayDebug, displayInfo } from './display';
-import { offerSlackSetup } from './slack-setup';
+import { offerSlackSetup, shSingleQuote } from './slack-setup';
 import {
   getClaudeConfigDir,
   getClaudeConfigPath,
@@ -297,11 +297,10 @@ function updateRefreshToken(newRefreshToken: string, verbose?: boolean): void {
 
   let content = fs.readFileSync(SLACK_ENV_PATH, 'utf-8');
 
-  // Replace the refresh token line
-  content = content.replace(
-    /export SLACK_REFRESH_TOKEN=.*/,
-    `export SLACK_REFRESH_TOKEN="${newRefreshToken}"`
-  );
+  // Replace the refresh token line. Use a replacement FUNCTION (not a string) so
+  // String.prototype.replace does not treat `$` in the token specially ($&, $1, $$).
+  const newLine = `export SLACK_REFRESH_TOKEN=${shSingleQuote(newRefreshToken)}`;
+  content = content.replace(/export SLACK_REFRESH_TOKEN=.*/, () => newLine);
 
   fs.writeFileSync(SLACK_ENV_PATH, content);
   displayDebug('Refresh token updated successfully', verbose);


### PR DESCRIPTION
## Summary

Closes 6 of the 7 open security-scan findings (dated 2026-03-28) against `next`. Finding #7 (static heredoc delimiter) was already fixed by [#509](https://github.com/Uniswap/ai-toolkit/pull/509), so this PR covers the remaining six.

Implemented and adversarially verified via a parallel agent workflow (3 domain implementers + 6 per-finding verifiers), then a code-reviewer pass on the diff.

### Slack OAuth backend (`apps/slack-oauth-backend`)

| # | Sev | Fix |
|---|-----|-----|
| 1 | HIGH | **OAuth CSRF.** Replaced the length-only state check with a stateless **HMAC-SHA256 signed state token** (new `src/oauth/state.ts`). `generateState()` signs a CSPRNG nonce + timestamp with `config.sessionSecret` and base64url-encodes it; `validateState()` recomputes the HMAC with `timingSafeEqual` and a 10-min freshness window. Forged/unsigned/tampered/expired states are rejected. |
| 2 | MED | **Weak randomness.** Nonce now from `crypto.randomBytes(16)` instead of `Math.random()`/`Date.now()`. |
| 3 | MED | **Tokens in cacheable HTML.** `Cache-Control: no-store` (+ `no-cache`/`Pragma`/`Expires`) on all token-bearing `/callback` responses and the `/refresh` JSON; the refresh token is no longer rendered in the HTML fallback. |
| 6 | MED | **Unauthenticated `/slack/refresh`.** Proportionate hardening: rate limit 10 → 5/min, `no-store` header, documented threat model. |

**Why HMAC-signed state, not a server-side store (as the scan suggested):** the backend runs on Vercel serverless, where in-process memory is not shared across invocations/instances. A `MemoryCache` would mean `/authorize` and `/callback` hit different instances and every legitimate flow would miss the cache. HMAC signing with the existing `sessionSecret` blocks forgery with no store. base64url output satisfies the existing `validateOAuthCallback` regex (`/^[a-zA-Z0-9_-]+$/`, length 16..500).

**Why #6 keeps the token relay unauthenticated:** the `refresh_token` *is* the bearer credential in this stateless flow; per-caller auth can't be added without new session infra, and the real leak vector (a refresh token in cacheable HTML) is closed by #3. The hardening reduces the abuse surface without pretending the security boundary changed.

### nx-claude scripts (`packages/ai-toolkit-nx-claude`)

| # | Sev | Fix |
|---|-----|-----|
| 4 | MED | **Bash arithmetic command injection** in `reset-prerelease-version.sh`. Sources the existing-but-unused `.github/scripts/validate-numeric.sh` and validates registry-derived values (`^[0-9]+$`) before `$((...))`. Payload `1.1.0-next.a[$(...)]` is now rejected. |
| 5 | MED | **Shell injection** in the generated `slack-env.sh`. New `shSingleQuote()` POSIX single-quote escaping in `createSlackEnvFile`; `updateRefreshToken` also switches `String.replace` to a replacement **function** to neutralize `$`-substitution corruption on tokens containing `$`. |

## Test plan

- `nx test slack-oauth-backend` → **83/83 pass.** New `state.spec.ts` covers fresh/tampered/expired/empty/malformed tokens; the integration suite was updated to mint real signed states via `generateState()` (the old hardcoded unsigned states correctly 400 now).
- `nx run-many -t typecheck lint -p slack-oauth-backend ai-toolkit-nx-claude` → clean (0 errors; pre-existing `no-explicit-any` warnings only).
- **#4** functionally verified: injection payload rejected, no command execution; clean value passes.
- **#5** functionally verified: `$(...)`, backticks, `$HOME`, and a single-quote breakout all inert when sourced (bash); benign `xoxe-1-…` token round-trips verbatim.
- Code-reviewer pass on the diff: **READY TO MERGE**.

## Notes

- No `CLAUDE.md`/version changes: the nx-claude edits are internal hardening (no API change) and the package is not under `packages/plugins/`, so the mandatory plugin-version-bump rule does not apply.
- Out of scope (noted by verifiers): enforcing a minimum `SESSION_SECRET` entropy at boot, and the `loadSlackConfig` parser's single-quote truncation (benign for real `xoxe-` tokens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Closes 6 of the 7 open security-scan findings (dated 2026-03-28) against `next`. Finding #7 (static heredoc delimiter) was already fixed by [#509](https://github.com/Uniswap/ai-toolkit/pull/509), so this PR covers the remaining six.
Implemented and adversarially verified via a parallel agent workflow (3 domain implementers + 6 per-finding verifiers), then a code-reviewer pass on the diff.
### Slack OAuth backend (`apps/slack-oauth-backend`)
| # | Sev | Fix |
|---|-----|-----|
| 1 | HIGH | **OAuth CSRF.** Replaced the length-only state check with a stateless **HMAC-SHA256 signed state token** (new `src/oauth/state.ts`). `generateState()` signs a CSPRNG nonce + timestamp with `config.sessionSecret` and base64url-encodes it; `validateState()` recomputes the HMAC with `timingSafeEqual` and a 10-min freshness window. Forged/unsigned/tampered/expired states are rejected. |
| 2 | MED | **Weak randomness.** Nonce now from `crypto.randomBytes(16)` instead of `Math.random()`/`Date.now()`. |
| 3 | MED | **Tokens in cacheable HTML.** `Cache-Control: no-store` (+ `no-cache`/`Pragma`/`Expires`) on all token-bearing `/callback` responses and the `/refresh` JSON; the refresh token is no longer rendered in the HTML fallback. |
| 6 | MED | **Unauthenticated `/slack/refresh`.** Proportionate hardening: rate limit 10 → 5/min, `no-store` header, documented threat model. |
**Why HMAC-signed state, not a server-side store (as the scan suggested):** the backend runs on Vercel serverless, where in-process memory is not shared across invocations/instances. A `MemoryCache` would mean `/authorize` and `/callback` hit different instances and every legitimate flow would miss the cache. HMAC signing with the existing `sessionSecret` blocks forgery with no store. base64url output satisfies the existing `validateOAuthCallback` regex (`/^[a-zA-Z0-9_-]+$/`, length 16..500).
**Why #6 keeps the token relay unauthenticated:** the `refresh_token` *is* the bearer credential in this stateless flow; per-caller auth can't be added without new session infra, and the real leak vector (a refresh token in cacheable HTML) is closed by #3. The hardening reduces the abuse surface without pretending the security boundary changed.
### nx-claude scripts (`packages/ai-toolkit-nx-claude`)
| # | Sev | Fix |
|---|-----|-----|
| 4 | MED | **Bash arithmetic command injection** in `reset-prerelease-version.sh`. Sources the existing-but-unused `.github/scripts/validate-numeric.sh` and validates registry-derived values (`^[0-9]+$`) before `$((...))`. Payload `1.1.0-next.a[$(...)]` is now rejected. |
| 5 | MED | **Shell injection** in the generated `slack-env.sh`. New `shSingleQuote()` POSIX single-quote escaping in `createSlackEnvFile`; `updateRefreshToken` also switches `String.replace` to a replacement **function** to neutralize `$`-substitution corruption on tokens containing `$`. |
## Test plan
- `nx test slack-oauth-backend` → **83/83 pass.** New `state.spec.ts` covers fresh/tampered/expired/empty/malformed tokens; the integration suite was updated to mint real signed states via `generateState()` (the old hardcoded unsigned states correctly 400 now).
- `nx run-many -t typecheck lint -p slack-oauth-backend ai-toolkit-nx-claude` → clean (0 errors; pre-existing `no-explicit-any` warnings only).
- **#4** functionally verified: injection payload rejected, no command execution; clean value passes.
- **#5** functionally verified: `$(...)`, backticks, `$HOME`, and a single-quote breakout all inert when sourced (bash); benign `xoxe-1-…` token round-trips verbatim.
- Code-reviewer pass on the diff: **READY TO MERGE**.
## Notes
- No `CLAUDE.md`/version changes: the nx-claude edits are internal hardening (no API change) and the package is not under `packages/plugins/`, so the mandatory plugin-version-bump rule does not apply.
- Out of scope (noted by verifiers): enforcing a minimum `SESSION_SECRET` entropy at boot, and the `loadSlackConfig` parser's single-quote truncation (benign for real `xoxe-` tokens).

</details>
<!-- claude-pr-description-end -->