### PR TITLE
docs(claude-init-plus): never emit line numbers or item counts

### DIFF
--- a/packages/plugins/development-productivity/commands/claude-init-plus.md
+++ b/packages/plugins/development-productivity/commands/claude-init-plus.md
@@ -118,6 +118,7 @@ Generate content in these categories only:
 - `[TODO]` placeholder entries
 - Self-evident commands like `npm test` or `npm run build` that need no elaboration
 - Standard language idioms or well-known framework patterns
+- Line numbers or item counts (e.g. "see line 42", "12 endpoints", "3 services") — these go stale on every edit and create high documentation churn
 
 ## Content Templates
 


### PR DESCRIPTION
## What

Adds a bullet to the `### What NOT to Generate` section of the `/claude-init-plus` command instructing it to never emit line numbers or item counts in generated CLAUDE.md files.

## Why

Line numbers ("see line 42") and item counts ("12 endpoints", "3 services") go stale on essentially every edit to the underlying code. Baking them into generated docs creates high documentation churn — the docs drift immediately and every unrelated change produces noisy CLAUDE.md diffs. This fits alongside the existing bans on `## Structure` listings and `[TODO]` placeholders, which are excluded for the same inferability/churn reasons.

## Change

```
  - Standard language idioms or well-known framework patterns
+ - Line numbers or item counts (e.g. "see line 42", "12 endpoints", "3 services") — these go stale on every edit and create high documentation churn
```

Docs-only; no behavioral code change.

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## What
Adds a bullet to the `### What NOT to Generate` section of the `/claude-init-plus` command instructing it to never emit line numbers or item counts in generated CLAUDE.md files.
## Why
Line numbers ("see line 42") and item counts ("12 endpoints", "3 services") go stale on essentially every edit to the underlying code. Baking them into generated docs creates high documentation churn — the docs drift immediately and every unrelated change produces noisy CLAUDE.md diffs. This fits alongside the existing bans on `[TODO]` placeholders and self-evident commands, which are excluded for the same inferability/churn reasons.
## Change
`packages/plugins/development-productivity/commands/claude-init-plus.md` — single bullet added under `### What NOT to Generate`:
```diff
  - Standard language idioms or well-known framework patterns
+ - Line numbers or item counts (e.g. "see line 42", "12 endpoints", "3 services") — these go stale on every edit and create high documentation churn
```
Docs-only; no behavioral code change.

</details>
<!-- claude-pr-description-end -->