### PR TITLE
feat(rules): add response-links-summary output convention

### DIFF
--- a/.claude/rules/response-links-summary.md
+++ b/.claude/rules/response-links-summary.md
@@ -1,0 +1,31 @@
+# Response Links Summary
+
+## Instructions for Claude Code
+
+When you finish a turn — that is, you are stopping, **not** asking the user a question and **not** mid-task — end the response with a short `## Links` block: a one-glance, copy-pasteable index of everything actionable from the turn, so the reader doesn't have to scroll back through the work to find it.
+
+## Critical Rules - ALWAYS FOLLOW
+
+### 1. End a stopping turn with a `## Links` block
+
+Include every link that is actionable or referenceable from the turn:
+
+- **PRs / branches** — any PR opened this session AND any PR referenced in-context.
+- **Issues / tickets / incidents** — anything touched or referenced (Jira, Linear, incident.io, GitHub issues, etc.).
+- **Observability** — dashboards, monitors, notebooks, SLOs, CI/build runs, or traces you cited.
+- **Docs / pages** — Notion, Confluence, design docs, runbooks you surfaced.
+
+Group by type when there are several; omit a group that's empty. If there are genuinely no links, **skip the section entirely** — never emit an empty heading.
+
+### 2. Always use full, clickable URLs — never bare IDs
+
+- Render `https://github.com/<org>/<repo>/pull/1234`, not `#1234`.
+- Whenever you reference an external component by ID or name in a summary (a monitor, dashboard, ticket, build job, etc.), link it directly — a bare ID forces the reader to go search for it. This applies to **every** summary that names such a component, not only the on-stop block.
+
+### 3. Keep it a trailing index, not the answer
+
+The `## Links` block sits **below** the substantive response and is just URLs plus a few words of label. Don't let it crowd out or replace the actual answer.
+
+## Why
+
+Readers act on these links immediately — open the PR, check the live dashboard, read the ticket. A trailing, grouped, fully-linked index turns "scroll back and reconstruct what was touched" into one glance, and avoids the common failure of citing a bare ID that the reader then has to hunt down.


### PR DESCRIPTION
Adds `.claude/rules/response-links-summary.md` — an always-on output convention: when stopping (not asking, not mid-task), end the response with a trailing `## Links` block (grouped by type, full clickable URLs, omitted when empty), and link any referenced component by URL rather than a bare ID.

### Why a rule (not a skill)
This is a passive output convention with no trigger phrase — it should apply to every stopping turn, so it belongs in `.claude/rules/` alongside `linting.md`/`plugin-docs.md`, not as a task-invoked skill. (A Stop hook could enforce it programmatically, but a hook can't author the links — guidance is the right fit, matching how it already lives as personal memory.)

### Generalized from personal memory
Stripped the Uniswap/Datadog-US1 and individual-name specifics; kept the portable convention (PRs / tickets / observability / docs categories, full URLs, no bare IDs).

Draft for review — happy to adjust categories/wording or convert to a hook if you'd prefer enforcement.

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## What
Adds `.claude/rules/response-links-summary.md` — an always-on output convention: when stopping (not asking, not mid-task), end the response with a trailing `## Links` block (grouped by type, full clickable URLs, omitted when empty), and link any referenced component by URL rather than a bare ID.
Single new file under `.claude/rules/`; no code or behavior changes elsewhere.
## Why
Readers act on these links immediately — open the PR, check the live dashboard, read the ticket. A trailing, grouped, fully-linked index turns "scroll back and reconstruct what was touched" into one glance, and avoids the common failure of citing a bare ID (`#1234`, monitor name, dashboard slug) that the reader then has to hunt down.
### Why a rule (not a skill)
This is a passive output convention with no trigger phrase — it should apply to every stopping turn, so it belongs in `.claude/rules/` alongside `linting.md` / `plugin-docs.md`, not as a task-invoked skill. (A Stop hook could enforce it programmatically, but a hook can't author the links — guidance is the right fit, matching how it already lives as personal memory.)
### Generalized from personal memory
Stripped the Uniswap/Datadog-US1 and individual-name specifics; kept the portable convention (PRs / tickets / observability / docs categories, full URLs, no bare IDs).
## Changes
| File | Change |
|------|--------|
| `.claude/rules/response-links-summary.md` | New rule (+31 lines): when/what to include in a trailing `## Links` block, full-URL requirement, "skip the section entirely if empty" guidance |
Total diff: +31 / -0 across 1 file. Docs-only; no plugin code touched, so no `packages/plugins/` version bump required.
## Test plan
- [ ] Markdown renders correctly under `.claude/rules/`
- [ ] `markdownlint-cli2` clean on the new file
- [ ] Future stopping turns end with a `## Links` block when there are actionable links, and omit it entirely when there are none
Draft for review — happy to adjust categories/wording or convert to a hook if you'd prefer enforcement.

</details>
<!-- claude-pr-description-end -->