### PR TITLE
chore(development-productivity): bump to 2.4.1 for claude-init-plus docs change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,7 +225,7 @@ All plugins follow semantic versioning (semver). Key versioning rules:
 | development-codebase-tools | 2.6.0   |
 | development-planning       | 2.0.1   |
 | development-pr-workflow    | 2.1.0   |
-| development-productivity   | 2.4.0   |
+| development-productivity   | 2.4.1   |
 | spec-workflow              | 2.0.1   |
 | uniswap-integrations       | 2.4.0   |
 

--- a/packages/plugins/development-productivity/.claude-plugin/plugin.json
+++ b/packages/plugins/development-productivity/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-productivity",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Documentation, research, test generation, document generation, and prompt optimization tools",
   "author": {
     "name": "Uniswap Labs",


### PR DESCRIPTION
Follow-up to #529, which edited `packages/plugins/development-productivity/commands/claude-init-plus.md` but missed the required plugin version bump.

Per the root CLAUDE.md policy ("After making any changes to files in `packages/plugins/`, Claude Code MUST bump the plugin version"), this PR:

- Bumps `packages/plugins/development-productivity/.claude-plugin/plugin.json` `2.4.0` → `2.4.1`
- Updates the matching row in the root CLAUDE.md **Current plugins** table

No behavior change — version/metadata only.

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Follow-up to #529, which edited `packages/plugins/development-productivity/commands/claude-init-plus.md` but missed the required plugin version bump.
Per the root `CLAUDE.md` policy ("After making any changes to files in `packages/plugins/`, Claude Code MUST bump the plugin version"), this PR applies the patch-level bump that should have shipped alongside the docs-only change.
## Changes
| File | Change |
|------|--------|
| `packages/plugins/development-productivity/.claude-plugin/plugin.json` | `version`: `2.4.0` → `2.4.1` |
| `CLAUDE.md` | `development-productivity` row in the **Current plugins** table: `2.4.0` → `2.4.1` |
Total diff: +2 / -2 across 2 files.
## Why patch (not minor)
The originating change in #529 only added a `### What NOT to Generate` bullet to the `/claude-init-plus` command — no new skills, agents, commands, or MCP servers; no behavioral code change. That fits the patch criteria in the root policy ("documentation updates ... with no user-facing behavior change").
## Test plan
- [x] `plugin.json` version matches the **Current plugins** table row in root `CLAUDE.md`
- [x] No other files in `packages/plugins/development-productivity/` were touched
- [ ] CI on this PR

</details>
<!-- claude-pr-description-end -->