### PR TITLE
docs(create-pr): read live PR body before editing in update mode

### DIFF
--- a/packages/plugins/development-planning/.claude-plugin/plugin.json
+++ b/packages/plugins/development-planning/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-planning",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Implementation planning, execution, and PR creation workflows with multi-agent collaboration",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/development-planning/skills/create-pr/SKILL.md
+++ b/packages/plugins/development-planning/skills/create-pr/SKILL.md
@@ -20,7 +20,7 @@ Create or update pull requests with auto-generated conventional commits and desc
 ## Error Handling
 
 - **No changes / no commits ahead of target**: Stop and inform the user — there is nothing to submit
-- **PR already exists for this branch**: Switch to update mode; run `git push` to publish the latest commits (use `gt submit` for Graphite), then `gh pr edit` if the PR title or body also need updating
+- **PR already exists for this branch**: Switch to update mode; run `git push` to publish the latest commits (use `gt submit` for Graphite). If the PR title or body also need updating, **read the live body first** (`gh pr view <n> --json body -q .body`) and edit *from* it — never regenerate the body from scratch. The author may have hand-edited the description or pasted images/screenshots (`![](https://github.com/user-attachments/...)`) that exist only in the live body, not in any file; overwriting silently destroys them. Splice your change into the current body and apply with `gh pr edit <n> --body-file <tmp>`.
 - **User rejects commit message**: Re-generate with user-provided guidance, then confirm again before proceeding
 
 ## Conventional Commit Types


### PR DESCRIPTION
## What

Update-mode in the `create-pr` skill currently says: *"`gh pr edit` if the PR title or body also need updating."* That invites regenerating the body from scratch.

This adds a guard: **read the live body first** (`gh pr view <n> --json body -q .body`), edit *from* it, and apply with `gh pr edit <n> --body-file <tmp>`.

## Why

A PR body can contain content that exists **only** in the live body — author hand-edits and pasted screenshots (`![](https://github.com/user-attachments/...)`). Regenerating from the diff/template silently destroys those. Reading-then-splicing preserves them.

## Blast radius

One bullet in one skill's "Error Handling" section (`development-planning/skills/create-pr`). Docs-only; no code or behavior in the skill's tooling changes.

## Test plan

- [ ] Markdown renders correctly in the SKILL.md
- [ ] Guidance is consistent with the existing `gh pr edit` flow

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## What
Update-mode in the `create-pr` skill currently says: *"`gh pr edit` if the PR title or body also need updating."* That invites regenerating the body from scratch.
This adds a guard: **read the live body first** (`gh pr view <n> --json body -q .body`), edit *from* it, and apply with `gh pr edit <n> --body-file <tmp>`.
## Why
A PR body can contain content that exists **only** in the live body — author hand-edits and pasted screenshots (`![](https://github.com/user-attachments/...)`). Regenerating from the diff/template silently destroys those. Reading-then-splicing preserves them.
## Blast radius
One bullet in one skill's "Error Handling" section (`development-planning/skills/create-pr`). Docs-only; no code or behavior in the skill's tooling changes.
## Test plan
- [ ] Markdown renders correctly in the SKILL.md
- [ ] Guidance is consistent with the existing `gh pr edit` flow
<details>
<summary>AI-Generated Description</summary>
## What
Update-mode in the `create-pr` skill currently said: *"`gh pr edit` if the PR title or body also need updating."* That phrasing invites regenerating the body from scratch.
This rewrites the bullet to add a guard: **read the live body first** (`gh pr view <n> --json body -q .body`), edit *from* it, and apply the result with `gh pr edit <n> --body-file <tmp>`.
## Why
A live PR body can contain content that exists **only** in the live body — author hand-edits and pasted screenshots (`![](https://github.com/user-attachments/...)`). Regenerating from the diff/template silently destroys those. Reading-then-splicing preserves them.
## Changes
| File | Change |
|------|--------|
| `packages/plugins/development-planning/skills/create-pr/SKILL.md` | Single bullet rewritten in the **Error Handling** section to require reading the live body before editing and to call out hand-edits / `user-attachments` images as the failure mode |
| `packages/plugins/development-planning/.claude-plugin/plugin.json` | `version`: `2.0.5` → `2.0.6` (patch bump for the docs-only change to a skill, per the root `CLAUDE.md` mandatory-bump policy) |
Total diff: +2 / -2 across 2 files.
## Diff
```diff
- **PR already exists for this branch**: Switch to update mode; run `git push` to publish the latest commits (use `gt submit` for Graphite), then `gh pr edit` if the PR title or body also need updating
+ **PR already exists for this branch**: Switch to update mode; run `git push` to publish the latest commits (use `gt submit` for Graphite). If the PR title or body also need updating, **read the live body first** (`gh pr view <n> --json body -q .body`) and edit *from* it — never regenerate the body from scratch. The author may have hand-edited the description or pasted images/screenshots (`![](https://github.com/user-attachments/...)`) that exist only in the live body, not in any file; overwriting silently destroys them. Splice your change into the current body and apply with `gh pr edit <n> --body-file <tmp>`.
```
## Why patch (not minor)
Docs-only change to a single bullet in one skill's "Error Handling" section. No new skills, agents, commands, or MCP servers; no behavioral code change in the skill's tooling. That fits the patch criteria in the root policy ("Bug fixes, minor documentation updates, typo fixes").
## Blast radius
One bullet in one skill (`development-planning/skills/create-pr`) plus the mandatory plugin version bump. Docs-only; no code or behavior in the skill's tooling changes.
## Test plan
- [ ] Markdown renders correctly in the SKILL.md
- [ ] Guidance is consistent with the existing `gh pr edit` flow
- [ ] Next `/create-pr` invocation against an existing PR reads the live body via `gh pr view --json body -q .body` before composing the new body
- [ ] `plugin.json` version matches the **Current plugins** table row in root `CLAUDE.md` (note: table-row sync may land in a follow-up if not included here)
</details>

</details>
<!-- claude-pr-description-end -->