### PR TITLE
chore(slack-oauth-backend): remove OAuth scope diagnostic logging

### DIFF
--- a/apps/slack-oauth-backend/src/oauth/handler.ts
+++ b/apps/slack-oauth-backend/src/oauth/handler.ts
@@ -106,24 +106,6 @@ export class SlackOAuthHandler implements OAuthHandler {
         );
       }
 
-      // Observability: record the scopes Slack actually granted on the issued
-      // tokens, plus presence flags useful for diagnosing token-type confusion
-      // and refresh-token availability. Token values themselves are deliberately
-      // omitted; only scope strings and booleans are recorded, so this log is
-      // safe to leave on in production.
-      logger.info('Slack OAuth exchange complete', {
-        botScopesGranted: tokenResponse.scope,
-        userScopesGranted: tokenResponse.authed_user?.scope,
-        hasBotToken: !!tokenResponse.access_token,
-        hasUserToken: !!tokenResponse.authed_user?.access_token,
-        hasBotRefreshToken: !!tokenResponse.refresh_token,
-        hasUserRefreshToken: !!tokenResponse.authed_user?.refresh_token,
-        botTokenType: tokenResponse.token_type,
-        userTokenType: tokenResponse.authed_user?.token_type,
-        teamId: tokenResponse.team?.id,
-        enterpriseId: tokenResponse.enterprise?.id,
-      });
-
       // Enrich with user info using the bot token freshly issued by THIS
       // exchange. A static SLACK_BOT_TOKEN env var is incompatible with token
       // rotation (xoxe tokens expire ~12h) and dies on every reinstall, which

--- a/apps/slack-oauth-backend/src/routes/oauth.ts
+++ b/apps/slack-oauth-backend/src/routes/oauth.ts
@@ -157,16 +157,6 @@ router.get(
     const oauthHandler = createOAuthHandler();
     const authUrl = oauthHandler.generateAuthUrl(state);
 
-    // Observability: record the scopes being requested on this install
-    // attempt. Parse params out of the URL so the `state` CSRF nonce
-    // doesn't end up in logs alongside the scope data.
-    const parsedUrl = new URL(authUrl);
-    logger.info('Slack OAuth authorize redirect', {
-      scope: parsedUrl.searchParams.get('scope'),
-      userScope: parsedUrl.searchParams.get('user_scope'),
-      redirectUri: parsedUrl.searchParams.get('redirect_uri'),
-    });
-
     // In production, store state in session or database
     // For now, just redirect
     res.redirect(authUrl);


### PR DESCRIPTION
## What

Removes the two diagnostic `logger.info` calls added in #520 from the Slack OAuth backend:

- `apps/slack-oauth-backend/src/oauth/handler.ts` — `"Slack OAuth exchange complete"` (granted bot/user scopes + token presence flags)
- `apps/slack-oauth-backend/src/routes/oauth.ts` — `"Slack OAuth authorize redirect"` (requested scope / user_scope / redirect_uri)

This is the exact inverse of #520 — a pure deletion of 28 lines, no behavior change beyond no longer emitting these logs.

## Why

Those `logger.info` calls were temporary instrumentation for the ongoing org-install scope-grant debugging. That investigation has concluded, so the diagnostic logging is no longer needed and is being removed before the next production promotion.

The `logger` import remains in use in both files (e.g. `logger.child(...)` in `oauth.ts`, other calls in `handler.ts`), so no unused-import cleanup was needed.

## Test plan

- `bunx nx format:write --uncommitted` — no changes
- `bunx nx run slack-oauth-backend:lint` — 0 errors (only pre-existing `no-explicit-any` warnings, unchanged by this diff)
- `bunx nx run slack-oauth-backend:typecheck` — clean
- `bunx nx run slack-oauth-backend:test --skip-nx-cache` — **74/74 pass**

Note: a non-cached pre-commit run intermittently failed `refresh.spec.ts › should reject refresh_token that is too long` (expected 400, got 501) — a file untouched by this diff, which Nx itself flagged as a "flaky task" and which passes deterministically on a clean full-suite run.

## Context

- Supersedes the now-closed promotion PR #535, which bundled the logging commit. After this merges to \`next\`, a fresh next→main promotion PR will be triggered without the logging.