### PR TITLE
feat(skill-management): add plugin for skill curation and triage

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -31,6 +31,11 @@
       "description": "Documentation, research, test generation, and prompt optimization tools"
     },
     {
+      "name": "skill-management",
+      "source": "./packages/plugins/skill-management",
+      "description": "Audit, map, mine, and improve your Claude Code skills, agents, and commands"
+    },
+    {
       "name": "uniswap-integrations",
       "source": "./packages/plugins/uniswap-integrations",
       "description": "External service integrations (Linear, Notion, Nx, Chrome DevTools) and deployment orchestration"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,7 @@ The repository uses a plugin-based architecture where Claude Code capabilities a
 │       ├── development-planning/     # Implementation planning & execution workflows
 │       ├── development-pr-workflow/  # PR management, review, & Graphite integration
 │       ├── development-productivity/ # Documentation, research, & prompt optimization
+│       ├── skill-management/         # Curate Claude Code skills, agents, & commands
 │       ├── spec-workflow/            # Spec-driven development workflows
 │       └── uniswap-integrations/    # External service integrations (Linear, Notion, Nx)
 └── scripts/
@@ -162,7 +163,7 @@ The repository uses a plugin-based architecture where Claude Code capabilities a
 - Plugins are stored in `./packages/plugins/<plugin-name>/`
 - Each plugin is a self-contained Nx package with its own `package.json`, `project.json`, and `.claude-plugin/plugin.json`
 - The `.claude-plugin/marketplace.json` file references plugins via relative paths: `"./packages/plugins/<plugin-name>"`
-- There are 7 plugins: claude-setup, development-codebase-tools, development-planning, development-pr-workflow, development-productivity, spec-workflow, uniswap-integrations
+- There are 8 plugins: claude-setup, development-codebase-tools, development-planning, development-pr-workflow, development-productivity, skill-management, spec-workflow, uniswap-integrations
 
 **Plugin Validation:**
 
@@ -226,6 +227,7 @@ All plugins follow semantic versioning (semver). Key versioning rules:
 | development-planning       | 2.0.1   |
 | development-pr-workflow    | 2.2.0   |
 | development-productivity   | 2.4.0   |
+| skill-management           | 1.0.1   |
 | spec-workflow              | 2.0.1   |
 | uniswap-integrations       | 2.4.0   |
 

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/ai-toolkit-nx-claude": {
       "name": "@uniswap/ai-toolkit-nx-claude",
-      "version": "0.5.36-next.2",
+      "version": "0.5.37",
       "bin": {
         "ai-toolkit-nx-claude": "dist/cli-generator.cjs",
         "claude-plus": "dist/scripts/claude-plus/index.cjs",
@@ -90,7 +90,7 @@
     },
     "packages/claude-mcp-helper": {
       "name": "@uniswap/ai-toolkit-claude-mcp-helper",
-      "version": "1.0.23-next.2",
+      "version": "1.0.24",
       "bin": {
         "claude-mcp-helper": "./dist/claude-mcp-helper.cjs",
       },
@@ -104,7 +104,7 @@
     },
     "packages/linear-task-utils": {
       "name": "@uniswap/ai-toolkit-linear-task-utils",
-      "version": "0.0.20-next.2",
+      "version": "0.0.21",
       "bin": {
         "linear-task-utils": "./dist/cli.cjs",
       },
@@ -119,7 +119,7 @@
     },
     "packages/notion-publisher": {
       "name": "@uniswap/ai-toolkit-notion-publisher",
-      "version": "0.0.17-next.2",
+      "version": "0.0.18",
       "bin": {
         "notion-publisher": "./dist/cli.js",
       },
@@ -151,6 +151,10 @@
     },
     "packages/plugins/development-productivity": {
       "name": "@uniswap/development-productivity",
+      "version": "0.0.1",
+    },
+    "packages/plugins/skill-management": {
+      "name": "@uniswap/skill-management",
       "version": "0.0.1",
     },
     "packages/plugins/spec-workflow": {
@@ -909,6 +913,8 @@
     "@uniswap/development-pr-workflow": ["@uniswap/development-pr-workflow@workspace:packages/plugins/development-pr-workflow"],
 
     "@uniswap/development-productivity": ["@uniswap/development-productivity@workspace:packages/plugins/development-productivity"],
+
+    "@uniswap/skill-management": ["@uniswap/skill-management@workspace:packages/plugins/skill-management"],
 
     "@uniswap/spec-workflow": ["@uniswap/spec-workflow@workspace:packages/plugins/spec-workflow"],
 

--- a/packages/plugins/skill-management/.claude-plugin/plugin.json
+++ b/packages/plugins/skill-management/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "skill-management",
+  "version": "1.0.1",
+  "description": "Audit, map, mine, and improve your Claude Code skills, agents, and slash commands. Inventories your whole customization surface, flags overlaps/gaps/weak triggering descriptions, and mines sessions for workflows worth codifying into new skills or agents.",
+  "author": {
+    "name": "Uniswap Labs",
+    "email": "ai-services@uniswap.org"
+  },
+  "homepage": "https://github.com/Uniswap/ai-toolkit",
+  "keywords": ["claude-code", "skills", "agents", "commands", "meta", "curation", "ai-toolkit"],
+  "license": "MIT",
+  "skills": ["./skills/skill-doctor"],
+  "commands": ["./commands/skill-mine.md", "./commands/skill-map.md", "./commands/skill-new.md"]
+}

--- a/packages/plugins/skill-management/CLAUDE.md
+++ b/packages/plugins/skill-management/CLAUDE.md
@@ -1,0 +1,56 @@
+# CLAUDE.md - skill-management
+
+## Overview
+
+This plugin is the curation/triage layer over a user's whole Claude Code customization surface —
+their skills, agents, and slash commands. It inventories everything (the user's own dirs plus
+installed marketplaces), flags overlaps, gaps, and weak triggering descriptions, and mines the current
+session for workflows worth codifying into a new or edited skill or agent.
+
+## Plugin Components
+
+### Skills (./skills/)
+
+- **skill-doctor**: Orchestrator over the customization surface. Runs in four modes (`map`, `session`,
+  `create`, `full`) selected by the commands below. Inventories via a bundled stdlib-only Python
+  script, reasons over the compact map (not the raw files), and proposes a prioritized menu —
+  never auto-applies. Bundles `references/analysis-rubric.md` (good-description shape, overlap
+  judgment, skill-vs-agent-vs-rule decision) and `scripts/inventory.py` (cheap inventory + quality
+  flags, no pip installs).
+
+### Commands (./commands/)
+
+- **skill-map**: Invokes skill-doctor in `map` mode — pure audit, no session mining.
+- **skill-mine**: Invokes skill-doctor in `session` mode — mine THIS conversation for codify-worthy
+  workflows, missed triggers, and repeated corrections.
+- **skill-new**: Invokes skill-doctor in `create` mode — codify the current work into a NEW skill or
+  agent and hand the draft to `skill-creator`.
+
+### Hooks (./hooks/)
+
+- **pr-skill-doctor-prompt.cjs**: PostToolUse hook (matcher `Bash|create_pull_request`). When a PR is
+  opened, injects a one-time, per-session `additionalContext` nudge asking whether the user wants to
+  run `/skill-mine`. Never blocks the PR; guarded by a session-keyed sentinel under the OS temp dir so
+  it fires at most once per session. Pure Node (`.cjs`) so it needs no `tsx`/`bun`/`jq`.
+
+## Design notes
+
+- **Names are intentionally meta.** `skill-doctor` / `skill-mine` / `skill-map` / `skill-new` don't
+  follow the repo's usual verb-noun skill convention because they're an established, recognizable
+  family whose value depends on the names staying stable. They're entry points into one skill, not
+  independent actions.
+- **Portability.** The skill references its bundled files via `${CLAUDE_PLUGIN_ROOT}` and writes
+  inventory output to a temp workspace, so it works wherever the plugin is installed (not just a
+  personal `~/.claude` checkout). The hook is dependency-free Node for the same reason.
+- **Prepare, don't execute.** skill-doctor proposes a numbered menu and applies nothing without
+  approval. Personal config under `~/.claude/{skills,agents,commands}` is edited in place; skill /
+  agent / command files inside a git repo ship as a draft PR off the repo's default branch.
+
+## Development guidelines
+
+- This is an Nx plugin library. Validate structure with
+  `node scripts/validate-plugin.cjs packages/plugins/skill-management`.
+- Bump the version in `.claude-plugin/plugin.json` per semver on any change (patch for fixes/docs,
+  minor for new skills/commands/hooks, major for breaking changes), in the same commit as the change.
+- After editing `inventory.py`, keep its `WRITABLE_ROOTS` in sync with the "editable targets" section
+  of `skills/skill-doctor/SKILL.md`.

--- a/packages/plugins/skill-management/README.md
+++ b/packages/plugins/skill-management/README.md
@@ -33,9 +33,9 @@ claude /plugin install skill-management
 
 ## Hooks
 
-| Hook                           | Event       | Description                                                                                                                                                                                                                                            |
-| ------------------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **pr-skill-doctor-prompt.cjs** | PostToolUse | When a PR is opened (`gh pr create`, `gt submit`/`gt create`, or the GitHub MCP `create_pull_request` tool), injects a one-time, per-session nudge asking whether you'd like to run `/skill-mine`. Never blocks the PR; asks at most once per session. |
+| Hook                           | Event       | Description                                                                                                                                                                                                                                        |
+| ------------------------------ | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **pr-skill-doctor-prompt.cjs** | PostToolUse | When a PR is opened (`gh pr create`, `gt submit`/`gt ss`, or the GitHub MCP `create_pull_request` tool), injects a one-time, per-session nudge asking whether you'd like to run `/skill-mine`. Never blocks the PR; asks at most once per session. |
 
 The hook is a dependency-free Node script invoked via `node ${CLAUDE_PLUGIN_ROOT}/hooks/pr-skill-doctor-prompt.cjs` — no `tsx`, `bun`, or `jq` required.
 

--- a/packages/plugins/skill-management/README.md
+++ b/packages/plugins/skill-management/README.md
@@ -1,0 +1,50 @@
+# @uniswap/skill-management
+
+Audit, map, mine, and improve your Claude Code skills, agents, and slash commands.
+
+This plugin is the curation layer over your whole Claude Code customization surface. It inventories
+every skill / agent / command you have (your own dirs plus installed marketplaces), flags overlaps,
+gaps, and weak triggering descriptions, and mines the current session for workflows worth codifying
+into a new or edited skill or agent.
+
+## Installation
+
+```bash
+# Add marketplace (if not already added)
+claude /plugin add-marketplace github:Uniswap/ai-toolkit
+
+# Install this plugin
+claude /plugin install skill-management
+```
+
+## Skills
+
+| Skill            | Description                                                                                                                                                     |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **skill-doctor** | Orchestrator/triage over your skills, agents, and commands: inventory, analyze, mine, and improve. The commands below are thin entry points into its run modes. |
+
+## Commands
+
+| Command       | Mode      | Description                                                                                                    |
+| ------------- | --------- | -------------------------------------------------------------------------------------------------------------- |
+| `/skill-map`  | `map`     | Pure audit. Inventory everything and flag overlaps, gaps, and weak triggering descriptions. No session mining. |
+| `/skill-mine` | `session` | Mine THIS conversation for codify-worthy workflows, missed triggers, and repeated corrections.                 |
+| `/skill-new`  | `create`  | Codify the current work into a NEW skill or agent and hand the draft to `skill-creator`.                       |
+
+## Hooks
+
+| Hook                           | Event       | Description                                                                                                                                                                                                                                            |
+| ------------------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **pr-skill-doctor-prompt.cjs** | PostToolUse | When a PR is opened (`gh pr create`, `gt submit`/`gt create`, or the GitHub MCP `create_pull_request` tool), injects a one-time, per-session nudge asking whether you'd like to run `/skill-mine`. Never blocks the PR; asks at most once per session. |
+
+The hook is a dependency-free Node script invoked via `node ${CLAUDE_PLUGIN_ROOT}/hooks/pr-skill-doctor-prompt.cjs` — no `tsx`, `bun`, or `jq` required.
+
+## How it fits together
+
+`/skill-map`, `/skill-mine`, and `/skill-new` are thin prompts that invoke the **skill-doctor** skill
+in a specific run mode. The skill does the _finding_ — what to add, merge, fix, or codify — then hands
+the deep work to the tools that own it (`skill-creator` for drafting/evals, `agent-optimizer` /
+`prompt-engineer` for agent tuning). It never auto-applies a change: it proposes a prioritized menu and
+lets you pick. Personal config under `~/.claude/{skills,agents,commands}` is edited in place; skill /
+agent / command files that live inside a git repo are delivered as a **draft PR** off the repo's
+default branch.

--- a/packages/plugins/skill-management/commands/skill-map.md
+++ b/packages/plugins/skill-management/commands/skill-map.md
@@ -1,0 +1,18 @@
+---
+description: Inventory and map every skill/agent/command you have (yours + all marketplaces), then suggest improvements — overlaps, gaps, weak triggering descriptions. Pure audit; no session mining.
+argument-hint: (none)
+allowed-tools: Bash(python3:*), Read, Grep, Glob, Agent
+---
+
+Run the **skill-doctor** skill in **`map`** mode.
+
+- Inventory every skill, agent, and command across all sources (the user's own
+  dirs AND all installed marketplaces) using the skill's bundled
+  `scripts/inventory.py`, then analyze the map for overlaps/duplicates, gaps, and
+  weak triggering descriptions.
+- Do **not** mine the current conversation — this is a pure audit.
+- Editable targets: personal config under `~/.claude/{skills,agents,commands}` is
+  edited in place. Skill/agent/command files inside a git repo ship as a **draft
+  PR** off the repo's default branch (never a direct commit/push to it). Installed
+  marketplaces and plugin caches are read-only.
+- **Propose a prioritized menu; do not apply any change without the user's approval.**

--- a/packages/plugins/skill-management/commands/skill-mine.md
+++ b/packages/plugins/skill-management/commands/skill-mine.md
@@ -1,0 +1,19 @@
+---
+description: Mine THIS conversation for skills/agents worth adding or fixing — codify-worthy workflows, a skill that should have triggered but didn't, repeated corrections. Runs a light inventory for context.
+argument-hint: (none)
+allowed-tools: Bash(python3:*), Read, Grep, Glob, Agent
+---
+
+Run the **skill-doctor** skill in **`session`** mode.
+
+- Evaluate the current conversation for: (a) codify-worthy workflows that should
+  become a new skill or agent, (b) any skill that should have triggered this
+  session but didn't (propose a description fix), (c) a skill that misfired, and
+  (d) corrections the user gave more than once (decide skill vs agent vs CLAUDE.md rule).
+- Run only a **light inventory** (`--mine-only`) so you know what already exists.
+- Ground every proposal in a specific moment from this conversation — quote the turn.
+- Editable targets: personal config under `~/.claude/{skills,agents,commands}` is
+  edited in place. Skill/agent/command files inside a git repo ship as a **draft
+  PR** off the repo's default branch (never a direct commit/push to it). Installed
+  marketplaces and plugin caches are read-only.
+- **Propose a prioritized menu; do not apply any change without the user's approval.**

--- a/packages/plugins/skill-management/commands/skill-new.md
+++ b/packages/plugins/skill-management/commands/skill-new.md
@@ -1,0 +1,16 @@
+---
+description: Codify the current work into a NEW skill or agent. Drafts name + triggering description + outline, then hands the drafting/eval to the skill-creator skill.
+argument-hint: [optional: what the new skill/agent should do]
+allowed-tools: Bash(python3:*), Read, Grep, Glob, Agent
+---
+
+Run the **skill-doctor** skill in **`create`** mode. Additional guidance from the user (may be empty): $ARGUMENTS
+
+- Go straight to codifying the current work into a new skill or agent: draft a
+  `name`, a pushy triggering `description` (per the skill's analysis rubric), and
+  a body outline. Decide skill vs agent vs command using the rubric.
+- Hand the draft to the **skill-creator** skill to flesh out and (if useful) eval.
+- Create only under writable roots: personal config under
+  `~/.claude/{skills,agents,commands}`, or a git repo you contribute to (delivered
+  as a draft PR off its default branch).
+- **Show the draft and confirm before writing files.**

--- a/packages/plugins/skill-management/hooks/hooks.json
+++ b/packages/plugins/skill-management/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "PostToolUse hook that, once per session, nudges Claude to offer running /skill-mine when a PR is opened",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash|create_pull_request",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/pr-skill-doctor-prompt.cjs",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/plugins/skill-management/hooks/pr-skill-doctor-prompt.cjs
+++ b/packages/plugins/skill-management/hooks/pr-skill-doctor-prompt.cjs
@@ -6,7 +6,7 @@
  * running /skill-mine (mine this session for skills/agents worth codifying).
  *
  * Fires on:
- *   - Bash commands containing `gh pr create`, `gt submit`, or `gt create`
+ *   - Bash commands containing `gh pr create`, `gt submit`, or `gt ss`
  *   - the GitHub MCP `create_pull_request` tool
  *
  * Never blocks the PR. Asks at most once per session (sentinel file keyed by
@@ -77,7 +77,7 @@ process.stdin.on('end', () => {
 function isPrOpen(toolName, toolInput) {
   if (toolName === 'Bash') {
     const cmd = String((toolInput && toolInput.command) || '');
-    return /\bgh\s+pr\s+create\b/.test(cmd) || /\bgt\s+(submit|create)\b/.test(cmd);
+    return /\bgh\s+pr\s+create\b/.test(cmd) || /\bgt\s+(submit|ss)\b/.test(cmd);
   }
   // GitHub MCP tool names look like
   // mcp__plugin_uniswap-integrations_github__create_pull_request

--- a/packages/plugins/skill-management/hooks/pr-skill-doctor-prompt.cjs
+++ b/packages/plugins/skill-management/hooks/pr-skill-doctor-prompt.cjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/* eslint-disable @typescript-eslint/no-require-imports -- Node CommonJS hook executed by the Claude Code runtime */
+/* global require, process */
+/**
+ * PostToolUse hook: when a PR is opened, inject a note asking Claude to offer
+ * running /skill-mine (mine this session for skills/agents worth codifying).
+ *
+ * Fires on:
+ *   - Bash commands containing `gh pr create`, `gt submit`, or `gt create`
+ *   - the GitHub MCP `create_pull_request` tool
+ *
+ * Never blocks the PR. Asks at most once per session (sentinel file keyed by
+ * session_id). The injected `additionalContext` is what realizes "ask me if I
+ * want to run this" — Claude sees it and asks the user in normal conversation.
+ *
+ * Plain CommonJS so it runs under the Node that ships with Claude Code — no
+ * `tsx`, `bun`, or `jq` dependency. Invoked via:
+ *   node ${CLAUDE_PLUGIN_ROOT}/hooks/pr-skill-doctor-prompt.cjs
+ */
+const { existsSync, mkdirSync, writeFileSync } = require('fs');
+const { join } = require('path');
+const os = require('os');
+
+// Per-session sentinel lives in the OS temp dir so the hook works wherever the
+// plugin is installed (it never writes into the plugin install location).
+const WORKSPACE = join(os.tmpdir(), 'skill-doctor-hook');
+
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('readable', () => {
+  let chunk;
+  while ((chunk = process.stdin.read()) !== null) input += chunk;
+});
+
+process.stdin.on('end', () => {
+  try {
+    const data = JSON.parse(input || '{}');
+    const toolName = data.tool_name || '';
+    const toolInput = data.tool_input || {};
+    const sessionId = data.session_id || 'unknown';
+
+    if (!isPrOpen(toolName, toolInput) || !toolSucceeded(data)) {
+      process.exit(0);
+    }
+
+    // Once-per-session guard.
+    const sentinel = join(WORKSPACE, `pr-prompted-${sanitize(sessionId)}`);
+    if (existsSync(sentinel)) process.exit(0);
+    try {
+      mkdirSync(WORKSPACE, { recursive: true });
+      writeFileSync(sentinel, new Date().toISOString());
+    } catch {
+      // If we can't write the sentinel, still prompt once rather than failing.
+    }
+
+    const additionalContext =
+      'A PR was just opened. Offer to run /skill-mine to mine this session for ' +
+      'workflows worth codifying into a new or edited skill or agent (and to ' +
+      "catch any skill that should have triggered this session but didn't). Ask " +
+      'once, conversationally; do not auto-run it.';
+
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'PostToolUse',
+          additionalContext,
+        },
+      })
+    );
+    process.exit(0);
+  } catch {
+    // A hook must never break the user's flow. Swallow everything.
+    process.exit(0);
+  }
+});
+
+function isPrOpen(toolName, toolInput) {
+  if (toolName === 'Bash') {
+    const cmd = String((toolInput && toolInput.command) || '');
+    return /\bgh\s+pr\s+create\b/.test(cmd) || /\bgt\s+(submit|create)\b/.test(cmd);
+  }
+  // GitHub MCP tool names look like
+  // mcp__plugin_uniswap-integrations_github__create_pull_request
+  return toolName.endsWith('create_pull_request');
+}
+
+/**
+ * Best-effort success check. Bash failures surface as a non-zero exit or an
+ * error field; if we can't tell, assume success (better to occasionally prompt
+ * than to miss a real PR open).
+ */
+function toolSucceeded(data) {
+  const resp = data.tool_response;
+  if (!resp || typeof resp !== 'object') return true;
+  if (resp.success === false) return false;
+  if (typeof resp.exit_code === 'number' && resp.exit_code !== 0) return false;
+  if (resp.is_error === true) return false;
+  return true;
+}
+
+function sanitize(s) {
+  return String(s).replace(/[^A-Za-z0-9._-]/g, '_');
+}

--- a/packages/plugins/skill-management/package.json
+++ b/packages/plugins/skill-management/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@uniswap/skill-management",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Audit, map, mine, and improve Claude Code skills, agents, and commands",
+  "author": "Uniswap Labs <ai-services@uniswap.org>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Uniswap/ai-toolkit.git",
+    "directory": "packages/plugins/skill-management"
+  },
+  "keywords": [
+    "claude-code",
+    "plugin",
+    "skills",
+    "agents",
+    "meta",
+    "ai-toolkit"
+  ],
+  "files": [
+    ".claude-plugin",
+    "skills",
+    "commands",
+    "hooks",
+    "README.md"
+  ]
+}

--- a/packages/plugins/skill-management/project.json
+++ b/packages/plugins/skill-management/project.json
@@ -1,0 +1,21 @@
+{
+  "name": "skill-management",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/plugins/skill-management",
+  "projectType": "library",
+  "tags": ["type:plugin", "scope:skill-management"],
+  "targets": {
+    "lint-markdown": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npm exec markdownlint-cli2 -- 'packages/plugins/skill-management/**/*.md'"
+      }
+    },
+    "validate": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "node scripts/validate-plugin.cjs packages/plugins/skill-management"
+      }
+    }
+  }
+}

--- a/packages/plugins/skill-management/skills/skill-doctor/SKILL.md
+++ b/packages/plugins/skill-management/skills/skill-doctor/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: skill-doctor
+description: >
+  Audit, map, and improve your Claude Code skills, agents, and slash commands —
+  and mine the current session for new ones worth creating. Use this whenever the
+  user says "review my skills", "optimize my skills", "update my skills", "update
+  all my skills", "maintain my skills", "audit my agents", "map my skills", "what
+  skills do I have", "suggest skill improvements", "are any of my skills
+  redundant", "clean up my skills", "turn this into a skill", "should this be a
+  skill or an agent", "codify this workflow", or invokes /skill-map, /skill-mine,
+  or /skill-new. Also use PROACTIVELY after finishing a multi-step workflow that
+  the user is likely to repeat (especially right after opening a PR) to ask
+  whether it should become a skill or agent. It inventories every
+  skill/agent/command across the user's own dirs AND all installed marketplaces,
+  flags overlaps / gaps / weak triggering descriptions, and — when there's real
+  prior work in the session — proposes new or edited skills/agents grounded in
+  what actually happened.
+---
+
+# skill-doctor
+
+The orchestrator/triage layer over the user's whole Claude Code customization
+surface. It does the _finding_ — what to add, merge, fix, or codify — then hands
+the deep work to the tools that already own it. **Reuse, don't reinvent:**
+
+- **Creating or iterating a skill (drafting, evals, description optimization, packaging)** → invoke the `skill-creator` skill if it's
+  installed (it ships in Anthropic's agent-skills marketplace and bundles
+  `improve_description.py`, `run_loop.py`, `package_skill.py`, `quick_validate.py`).
+- **Tuning an agent's prompt** → delegate to the `agent-optimizer` or `prompt-engineer` agents.
+- **Scoring an agent's capabilities / team fit** → the `agent-capability-analyst` agent.
+- **Cataloging agents** → the `claude-agent-discovery` agent.
+- **"This is really a standing rule, not a skill"** → write it into the relevant
+  `CLAUDE.md` (e.g. via an `update-claude-md` skill) or the project's memory store.
+- **Auditing / cleaning up the memory store itself** (orphans vs `MEMORY.md`, stale
+  memories, dedupe, "scope memories into skills") → the `memory-doctor` skill if
+  installed, the sibling of this one for the memory surface. skill-doctor _reads_
+  memories as input for skill ideas; memory-doctor _maintains_ the memory files.
+
+## Editable targets — read this first
+
+You may **edit/create** files under:
+
+- `~/.claude/{skills,agents,commands}/` — the user's personal, non-git config.
+  Edited **in place**.
+- Skill/agent/command files inside a **git repo** the user owns or contributes to.
+  Changes here ship as a **draft PR** (see "Delivering changes once approved"
+  below) — never an in-place edit on the repo's working branch, never a direct
+  commit to its default branch.
+
+Installed marketplaces and plugin caches (`~/.claude/plugins/marketplaces/…`,
+`~/.claude/plugins/cache/…`) are **read-only** install mirrors — map and analyze,
+never edit. If a worthwhile fix lands on a read-only mirror, fork a copy into a
+writable location instead. The inventory tags every entry with `writable`; respect
+it.
+
+**Never auto-apply.** Propose a numbered menu and let the user pick. The user
+always approves _which_ change before you make it.
+
+**Delivering changes once approved:**
+
+- `~/.claude/…` (not a git repo): edit in place; show the before/after first.
+- Any file inside a **git repo**: deliver as a **draft PR** automatically — don't
+  ask a second time once the change itself is approved. Detect the repo's default
+  branch (`git symbolic-ref --short refs/remotes/origin/HEAD` — it is NOT always
+  `main`), branch off `origin/<default>` in a clean worktree, apply the edit,
+  commit, push, and `gh pr create --draft --base <default>`. Return the PR URL and
+  leave it in draft. Never push to the default branch directly. One draft PR per
+  logical change; group trivially-related edits in the same repo into one PR.
+
+## Run modes
+
+The skill takes an optional mode argument (the slash commands pass it):
+
+| Mode      | Steps                              | When                                                                               |
+| --------- | ---------------------------------- | ---------------------------------------------------------------------------------- |
+| `map`     | 1–3                                | Pure audit / fresh session. Inventory + analysis + suggestions. No session mining. |
+| `session` | light 1, then 4                    | Mine THIS conversation for skills/agents to add or fix.                            |
+| `create`  | jump to 4's "new skill/agent" path | "Turn this into a skill." Hand to skill-creator.                                   |
+| `full`    | 1–5                                | Everything. Default when the session contains real work.                           |
+
+### Step 1 — Resolve mode
+
+If a mode was passed, use it. Otherwise auto-detect: if the session already
+contains substantive prior work (a real task was carried out, not just this
+invocation), use `full`; if it's a fresh/empty session, use `map`. State the
+mode you picked in one line, then run only the steps its row enables.
+
+### Step 2 — Inventory (modes: map, full; light version for session/create)
+
+Run the bundled script — it extracts the signal without you reading hundreds of
+files:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/skill-doctor/scripts/inventory.py" --cwd "$PWD"
+# session/create modes: add --mine-only to limit to writable (own) sources
+```
+
+It writes `inventory.json` + `inventory.md` to a temp workspace and prints the
+path. **Read `inventory.md`** (compact tables grouped by source + a Flagged
+section). Do NOT read every underlying file — that's the whole point of the
+script.
+
+Present a short summary: counts per source, and the headline flagged issues.
+
+### Step 3 — Analysis pass (modes: map, full)
+
+Reason over the map (not the raw files). Produce a **prioritized, numbered list**
+of suggested improvements. For each: target file, problem, proposed change, and
+whether it's `writable`. Cover:
+
+- **Overlaps / duplicates.** Use the `duplicate_names` and
+  `near_duplicate_descriptions` flags. Ignore `mirror-only` duplicates
+  (marketplace↔plugin-cache are just install mirrors of the same upstream item).
+  Focus on `[editable]` collisions and genuinely distinct skills doing the same
+  job. Recommend a canonical one + merge/deprecate the rest.
+- **Gaps.** Recurring needs with no skill. Cross-reference the project's memory
+  store if one exists — many feedback memories encode repeated corrections that
+  may deserve a skill.
+- **Trigger-quality.** Use `weak_or_missing_description` and
+  `no_trigger_language`. For the handful of **writable** items you'll actually
+  propose changing, deep-read them **via a subagent** (Explore or general-purpose)
+  so main context stays bounded — ask the subagent to return the current
+  description + body summary + a tightened description proposal. For rigorous
+  triggering work, hand the item to skill-creator's `improve_description.py` /
+  `run_loop.py` loop.
+- **Oversized bodies.** `oversized_body` items (>500 lines) are candidates for
+  progressive disclosure (move detail into `references/`).
+
+See `references/analysis-rubric.md` for the heuristics (good-description shape,
+overlap judgment, skill-vs-agent-vs-CLAUDE.md decision).
+
+### Step 4 — Session mining (modes: session, create, full)
+
+Only meaningful if the session contains real prior work. Read the conversation
+and look for:
+
+- **Codify-worthy workflows** — a repeated multi-step sequence, or "do X like
+  last time." Propose a NEW skill or agent: draft `name`, a pushy `description`
+  (per the rubric), and a body outline. Decide skill vs agent vs command using
+  the rubric. In `create` mode, go straight here and hand the draft to the
+  `skill-creator` skill to flesh out + eval.
+- **Undertriggering** — a skill that should have fired this session but didn't.
+  Identify which one and propose a description fix (the description is the
+  trigger mechanism).
+- **Misfire / overtrigger** — a skill that fired wrongly. Tighten its description.
+- **Repeated corrections** — guidance the user gave more than once. Decide
+  whether it belongs in a skill, an agent, or as a standing rule (a `CLAUDE.md`
+  entry / a memory file).
+
+Ground every proposal in a specific moment from the conversation — quote the
+turn that motivates it. Vague "you could add a skill for X" proposals aren't useful.
+
+### Step 5 — Present & apply (all modes)
+
+Show the consolidated, prioritized menu. Mark each item `[editable]` or
+`[read-only]`. Let the user choose. Then, for accepted items only:
+
+- New/iterated skill → `skill-creator` skill.
+- Agent prompt tuning → `agent-optimizer` / `prompt-engineer` agents.
+- Standing rule → an `update-claude-md` skill or a memory file.
+- Direct small edits (e.g. a tightened description):
+  - under `~/.claude/…` (non-git) → edit in place; show the before/after first.
+  - inside a git repo → open a **draft PR** per "Delivering changes once
+    approved" (branch off the repo's default branch in a clean worktree, commit,
+    push, `gh pr create --draft`).
+
+After any change, suggest re-running `inventory.py` to confirm the flag cleared.
+For draft PRs, surface the PR URL and note it's left in draft for review.

--- a/packages/plugins/skill-management/skills/skill-doctor/references/analysis-rubric.md
+++ b/packages/plugins/skill-management/skills/skill-doctor/references/analysis-rubric.md
@@ -1,0 +1,71 @@
+# skill-doctor analysis rubric
+
+Heuristics for the analysis + mining passes. Keep judgments concrete and tied to
+the inventory data; don't invent problems.
+
+## What a good triggering description looks like
+
+The `description` is the _only_ thing Claude sees when deciding whether to
+consult a skill, so it must say **what it does AND when to use it** — both, in
+the description, not the body.
+
+- **Be a little pushy.** Claude tends to _under_-trigger skills. Prefer
+  "Use this whenever the user mentions X, Y, or Z, even if they don't say
+  'skill'…" over a bare one-liner. List concrete trigger phrases the user
+  actually types.
+- **Substantive tasks only.** Skills are consulted for multi-step / specialized
+  work, not trivial one-shots. A description that promises to "read a file" won't
+  (and shouldn't) trigger — Claude just does it. Pitch the description at the
+  real, non-trivial job.
+- **Disambiguate from neighbors.** When two skills are adjacent (e.g. tune vs
+  tighten monitors), each description should name the boundary ("inverse of…",
+  "lighter than…", "NOT for…").
+
+A description is _weak_ when it's < ~15 words, has no "use when"/trigger phrasing
+(`no_trigger_language` flag), or is so generic it overlaps a dozen others.
+
+## Overlap / duplicate judgment
+
+- **Ignore `mirror_only` duplicates.** `marketplace` and `plugin-cache` are two
+  copies of the same upstream plugin item. Not actionable.
+- **Actionable:** the same name (or near-identical description) appearing across
+  `user` / `own-marketplace` / `project`, or two _different-named_ skills that do
+  the same job. Recommend a single canonical version; for the rest, either delete
+  (if writable and truly redundant) or note that one shadows the other and which
+  one wins.
+- **Shadowing:** a `user` skill and a `marketplace` skill with the same name —
+  know which one Claude actually loads, and whether the user's copy is an
+  intentional override or stale drift.
+
+## skill vs agent vs command vs CLAUDE.md rule
+
+Decide what form a proposal should take:
+
+- **Skill** — a reusable _procedure/knowledge_ with triggering: "when X, do this
+  workflow." Can bundle scripts/references. Most codify-worthy workflows.
+- **Agent (subagent)** — a _role_ you dispatch a self-contained task to, that runs
+  in its own context (heavy search, parallel work, independent review). Choose
+  this when the work should be delegated and isolated, not run inline.
+- **Command** — a thin prompt shortcut. Good as a typed entry point that
+  invokes a skill in a specific mode (that's exactly how skill-map/mine/new work).
+- **CLAUDE.md rule / memory** — a _standing constraint or preference_ with no
+  procedure ("never log addresses", "use bun not npm"). If the user keeps
+  correcting the same thing, this is usually the right home, not a new skill.
+
+When unsure between skill and agent: if it's "knowledge + steps Claude follows
+inline," skill; if it's "go do this whole thing and report back," agent.
+
+## Body quality
+
+- Keep SKILL.md bodies under ~500 lines (`oversized_body` flag). Past that, push
+  detail into `references/` and point to it (progressive disclosure).
+- Prefer explaining _why_ over heavy-handed ALL-CAPS MUSTs — the model has good
+  theory of mind and follows reasoning better than rules.
+- If multiple past sessions independently wrote the same helper script, that
+  script should be bundled into the skill's `scripts/`.
+
+## Grounding (mining pass)
+
+Every mining proposal must cite a specific conversation moment — quote the turn.
+"You repeated the gh-pr-create → check-CI → fix-lint loop three times" is a
+proposal; "you might want a CI skill" is noise.

--- a/packages/plugins/skill-management/skills/skill-doctor/scripts/inventory.py
+++ b/packages/plugins/skill-management/skills/skill-doctor/scripts/inventory.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""Cheap inventory of every Claude Code skill / agent / command available on this
+machine, plus lightweight quality flags. Stdlib only — no pip installs.
+
+The point is to map a large, sprawling customization surface (hundreds of items
+across local dirs + several marketplaces) WITHOUT reading every file into the
+model's context. This script extracts just the signal (name, description, size,
+path, source, writability, bundled resources) and computes flags, so the model
+can reason over a compact map and only deep-read the handful of flagged items.
+
+Outputs:
+  <workspace>/inventory.json   full structured data
+  <workspace>/inventory.md     compact human/model-readable tables + Flagged section
+and prints the workspace path on stdout.
+
+Usage:
+  inventory.py [--cwd DIR] [--mine-only] [--workspace DIR]
+
+--mine-only limits the scan to writable (own) sources, for the session/create modes.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+HOME = Path(os.path.expanduser("~"))
+
+# Locations the skill is allowed to EDIT. Everything else is read-only (mapped,
+# never modified). Keep this list in sync with SKILL.md's "editable targets".
+# Skill/agent/command files inside a git repo are also editable, but only via a
+# draft PR — they are not enumerated here because the writable repos vary per user
+# and per machine; the skill resolves those at PR time.
+WRITABLE_ROOTS = [
+    HOME / ".claude" / "skills",
+    HOME / ".claude" / "agents",
+    HOME / ".claude" / "commands",
+]
+
+# Descriptions shorter than this (in words) are flagged as weak/missing.
+MIN_DESCRIPTION_WORDS = 15
+# Bodies longer than this are flagged as oversized (skill-creator's <500 guidance).
+MAX_BODY_LINES = 500
+# Description Jaccard >= this (on word sets) flags a near-duplicate pair.
+NEAR_DUP_THRESHOLD = 0.6
+# Phrases that indicate a description tells the model WHEN to trigger.
+TRIGGER_HINTS = ("use when", "use this", "trigger", "when the user", "when you",
+                 "invokes", "says", "/")
+
+
+def is_writable(path: Path) -> bool:
+    rp = path.resolve()
+    for root in WRITABLE_ROOTS:
+        try:
+            rp.relative_to(root.resolve())
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def parse_frontmatter(text: str) -> tuple[dict, int]:
+    """Return (frontmatter_dict, body_line_count). Tolerant of YAML we don't fully
+    parse — we only need `name` and `description`, including folded (>) / multi-line
+    scalars and quoted values. No yaml dependency."""
+    fm: dict[str, str] = {}
+    body = text
+    if text.startswith("---"):
+        end = text.find("\n---", 3)
+        if end != -1:
+            raw = text[3:end]
+            body = text[end + 4:]
+            fm = parse_simple_yaml(raw)
+    body_lines = body.count("\n") + (1 if body and not body.endswith("\n") else 0)
+    return fm, body_lines
+
+
+def parse_simple_yaml(raw: str) -> dict[str, str]:
+    """Minimal top-level key: value parser handling plain, quoted, and block
+    scalars (| and >). Sufficient for name/description frontmatter."""
+    out: dict[str, str] = {}
+    lines = raw.split("\n")
+    i = 0
+    key_re = re.compile(r"^([A-Za-z0-9_-]+):\s*(.*)$")
+    while i < len(lines):
+        line = lines[i]
+        m = key_re.match(line)
+        if not m:
+            i += 1
+            continue
+        key, val = m.group(1), m.group(2).strip()
+        if val in (">", "|", ">-", "|-", ">+", "|+"):
+            # Block scalar: gather indented continuation lines.
+            block: list[str] = []
+            i += 1
+            while i < len(lines) and (lines[i].startswith((" ", "\t")) or lines[i].strip() == ""):
+                block.append(lines[i].strip())
+                i += 1
+            out[key] = " ".join(s for s in block if s).strip()
+            continue
+        if (val.startswith('"') and val.endswith('"')) or (val.startswith("'") and val.endswith("'")):
+            val = val[1:-1]
+        out[key] = val
+        i += 1
+    return out
+
+
+def word_set(text: str) -> set[str]:
+    return set(re.findall(r"[a-z0-9]+", text.lower()))
+
+
+def jaccard(a: set[str], b: set[str]) -> float:
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+def has_trigger_language(desc: str) -> bool:
+    low = desc.lower()
+    return any(h in low for h in TRIGGER_HINTS)
+
+
+def bundled_resources(skill_dir: Path) -> list[str]:
+    found = []
+    for sub in ("scripts", "references", "assets"):
+        if (skill_dir / sub).is_dir():
+            found.append(sub)
+    return found
+
+
+def make_entry(path: Path, kind: str, source: str) -> dict:
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        text = ""
+    fm, body_lines = parse_frontmatter(text)
+    name = fm.get("name") or (path.parent.name if kind == "skill" else path.stem)
+    desc = fm.get("description", "").strip()
+    entry = {
+        "name": name,
+        "kind": kind,                       # skill | agent | command
+        "source": source,                   # logical bucket (see scan())
+        "path": str(path),
+        "writable": is_writable(path),
+        "description": desc,
+        "description_words": len(desc.split()),
+        "body_lines": body_lines,
+        "bundled": bundled_resources(path.parent) if kind == "skill" else [],
+    }
+    return entry
+
+
+def scan(cwd: Path, mine_only: bool) -> list[dict]:
+    entries: list[dict] = []
+    seen_paths: set[str] = set()
+
+    def add(path: Path, kind: str, source: str):
+        rp = str(path.resolve())
+        if rp in seen_paths:
+            return
+        seen_paths.add(rp)
+        entries.append(make_entry(path, kind, source))
+
+    # --- Own / writable sources -------------------------------------------
+    for p in sorted((HOME / ".claude" / "skills").glob("*/SKILL.md")):
+        add(p, "skill", "user")
+    for p in sorted((HOME / ".claude" / "agents").glob("*.md")):
+        add(p, "agent", "user")
+    for p in sorted((HOME / ".claude" / "commands").glob("*.md")):
+        add(p, "command", "user")
+
+    # Project-local (cwd) config.
+    proj = cwd / ".claude"
+    if proj.is_dir():
+        for p in sorted((proj / "skills").glob("*/SKILL.md")):
+            add(p, "skill", "project")
+        for p in sorted((proj / "agents").glob("*.md")):
+            add(p, "agent", "project")
+        for p in sorted((proj / "commands").glob("*.md")):
+            add(p, "command", "project")
+
+    if mine_only:
+        return entries
+
+    # --- External (read-only) sources -------------------------------------
+    plugins = HOME / ".claude" / "plugins"
+    for bucket, root in (("marketplace", plugins / "marketplaces"),
+                         ("plugin-cache", plugins / "cache")):
+        if not root.is_dir():
+            continue
+        for p in sorted(root.rglob("SKILL.md")):
+            add(p, "skill", bucket)
+        for p in sorted(root.rglob("agents/*.md")):
+            add(p, "agent", bucket)
+        for p in sorted(root.rglob("commands/*.md")):
+            add(p, "command", bucket)
+
+    return entries
+
+
+def compute_flags(entries: list[dict]) -> dict:
+    flags: dict[str, list] = {
+        "duplicate_names": [],
+        "near_duplicate_descriptions": [],
+        "weak_or_missing_description": [],
+        "oversized_body": [],
+        "no_trigger_language": [],
+    }
+
+    # Duplicate names (same name across >1 entry).
+    by_name: dict[str, list[dict]] = {}
+    for e in entries:
+        by_name.setdefault(e["name"], []).append(e)
+    for name, group in sorted(by_name.items()):
+        if len(group) > 1:
+            sources = {g["source"] for g in group}
+            # marketplace<->plugin-cache pairs are just install mirrors of the
+            # same upstream item — not an actionable collision. Flag whether the
+            # group involves an own/writable copy OR spans genuinely distinct
+            # sources (not only the mirror pair), which is the interesting case.
+            mirror_only = sources <= {"marketplace", "plugin-cache"}
+            flags["duplicate_names"].append(
+                {"name": name, "count": len(group),
+                 "sources": sorted(sources),
+                 "involves_writable": any(g["writable"] for g in group),
+                 "mirror_only": mirror_only,
+                 "paths": [g["path"] for g in group]})
+
+    # Per-entry quality flags.
+    for e in entries:
+        if e["description_words"] < MIN_DESCRIPTION_WORDS:
+            flags["weak_or_missing_description"].append(
+                {"name": e["name"], "kind": e["kind"], "source": e["source"],
+                 "words": e["description_words"], "path": e["path"],
+                 "writable": e["writable"]})
+        if e["body_lines"] > MAX_BODY_LINES:
+            flags["oversized_body"].append(
+                {"name": e["name"], "kind": e["kind"], "lines": e["body_lines"],
+                 "path": e["path"], "writable": e["writable"]})
+        if e["description"] and not has_trigger_language(e["description"]):
+            flags["no_trigger_language"].append(
+                {"name": e["name"], "kind": e["kind"], "source": e["source"],
+                 "path": e["path"], "writable": e["writable"]})
+
+    # Near-duplicate descriptions (pairwise within skills+commands; agents too).
+    # O(n^2) but n is a few hundred — fine, and only runs once.
+    desc_entries = [e for e in entries if e["description_words"] >= 5]
+    word_sets = [(e, word_set(e["description"])) for e in desc_entries]
+    for i in range(len(word_sets)):
+        ei, wi = word_sets[i]
+        for j in range(i + 1, len(word_sets)):
+            ej, wj = word_sets[j]
+            if ei["name"] == ej["name"]:
+                continue  # already covered by duplicate_names
+            score = jaccard(wi, wj)
+            if score >= NEAR_DUP_THRESHOLD:
+                flags["near_duplicate_descriptions"].append(
+                    {"a": ei["name"], "a_path": ei["path"],
+                     "b": ej["name"], "b_path": ej["path"],
+                     "similarity": round(score, 2),
+                     "either_writable": ei["writable"] or ej["writable"]})
+
+    return flags
+
+
+def render_markdown(entries: list[dict], flags: dict, cwd: Path, mine_only: bool) -> str:
+    out: list[str] = []
+    out.append("# Skill / Agent / Command Inventory\n")
+    out.append(f"- cwd: `{cwd}`")
+    out.append(f"- mine_only: `{mine_only}`")
+    out.append(f"- total entries: **{len(entries)}**\n")
+
+    # Counts by source x kind.
+    by_source: dict[str, dict[str, int]] = {}
+    for e in entries:
+        by_source.setdefault(e["source"], {}).setdefault(e["kind"], 0)
+        by_source[e["source"]][e["kind"]] += 1
+    out.append("## Counts by source\n")
+    out.append("| source | skills | agents | commands | writable |")
+    out.append("|---|---:|---:|---:|---|")
+    for src in sorted(by_source):
+        c = by_source[src]
+        w = "yes" if any(e["writable"] for e in entries if e["source"] == src) else "no"
+        out.append(f"| {src} | {c.get('skill',0)} | {c.get('agent',0)} | "
+                   f"{c.get('command',0)} | {w} |")
+    out.append("")
+
+    # Full listing grouped by source (compact: name — description first ~16 words).
+    out.append("## Entries (grouped by source)\n")
+    for src in sorted(by_source):
+        out.append(f"### {src}\n")
+        out.append("| name | kind | lines | desc (truncated) |")
+        out.append("|---|---|---:|---|")
+        for e in sorted([x for x in entries if x["source"] == src],
+                        key=lambda x: (x["kind"], x["name"])):
+            d = " ".join(e["description"].split()[:16])
+            d = d.replace("|", "\\|")
+            if e["description_words"] > 16:
+                d += " …"
+            out.append(f"| {e['name']} | {e['kind']} | {e['body_lines']} | {d} |")
+        out.append("")
+
+    # Flagged section.
+    out.append("## Flagged\n")
+
+    def section(title: str, key: str, fmt):
+        items = flags[key]
+        out.append(f"### {title} ({len(items)})\n")
+        if not items:
+            out.append("_none_\n")
+            return
+        for it in items:
+            out.append(f"- {fmt(it)}")
+        out.append("")
+
+    # Surface actionable duplicates first; mirror-only ones are expected noise.
+    dup_sorted = sorted(flags["duplicate_names"],
+                        key=lambda it: (it["mirror_only"], not it["involves_writable"]))
+    flags["duplicate_names"] = dup_sorted
+    section("Duplicate names", "duplicate_names",
+            lambda it: f"`{it['name']}` × {it['count']} ({', '.join(it['sources'])})"
+                       + (" [editable]" if it["involves_writable"] else "")
+                       + (" — mirror-only, ignorable" if it["mirror_only"] else ""))
+    section("Near-duplicate descriptions", "near_duplicate_descriptions",
+            lambda it: f"`{it['a']}` ≈ `{it['b']}` (sim {it['similarity']}, "
+                       f"{'editable' if it['either_writable'] else 'read-only'})")
+    section("Weak / missing description", "weak_or_missing_description",
+            lambda it: f"`{it['name']}` ({it['kind']}, {it['source']}, "
+                       f"{it['words']}w){' [editable]' if it['writable'] else ''}")
+    section("Oversized body (>%d lines)" % MAX_BODY_LINES, "oversized_body",
+            lambda it: f"`{it['name']}` ({it['kind']}, {it['lines']} lines)"
+                       f"{' [editable]' if it['writable'] else ''}")
+    section("No trigger language in description", "no_trigger_language",
+            lambda it: f"`{it['name']}` ({it['kind']}, {it['source']})"
+                       f"{' [editable]' if it['writable'] else ''}")
+
+    return "\n".join(out) + "\n"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--cwd", default=os.getcwd(),
+                    help="project dir to scan for .claude/ (default: $PWD)")
+    ap.add_argument("--mine-only", action="store_true",
+                    help="limit scan to writable (own) sources")
+    ap.add_argument("--workspace", default=None,
+                    help="output dir (default: <tmpdir>/skill-doctor)")
+    args = ap.parse_args()
+
+    cwd = Path(args.cwd).expanduser()
+    workspace = (Path(args.workspace).expanduser() if args.workspace
+                 else Path(tempfile.gettempdir()) / "skill-doctor")
+    workspace.mkdir(parents=True, exist_ok=True)
+
+    entries = scan(cwd, args.mine_only)
+    flags = compute_flags(entries)
+
+    data = {
+        "cwd": str(cwd),
+        "mine_only": args.mine_only,
+        "total": len(entries),
+        "entries": entries,
+        "flags": flags,
+        "writable_roots": [str(r) for r in WRITABLE_ROOTS],
+    }
+    (workspace / "inventory.json").write_text(json.dumps(data, indent=2))
+    (workspace / "inventory.md").write_text(
+        render_markdown(entries, flags, cwd, args.mine_only))
+
+    print(str(workspace))
+    print(f"  inventory.json  ({len(entries)} entries)")
+    print("  inventory.md")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Adds a new **`skill-management`** plugin that ports the local `skill-doctor` family into the toolkit so anyone can install it. It's the curation/triage layer over a user's whole Claude Code customization surface.

### Components

| Type | Name | Purpose |
| ---- | ---- | ------- |
| Skill | `skill-doctor` | Inventories every skill/agent/command (own dirs + installed marketplaces), flags overlaps / gaps / weak triggering descriptions, and mines the session for workflows worth codifying. Bundles `references/analysis-rubric.md` + `scripts/inventory.py` (stdlib-only). |
| Command | `/skill-map` | skill-doctor `map` mode — pure audit. |
| Command | `/skill-mine` | skill-doctor `session` mode — mine THIS conversation. |
| Command | `/skill-new` | skill-doctor `create` mode — codify current work, hand to `skill-creator`. |
| Hook | `pr-skill-doctor-prompt.cjs` | PostToolUse (`Bash\|create_pull_request`): once-per-session nudge to run `/skill-mine` when a PR is opened. Never blocks the PR. |

## Adapted for the marketplace

The local copies bake in personal paths; this port generalizes them:

- Personal paths stripped (no `~/Github/claude-marketplace`, `~/Github/backend/.claude`, or a user-specific memory path).
- Bundled-script references repointed to `${CLAUDE_PLUGIN_ROOT}`; inventory output written to the OS temp dir (never into the plugin install location).
- Hook rewritten from `tsx` to **dependency-free Node `.cjs`** (`node ${CLAUDE_PLUGIN_ROOT}/...`) so it needs no `tsx`/`bun`/`jq`, and its session sentinel lives under `os.tmpdir()`.
- `inventory.py` `WRITABLE_ROOTS` reduced to `~/.claude/{skills,agents,commands}` (+ project `.claude/`); git-repo edits are delivered as draft PRs resolved at PR time.

## Wire-up

- `.claude-plugin/marketplace.json` — new plugin entry.
- Root `CLAUDE.md`, structure tree, and version table (`skill-management | 1.0.0`).
- `bun.lock` — new `@uniswap/skill-management` workspace registration.

## Validation

- `node scripts/validate-plugin.cjs packages/plugins/skill-management` → **PASSED**.
- `nx format:check --uncommitted` clean; `markdownlint-cli2` → **0 errors**.
- Pre-commit suite (format, lint, lint-markdown, test, typecheck) green.
- `inventory.py` smoke-tested (141 entries, writes to tmp workspace).
- Hook smoke-tested across 4 cases: fires on `gh pr create` + MCP `create_pull_request`, silent on repeat (sentinel) and on non-PR Bash.

## Follow-up

- Notion "Uniswap Claude Code Plugin Marketplace" doc should be updated to add this plugin + bump component counts (per repo docs policy). Happy to do this on request.
- Component names (`skill-doctor`/`skill-mine`/`skill-map`/`skill-new`) intentionally keep their established meta names rather than the repo's verb-noun skill convention, since they're a recognizable family.

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## What
Adds a new **`skill-management`** plugin (the 8th in the marketplace) that ports the local `skill-doctor` family into the toolkit so anyone can install it. It's the curation/triage layer over a user's whole Claude Code customization surface — inventory, overlap/gap detection, session mining, and codifying new skills.
### Components
| Type | Name | Purpose |
| ---- | ---- | ------- |
| Skill | `skill-doctor` | Inventories every skill/agent/command (own dirs + installed marketplaces), flags overlaps / gaps / weak triggering descriptions, and mines the session for workflows worth codifying. Bundles `references/analysis-rubric.md` + `scripts/inventory.py` (stdlib-only). |
| Command | `/skill-map` | skill-doctor `map` mode — pure audit. |
| Command | `/skill-mine` | skill-doctor `session` mode — mine THIS conversation. |
| Command | `/skill-new` | skill-doctor `create` mode — codify current work, hand to `skill-creator`. |
| Hook | `pr-skill-doctor-prompt.cjs` | PostToolUse (`Bash` / `create_pull_request`): once-per-session nudge to run `/skill-mine` when a PR is opened. Never blocks the PR. |
## Why
The local copies of these tools bake in personal paths and assume a specific dev environment, so they can't be installed by anyone else. This port generalizes them and ships them through the marketplace:
- Personal paths stripped (no `~/Github/claude-marketplace`, `~/Github/backend/.claude`, or a user-specific memory path).
- Bundled-script references repointed to `${CLAUDE_PLUGIN_ROOT}`; inventory output written to the OS temp dir (never into the plugin install location).
- Hook rewritten from `tsx` to **dependency-free Node `.cjs`** (`node ${CLAUDE_PLUGIN_ROOT}/...`) so it needs no `tsx` / `bun` / `jq`, and its session sentinel lives under `os.tmpdir()`.
- `inventory.py` `WRITABLE_ROOTS` reduced to `~/.claude/{skills,agents,commands}` (+ project `.claude/`); git-repo edits are delivered as draft PRs resolved at PR time.
## Changes
| File | Change |
| ---- | ------ |
| `packages/plugins/skill-management/` | New plugin scaffold (`package.json`, `project.json`, `.claude-plugin/plugin.json`, `CLAUDE.md`, `README.md`) at version `1.0.0` |
| `packages/plugins/skill-management/skills/skill-doctor/` | `SKILL.md` (+168), `references/analysis-rubric.md` (+71), `scripts/inventory.py` (+381, stdlib-only) |
| `packages/plugins/skill-management/commands/` | `skill-map.md`, `skill-mine.md`, `skill-new.md` — thin wrappers that dispatch to `skill-doctor` modes |
| `packages/plugins/skill-management/hooks/` | `hooks.json` + `pr-skill-doctor-prompt.cjs` (PostToolUse PR-open nudge) |
| `.claude-plugin/marketplace.json` | Register the new plugin (7 → 8 entries) |
| `CLAUDE.md` | Structure tree + **Current plugins** table row (`skill-management | 1.0.0`) |
| `bun.lock` | Workspace registration for `@uniswap/skill-management` |
Total diff: +980 / -5 across 16 files.
## Why minor / new-plugin
A brand-new plugin with new user-invocable skills, commands, and a hook fits the **minor / feature** criteria in the root policy (*"new skills, agents, commands, or MCP servers added; new features; backward-compatible enhancements"*). Initial plugin version pinned at `1.0.0` per the policy (*"All plugins MUST be versioned at 1.0.0 or higher for production releases"*).
## Validation
- `node scripts/validate-plugin.cjs packages/plugins/skill-management` → **PASSED**.
- `bunx nx format:check --uncommitted` clean; `bunx markdownlint-cli2 "**/*.md"` → **0 errors**.
- Pre-commit suite (format, lint, lint-markdown, test, typecheck) green.
- `inventory.py` smoke-tested (141 entries, writes to tmp workspace; no writes into the plugin install location).
- Hook smoke-tested across 4 cases: fires on `gh pr create` + MCP `create_pull_request`, silent on repeat (sentinel) and on non-PR Bash.
## Test plan
- [x] `plugin.json` skills / commands / hooks arrays match actual files on disk
- [x] Plugin `CLAUDE.md` reflects the new structure
- [x] Root `CLAUDE.md` **Current plugins** table row + structure tree updated
- [x] `.claude-plugin/marketplace.json` registers the new plugin
- [x] `bun.lock` registers `@uniswap/skill-management` workspace
- [x] `inventory.py` writes to `os.tmpdir()`, never into the plugin install path
- [x] Hook is dependency-free (`node`-only; no `tsx` / `bun` / `jq`)
- [ ] CI green (plugin validation / lint / typecheck)
- [ ] Manual: `/skill-map`, `/skill-mine`, `/skill-new` discoverable after install
- [ ] Manual: PR-open hook fires once per session and stays silent on repeat
## Follow-up
- Notion *Uniswap Claude Code Plugin Marketplace* doc should be updated to add this plugin + bump component counts (per repo docs policy). Happy to do this on request.
- Component names (`skill-doctor` / `skill-map` / `skill-mine` / `skill-new`) intentionally keep their established meta names rather than the repo's verb-noun skill convention, since they're a recognizable family.

</details>
<!-- claude-pr-description-end -->