### PR TITLE
chore(plugins): update model references to claude-opus-4-8

### DIFF
--- a/.github/REUSABLE_WORKFLOWS.md
+++ b/.github/REUSABLE_WORKFLOWS.md
@@ -218,7 +218,7 @@ Notify Release (_notify-release.yml)
 
 | Input                           | Required | Default                          | Description                                                                        |
 | ------------------------------- | -------- | -------------------------------- | ---------------------------------------------------------------------------------- |
-| `model`                         | No       | `'claude-sonnet-4-6'`            | Claude model to use (Sonnet 4.6, Opus 4.7, or Haiku 4.5)                           |
+| `model`                         | No       | `'claude-sonnet-4-6'`            | Claude model to use (Sonnet 4.6, Opus 4.8, or Haiku 4.5)                           |
 | `allowed_tools`                 | No       | (permissive defaults, see below) | YAML string specifying which tools Claude can use (file operations, bash commands) |
 | `custom_instructions`           | No       | `'Be sure to follow rules...'`   | Additional instructions for Claude beyond CLAUDE.md files                          |
 | `timeout_minutes`               | No       | `'10'`                           | Maximum execution time in minutes (prevents runaway costs)                         |
@@ -282,7 +282,7 @@ The following settings are intentionally fixed to ensure consistent security and
 
 - **Interactive AI Assistance**: Respond to `@claude` mentions anywhere in GitHub
 - **Multiple Trigger Points**: Works in issue comments, PR comments, review comments, and reviews
-- **Configurable Model**: Choose between Sonnet 4.6 (balanced), Opus 4.7 (thorough), or Haiku 4.5 (fast)
+- **Configurable Model**: Choose between Sonnet 4.6 (balanced), Opus 4.8 (thorough), or Haiku 4.5 (fast)
 - **Flexible Tool Permissions**: Control what Claude can do (read-only, read-write, or custom)
 - **Custom Instructions**: Add repository-specific guidelines and standards
 - **Bot Filtering**: Automatically excludes bot comments to prevent loops
@@ -334,7 +334,7 @@ jobs:
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     with:
-      model: 'claude-opus-4-7'
+      model: 'claude-opus-4-8'
       timeout_minutes: '15' # Opus may need more time
 ```
 
@@ -423,7 +423,7 @@ jobs:
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     with:
-      model: 'claude-opus-4-7'
+      model: 'claude-opus-4-8'
       timeout_minutes: '15'
 ```
 
@@ -546,7 +546,7 @@ Claude says it doesn't have permission to perform action
 2. **Choose the Right Model**:
 
    - **Sonnet 4.6** (default): Best balance of speed, capability, and cost for 90% of use cases
-   - **Opus 4.7**: Reserve for complex architectural reviews or critical security analysis
+   - **Opus 4.8**: Reserve for complex architectural reviews or critical security analysis
    - **Haiku 4.5**: Fast and cost-effective for simple questions, quick lookups, or high-volume usage
 
 3. **Set Appropriate Timeouts**:
@@ -619,7 +619,7 @@ jobs:
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     with:
-      model: 'claude-opus-4-7'
+      model: 'claude-opus-4-8'
       timeout_minutes: '15'
 ```
 
@@ -640,7 +640,7 @@ claude-deep:
     contains(github.event.pull_request.labels.*.name, 'deep-analysis') &&
     # ... (rest of if condition)
   with:
-    model: 'claude-opus-4-7'
+    model: 'claude-opus-4-8'
 ```
 
 #### Integration with Other Workflows
@@ -691,7 +691,7 @@ Tips for managing Claude API costs effectively:
 
    - Haiku 4.5: Most cost-effective for simple tasks
    - Sonnet 4.6: ~$3 per 1M input tokens, ~$15 per 1M output tokens (default, recommended)
-   - Opus 4.7: ~$5 per 1M input tokens, ~$25 per 1M output tokens (reserve for complex tasks)
+   - Opus 4.8: ~$5 per 1M input tokens, ~$25 per 1M output tokens (reserve for complex tasks)
    - Typical interaction: 5K-50K tokens (mostly input)
 
 2. **Timeout Strategy**:
@@ -1117,7 +1117,7 @@ jobs:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
       # Use Opus for PRs with 'claude-opus' label, otherwise Sonnet
-      model: ${{ contains(github.event.pull_request.labels.*.name, 'claude-opus') && 'claude-opus-4-7' || 'claude-sonnet-4-6' }}
+      model: ${{ contains(github.event.pull_request.labels.*.name, 'claude-opus') && 'claude-opus-4-8' || 'claude-sonnet-4-6' }}
       max_turns: 20 # Allow more turns for thorough Opus reviews
       timeout_minutes: 45 # Longer timeout for complex reviews
     secrets:
@@ -1501,7 +1501,7 @@ Claude submitted multiple reviews instead of updating one
 2. **Model Selection**:
 
    - **Sonnet 4.6** (default): Best balance for most PRs (~80% of use cases)
-   - **Opus 4.7**: Reserve for critical code, security-sensitive changes, or complex architectures
+   - **Opus 4.8**: Reserve for critical code, security-sensitive changes, or complex architectures
    - Use labels to let developers request deeper reviews when needed
 
 3. **Custom Prompts**:
@@ -1596,7 +1596,7 @@ jobs:
     with:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
-      model: 'claude-opus-4-7'
+      model: 'claude-opus-4-8'
       custom_prompt_path: '.github/prompts/security-review.md'
       timeout_minutes: 60
     secrets:

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -431,7 +431,7 @@ with:
   pr_number: ${{ github.event.pull_request.number }}
   base_ref: ${{ github.base_ref }}
   auto_fix: true # Enable automatic fixing of issues
-  auto_fix_model: 'claude-opus-4-7' # Use Opus for better fixes (optional)
+  auto_fix_model: 'claude-opus-4-8' # Use Opus for better fixes (optional)
 secrets:
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }} # Required for pushing fixes
@@ -638,7 +638,7 @@ uses: Uniswap/ai-toolkit/.github/workflows/_claude-docs-check.yml@main
 with:
   pr_number: ${{ github.event.pull_request.number }}
   auto_fix: true # Enable automatic fixing of documentation issues
-  auto_fix_model: 'claude-opus-4-7' # Use Opus for better fixes (optional)
+  auto_fix_model: 'claude-opus-4-8' # Use Opus for better fixes (optional)
 secrets:
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }} # Required for pushing fixes
@@ -950,7 +950,7 @@ If both are provided, OAuth token takes precedence. At least one authentication 
 
 | Input                     | Default           | Description                                     |
 | ------------------------- | ----------------- | ----------------------------------------------- |
-| `model`                   | `claude-opus-4-7` | Claude model to use                             |
+| `model`                   | `claude-opus-4-8` | Claude model to use                             |
 | `max_turns`               | `150`             | Maximum conversation turns                      |
 | `debug_mode`              | `true`            | Show full Claude output                         |
 | `timeout_minutes`         | `60`              | Job timeout                                     |
@@ -989,7 +989,7 @@ with:
   issue_url: ${{ matrix.issue_url }}
   branch_name: ${{ matrix.branch_name }}
   target_branch: 'next'
-  model: 'claude-opus-4-7'
+  model: 'claude-opus-4-8'
   debug_mode: true
   pr_type: 'draft' # or 'published' for non-draft PRs
 secrets:
@@ -1009,7 +1009,7 @@ with:
   issue_url: ${{ matrix.issue_url }}
   branch_name: ${{ matrix.branch_name }}
   target_branch: 'next'
-  model: 'claude-opus-4-7'
+  model: 'claude-opus-4-8'
   debug_mode: true
   pr_type: 'draft'
 secrets:
@@ -1101,7 +1101,7 @@ gh workflow run update-action-versions.yml
 gh workflow run update-action-versions.yml -f dry_run=true
 
 # Use Opus model
-gh workflow run update-action-versions.yml -f model=claude-opus-4-7
+gh workflow run update-action-versions.yml -f model=claude-opus-4-8
 ```
 
 **Usage example (API Key):**
@@ -1237,7 +1237,7 @@ gh workflow run dev-ai-newsletter.yml -f dry_run=true
 gh workflow run dev-ai-newsletter.yml -f days_back=14
 
 # Use Opus model for better quality
-gh workflow run dev-ai-newsletter.yml -f model=claude-opus-4-7
+gh workflow run dev-ai-newsletter.yml -f model=claude-opus-4-8
 
 # Post to specific Slack channels
 gh workflow run dev-ai-newsletter.yml -f slack_post_channel_ids="C091XE1DNP2,C094URH6C13"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -75,7 +75,7 @@ Workflows designed to be called by other workflows using `workflow_call`. These 
 
   - Interactive AI assistance via @claude mentions
   - Works in issue comments, PR comments, review comments, and reviews
-  - Configurable models (Sonnet 4.6, Opus 4.7, Haiku 4.5)
+  - Configurable models (Sonnet 4.6, Opus 4.8, Haiku 4.5)
   - Flexible tool permissions (read-only, read-write, or custom)
   - Custom instructions for repository-specific standards
   - Fixed security settings (Bullfrog scanning, immutable permissions)

--- a/.github/workflows/claude-auto-tasks.yml
+++ b/.github/workflows/claude-auto-tasks.yml
@@ -53,9 +53,9 @@ on:
         type: choice
         options:
           - "claude-sonnet-4-6"
-          - "claude-opus-4-7"
+          - "claude-opus-4-8"
           - "claude-haiku-4-5"
-        default: "claude-opus-4-7"
+        default: "claude-opus-4-8"
 
       target_branch:
         description: "Branch to create PRs against"
@@ -124,7 +124,7 @@ jobs:
       issue_url: ${{ matrix.issue_url }}
       branch_name: ${{ matrix.branch_name }}
       target_branch: ${{ inputs.target_branch || 'next' }}
-      model: ${{ inputs.model || 'claude-opus-4-7' }}
+      model: ${{ inputs.model || 'claude-opus-4-8' }}
       timeout_minutes: 60
       linear_task_utils_tag: ${{ needs.prepare.outputs.linear_task_utils_tag }}
       debug_mode: ${{ inputs.debug_mode != '' && inputs.debug_mode || true }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -227,12 +227,12 @@ jobs:
       force_review: false
       max_diff_lines: ${{ fromJSON(vars.MAX_DIFF_LINES) }}
 
-      # Use Opus 4.7 for comprehensive reviews with reliable inline comments
+      # Use Opus 4.8 for comprehensive reviews with reliable inline comments
       # Opus is more capable at following complex multi-step instructions
       # Uncomment one of these to use a different model for reviews:
       # model: 'claude-haiku-4-5'
       # model: 'claude-sonnet-4-6'
-      model: "claude-opus-4-7"
+      model: "claude-opus-4-8"
 
       # Allow standard review conversation turns
       # max_turns: 15
@@ -290,8 +290,8 @@ jobs:
       force_review: ${{ inputs.force_review }}
       max_diff_lines: ${{ fromJSON(vars.MAX_DIFF_LINES) }}
 
-      # Use Opus 4.7 for comprehensive reviews with reliable inline comments
-      model: "claude-opus-4-7"
+      # Use Opus 4.8 for comprehensive reviews with reliable inline comments
+      model: "claude-opus-4-8"
 
       # Standard timeout for most PRs
       timeout_minutes: 20
@@ -323,8 +323,8 @@ jobs:
       force_review: true # Always force when triggered by comment
       max_diff_lines: ${{ fromJSON(vars.MAX_DIFF_LINES) }}
 
-      # Use Opus 4.7 for comprehensive reviews with reliable inline comments
-      model: "claude-opus-4-7"
+      # Use Opus 4.8 for comprehensive reviews with reliable inline comments
+      model: "claude-opus-4-8"
 
       # Standard timeout for most PRs
       timeout_minutes: 20

--- a/.github/workflows/examples/06-claude-main-basic.yml
+++ b/.github/workflows/examples/06-claude-main-basic.yml
@@ -92,7 +92,7 @@ jobs:
 #     secrets:
 #       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 #     with:
-#       model: 'claude-opus-4-7'  # More capable, slower, higher cost
+#       model: 'claude-opus-4-8'  # More capable, slower, higher cost
 #       timeout_minutes: '15'  # Opus may need more time
 #
 # -------------------
@@ -204,7 +204,7 @@ jobs:
 #     secrets:
 #       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 #     with:
-#       model: 'claude-opus-4-7'
+#       model: 'claude-opus-4-8'
 #       timeout_minutes: '15'
 #
 

--- a/.github/workflows/examples/07-claude-main-custom.yml
+++ b/.github/workflows/examples/07-claude-main-custom.yml
@@ -48,9 +48,9 @@ jobs:
       # MODEL SELECTION
       # Choose the Claude model based on your needs:
       # - claude-sonnet-4-6: Latest, best balance (RECOMMENDED)
-      # - claude-opus-4-7: Most capable, slower, higher cost
+      # - claude-opus-4-8: Most capable, slower, higher cost
       # - claude-haiku-4-5: Fast, cost-effective for simpler tasks
-      model: "claude-opus-4-7"
+      model: "claude-opus-4-8"
 
       # TIMEOUT CONFIGURATION
       # Set maximum execution time in minutes
@@ -256,7 +256,7 @@ jobs:
 #     secrets:
 #       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 #     with:
-#       model: 'claude-opus-4-7'  # Thorough for code review
+#       model: 'claude-opus-4-8'  # Thorough for code review
 #       timeout_minutes: '15'
 #
 # -------------------
@@ -289,7 +289,7 @@ jobs:
 #     secrets:
 #       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 #     with:
-#       model: 'claude-opus-4-7'
+#       model: 'claude-opus-4-8'
 #       timeout_minutes: '30'
 #       custom_instructions: |
 #         Perform a comprehensive codebase audit focusing on:
@@ -368,7 +368,7 @@ jobs:
 # Solution:
 #   1. Verify model name exactly matches available models:
 #      - claude-sonnet-4-6
-#      - claude-opus-4-7
+#      - claude-opus-4-8
 #      - claude-haiku-4-5
 #   2. Check Anthropic API key has access to requested model
 #   3. Review Anthropic console for API limits or restrictions

--- a/.github/workflows/examples/10-claude-code-review-advanced.yml
+++ b/.github/workflows/examples/10-claude-code-review-advanced.yml
@@ -13,7 +13,7 @@ name: 'Example: Claude Code Review - Advanced'
 #
 # Model Selection:
 # - Default: Claude Sonnet 4.6 (fast, cost-effective)
-# - With 'claude-opus' label: Claude Opus 4.7 (more thorough, slower)
+# - With 'claude-opus' label: Claude Opus 4.8 (more thorough, slower)
 #
 # Use Cases:
 # - Large PRs that need more time
@@ -55,7 +55,7 @@ jobs:
 
       # Model selection based on PR labels
       # Add 'claude-opus' label to PRs that need more thorough review
-      model: ${{ contains(github.event.pull_request.labels.*.name, 'claude-opus') && 'claude-opus-4-7' || 'claude-sonnet-4-6' }}
+      model: ${{ contains(github.event.pull_request.labels.*.name, 'claude-opus') && 'claude-opus-4-8' || 'claude-sonnet-4-6' }}
 
       # Allow more turns for complex reviews
       # Default is 15, increase for PRs that need deeper analysis
@@ -95,7 +95,7 @@ jobs:
 #     with:
 #       pr_number: ${{ github.event.pull_request.number }}
 #       base_ref: ${{ github.base_ref }}
-#       model: 'claude-opus-4-7'  # Always use Opus for security
+#       model: 'claude-opus-4-8'  # Always use Opus for security
 #       custom_prompt_path: '.github/prompts/security-only-review.md'
 #     secrets:
 #       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/examples/11-autonomous-linear-tasks.yml
+++ b/.github/workflows/examples/11-autonomous-linear-tasks.yml
@@ -63,9 +63,9 @@ on:
         type: choice
         options:
           - "claude-sonnet-4-6" # Balanced (recommended)
-          - "claude-opus-4-7" # Most capable
+          - "claude-opus-4-8" # Most capable
           - "claude-haiku-4-5" # Fast & economical
-        default: "claude-opus-4-7"
+        default: "claude-opus-4-8"
 
       target_branch:
         description: "Branch to create PRs against"

--- a/.github/workflows/update-action-versions.yml
+++ b/.github/workflows/update-action-versions.yml
@@ -46,7 +46,7 @@ on:
         type: choice
         options:
           - 'claude-sonnet-4-6'
-          - 'claude-opus-4-7'
+          - 'claude-opus-4-8'
       target_branch:
         description: 'Base branch for the PR'
         required: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,9 +221,9 @@ All plugins follow semantic versioning (semver). Key versioning rules:
 
 | Plugin                     | Version |
 | -------------------------- | ------- |
-| claude-setup               | 1.0.4   |
-| development-codebase-tools | 2.6.0   |
-| development-planning       | 2.0.1   |
+| claude-setup               | 1.0.5   |
+| development-codebase-tools | 2.6.1   |
+| development-planning       | 2.0.7   |
 | development-pr-workflow    | 2.2.0   |
 | development-productivity   | 2.4.0   |
 | spec-workflow              | 2.0.1   |

--- a/docs/guides/autonomous-claude-tasks.md
+++ b/docs/guides/autonomous-claude-tasks.md
@@ -60,7 +60,7 @@ on:
         type: choice
         options:
           - 'claude-sonnet-4-6'
-          - 'claude-opus-4-7'
+          - 'claude-opus-4-8'
         default: 'claude-sonnet-4-6'
       target_branch:
         description: 'Branch to create PRs against'
@@ -143,7 +143,7 @@ See the full example at `.github/workflows/examples/11-autonomous-linear-tasks.y
 | Model               | Best For                                  |
 | ------------------- | ----------------------------------------- |
 | `claude-sonnet-4-6` | Balance of speed and capability (default) |
-| `claude-opus-4-7`   | Complex tasks requiring deep reasoning    |
+| `claude-opus-4-8`   | Complex tasks requiring deep reasoning    |
 | `claude-haiku-4-5`  | Simple tasks, cost optimization           |
 
 ## Creating Good Task Descriptions
@@ -213,7 +213,7 @@ Trigger manually from the GitHub Actions UI or CLI:
 gh workflow run claude-auto-tasks.yml \
   -f linear_team="Your Team" \
   -f max_issues="5" \
-  -f model="claude-opus-4-7"
+  -f model="claude-opus-4-8"
 ```
 
 ## Monitoring

--- a/packages/plugins/claude-setup/.claude-plugin/plugin.json
+++ b/packages/plugins/claude-setup/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-setup",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Interactive setup wizard for configuring any repository with Claude Code best practices, based on Boris Cherny's workflow",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/claude-setup/README.md
+++ b/packages/plugins/claude-setup/README.md
@@ -71,7 +71,7 @@ This plugin implements key practices from Boris Cherny (creator of Claude Code):
 - **Plan mode first** - Start complex tasks with planning
 - **Compounding learning** - Update CLAUDE.md when Claude makes mistakes
 - **Slash commands for inner loops** - Automate repetitive workflows
-- **Opus 4.7** - Use the best model for quality
+- **Opus 4.8** - Use the best model for quality
 
 See [references/boris-best-practices.md](skills/setup-repository/references/boris-best-practices.md) for full details.
 

--- a/packages/plugins/claude-setup/skills/setup-repository/references/boris-best-practices.md
+++ b/packages/plugins/claude-setup/skills/setup-repository/references/boris-best-practices.md
@@ -62,9 +62,9 @@ The key insight: Claude Code is powerful by default. The goal of configuration i
 - Use inline bash to pre-compute context (git status, etc.)
 - Reduces back-and-forth with the model
 
-### 5. Opus 4.7 (Most Capable)
+### 5. Opus 4.8 (Most Capable)
 
-> "The model choice is unambiguous: Opus 4.7 for everything."
+> "The model choice is unambiguous: Opus 4.8 for everything."
 
 **Rationale:**
 
@@ -135,7 +135,7 @@ Boris runs:
 | ------------------------------------ | ------------------------------------- |
 | `git add .`                          | Add files individually                |
 | Skip verification                    | Always verify before marking complete |
-| Use Sonnet for complex tasks         | Use Opus 4.7                          |
+| Use Sonnet for complex tasks         | Use Opus 4.8                          |
 | Skip plan mode                       | Start in plan mode, iterate on plan   |
 | Ignore mistakes                      | Add to CLAUDE.md immediately          |
 | Use `--dangerously-skip-permissions` | Use `/permissions` for pre-approval   |

--- a/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
+++ b/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-codebase-tools",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Codebase exploration, refactoring, and quality analysis",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/development-codebase-tools/agents/agent-orchestrator.md
+++ b/packages/plugins/development-codebase-tools/agents/agent-orchestrator.md
@@ -1,7 +1,7 @@
 ---
 name: agent-orchestrator-agent
 description: Use this agent when you need to coordinate multiple AI agents on a complex multi-step software development task. Trigger phrases include "implement this plan", "coordinate agents to", "orchestrate", "break this task into subtasks", "run agents in parallel". Decomposes tasks into atomic units, matches each to the right specialist agent, executes in parallel where possible, and aggregates results.
-model: claude-opus-4-7
+model: claude-opus-4-8
 tools: *
 ---
 

--- a/packages/plugins/development-codebase-tools/agents/refactorer.md
+++ b/packages/plugins/development-codebase-tools/agents/refactorer.md
@@ -1,7 +1,7 @@
 ---
 name: refactorer-agent
 description: Performs safe, incremental code refactoring with architectural analysis, SOLID principle enforcement, design pattern application, and performance optimization. Use when asked to refactor, improve code quality, reduce technical debt, apply design patterns, or modernize a codebase without changing behavior.
-model: claude-opus-4-7
+model: claude-opus-4-8
 tools:
   - Read
   - Edit

--- a/packages/plugins/development-codebase-tools/skills/refactor-code/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/refactor-code/SKILL.md
@@ -1,7 +1,7 @@
 ---
 description: Refactor code with safety checks and pattern application. Use when user says "refactor this code", "clean up this function", "simplify this logic", "extract this into a separate function", "apply the strategy pattern here", "reduce the complexity of this module", or "reorganize this file structure".
 allowed-tools: Read, Edit, Write, Grep, TodoWrite, Bash(git diff:*), Bash(git show:*), Task(subagent_type:refactorer-agent), Task(subagent_type:style-enforcer-agent), Task(subagent_type:code-explainer-agent), Task(subagent_type:test-writer-agent), Task(subagent_type:agent-orchestrator-agent)
-model: claude-opus-4-7
+model: claude-opus-4-8
 ---
 
 # Code Refactorer

--- a/packages/plugins/development-planning/.claude-plugin/plugin.json
+++ b/packages/plugins/development-planning/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-planning",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Implementation planning, execution, and PR creation workflows with multi-agent collaboration",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/development-planning/agents/execute-plan.md
+++ b/packages/plugins/development-planning/agents/execute-plan.md
@@ -2,7 +2,7 @@
 name: execute-plan-agent
 description: Execute implementation plans step-by-step. Use when user says "execute the plan", "implement the plan we created", "start building based on the plan", "go ahead and implement it", "proceed with the implementation", "execute as a stack", "create a PR stack while implementing", "implement with one PR per step", or references a plan file and wants to begin coding.
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git:*), Bash(gt:*), Bash(npx:*), Task(subagent_type:test-writer-agent), Task(subagent_type:documentation-agent), Task(subagent_type:pr-creator-agent), Task(subagent_type:commit-message-generator-agent)
-model: claude-opus-4-7
+model: claude-opus-4-8
 ---
 
 # Execute Plan Agent

--- a/packages/plugins/development-planning/agents/planner.md
+++ b/packages/plugins/development-planning/agents/planner.md
@@ -2,7 +2,7 @@
 name: planner-agent
 description: Create clear, actionable implementation plans without writing code. Use when asked to plan a feature, design an implementation approach, create a task breakdown, or decide how to implement a change before writing any code.
 allowed-tools: Read, Write, Glob, Grep
-model: claude-opus-4-7
+model: claude-opus-4-8
 ---
 
 # Planner Agent

--- a/packages/plugins/development-planning/skills/execute-plan/SKILL.md
+++ b/packages/plugins/development-planning/skills/execute-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 description: Execute implementation plans step-by-step. Use when user says "execute the plan", "implement the plan we created", "start building based on the plan", "go ahead and implement it", "proceed with the implementation", "execute as a stack", "create a PR stack while implementing", "implement with one PR per step", or references a plan file and wants to begin coding.
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git:*), Bash(gt:*), Bash(npx:*), Task(subagent_type:test-writer-agent), Task(subagent_type:documentation-agent), Task(subagent_type:pr-creator-agent), Task(subagent_type:commit-message-generator-agent)
-model: claude-opus-4-7
+model: claude-opus-4-8
 ---
 
 # Plan Executor


### PR DESCRIPTION
## Summary

- **New model detected**: `claude-opus-4-8` is now the latest Opus model per [Anthropic docs](https://platform.claude.com/docs/en/docs/about-claude/models). `claude-opus-4-7` has moved to the legacy table.
- Updates 20 files with `model:` field and hardcoded ID references from `claude-opus-4-7` → `claude-opus-4-8`
- Updates 3 additional files with prose mentions of "Opus 4.7" → "Opus 4.8" (README, REUSABLE_WORKFLOWS, boris-best-practices)
- `claude-sonnet-4-6` and `claude-haiku-4-5` are unchanged — still current

**New model capabilities (claude-opus-4-8 vs claude-opus-4-7):**
- Adaptive thinking: Yes (unchanged)
- Extended thinking: No (unchanged)
- Context window: 1M tokens, 128k max output (unchanged)
- Pricing: $5/$25 per MTok (unchanged)
- Knowledge cutoff: Jan 2026 (unchanged)

## Components updated
- `.github/` workflows and docs (13 files)
- `docs/guides/autonomous-claude-tasks.md`
- `packages/plugins/claude-setup/` README and boris-best-practices reference (2 files)
- `packages/plugins/development-codebase-tools/` agents and skills (3 files)
- `packages/plugins/development-planning/` agents and skills (3 files)

## Test plan
- [x] All pre-commit hooks passed (format, lint, lint-markdown, test, typecheck, update-lockfile)
- [x] Exhaustive `git ls-files` grep confirms 0 remaining `claude-opus-4-7` references after changes
- [x] 0 `claude-opus-4-6` regressions present in main at time of PR

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
`claude-opus-4-8` is now the latest Opus model per [Anthropic docs](https://platform.claude.com/docs/en/docs/about-claude/models); `claude-opus-4-7` has moved to the legacy table. This PR is a like-for-like swap of every `claude-opus-4-7` reference → `claude-opus-4-8` across workflows, docs, and plugins. `claude-sonnet-4-6` and `claude-haiku-4-5` are unchanged — still current.
## Changes
- Updates `model:` fields and hardcoded `claude-opus-4-7` ID references → `claude-opus-4-8`
- Updates prose mentions of "Opus 4.7" → "Opus 4.8"
- `.github/` workflows, examples, and docs (14 files)
- `docs/guides/autonomous-claude-tasks.md`
- `packages/plugins/claude-setup/` README + boris-best-practices reference (2 files)
- `packages/plugins/development-codebase-tools/` agents and skill (3 files)
- `packages/plugins/development-planning/` agents and skill (3 files)
Total diff: +59 / -59 across 23 files.
## Notes
Model capabilities are unchanged vs `claude-opus-4-7`: adaptive thinking (yes), extended thinking (no), 1M-token context / 128k max output, $5/$25 per MTok pricing, Jan 2026 knowledge cutoff. This is a pure model-identifier swap with no behavioral change.
## Test plan
- [ ] All pre-commit hooks pass (format, lint, lint-markdown, test, typecheck, lockfile)
- [ ] `git ls-files | xargs grep -l claude-opus-4-7` returns nothing after changes
- [ ] No `claude-opus-4-6` regressions present in base branch

</details>
<!-- claude-pr-description-end -->