### PR TITLE
feat(uniswap-integrations): add datadog-cost-tracker skill with gotchas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,7 +229,7 @@ All plugins follow semantic versioning (semver). Key versioning rules:
 | development-productivity   | 2.4.1   |
 | skill-management           | 1.0.1   |
 | spec-workflow              | 2.0.1   |
-| uniswap-integrations       | 2.5.0   |
+| uniswap-integrations       | 2.6.0   |
 
 **Note:** Keep this table updated when versions change.
 

--- a/packages/plugins/uniswap-integrations/.claude-plugin/plugin.json
+++ b/packages/plugins/uniswap-integrations/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uniswap-integrations",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "External service integrations (Linear, Notion, Nx, Chrome DevTools, GitHub, Slack, Amplitude, Datadog) and deployment orchestration",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/uniswap-integrations/.claude-plugin/plugin.json
+++ b/packages/plugins/uniswap-integrations/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uniswap-integrations",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "External service integrations (Linear, Notion, Nx, Chrome DevTools, GitHub, Slack, Amplitude, Datadog) and deployment orchestration",
   "author": {
     "name": "Uniswap Labs",
@@ -23,6 +23,7 @@
   "license": "MIT",
   "skills": [
     "./skills/daily-standup",
+    "./skills/datadog-cost-tracker",
     "./skills/github-setup",
     "./skills/investigate-incident",
     "./skills/orchestrate-deployment",

--- a/packages/plugins/uniswap-integrations/CLAUDE.md
+++ b/packages/plugins/uniswap-integrations/CLAUDE.md
@@ -9,6 +9,7 @@ This plugin provides external service integrations for Claude Code, bundling MCP
 ### Skills (./skills/)
 
 - **daily-standup**: Generate daily standup reports from GitHub and Linear activity
+- **datadog-cost-tracker**: Analyze Datadog ingestion costs by service using estimated-usage metrics, flagging anomalous growth and reduction opportunities
 - **github-setup**: Configure GitHub Personal Access Token for the GitHub MCP server
 - **investigate-incident**: Investigate production incidents using Datadog logs, metrics, and traces
 - **orchestrate-deployment**: Orchestrate deployment pipelines with CI/CD configuration
@@ -103,6 +104,7 @@ uniswap-integrations/
 │   └── plugin.json
 ├── skills/
 │   ├── daily-standup/
+│   ├── datadog-cost-tracker/
 │   ├── github-setup/
 │   ├── investigate-incident/
 │   ├── orchestrate-deployment/

--- a/packages/plugins/uniswap-integrations/README.md
+++ b/packages/plugins/uniswap-integrations/README.md
@@ -35,6 +35,7 @@ This plugin bundles the following MCP (Model Context Protocol) servers:
 | Skill                      | Description                                                              |
 | -------------------------- | ------------------------------------------------------------------------ |
 | **daily-standup**          | Generate daily standup reports from GitHub and Linear activity           |
+| **datadog-cost-tracker**   | Analyze Datadog ingestion costs by service using estimated-usage metrics |
 | **github-setup**           | Configure GitHub Personal Access Token for MCP server                    |
 | **investigate-incident**   | Investigate production incidents using Datadog logs, metrics, and traces |
 | **orchestrate-deployment** | Orchestrate deployment pipelines with CI/CD configuration                |
@@ -83,6 +84,7 @@ Some MCP servers require authentication:
 #### Slack Setup
 
 1. **Obtain a Slack Bot Token**:
+
    - Visit <https://ai-toolkit-slack-oauth-backend.vercel.app/>
    - Click "Add to Slack" and authorize the app
    - Copy the Access Token (starts with `xoxp-...`)
@@ -113,6 +115,7 @@ For detailed Slack setup documentation, see: <https://www.notion.so/uniswaplabs/
 #### GitHub Setup
 
 1. **Create a Personal Access Token**:
+
    - Go to <https://github.com/settings/tokens?type=beta>
    - Click "Generate new token" (Fine-grained recommended)
    - Set permissions: Contents (R/W), Issues (R/W), Pull requests (R/W)

--- a/packages/plugins/uniswap-integrations/skills/datadog-cost-tracker/SKILL.md
+++ b/packages/plugins/uniswap-integrations/skills/datadog-cost-tracker/SKILL.md
@@ -21,9 +21,9 @@ Analyze Datadog ingestion costs across logs, APM spans, and other estimated-usag
 
 2. **Read the gotchas reference first** — before issuing any queries, read `references/gotchas.md` in this skill directory. Empty results are often caused by known pitfalls (missing env tag, post-deploy baseline shifts) rather than zero actual ingestion.
 
-3. **Query estimated-usage metrics** — use `search_datadog_metrics` or `get_datadog_metric` on `datadog.estimated_usage.logs.ingested_bytes` and `datadog.estimated_usage.apm_hosts` (or `datadog.estimated_usage.ingested_spans`). Group by `service` tag.
+3. **Query estimated-usage metrics** — via the Datadog MCP server, query the estimated-usage metrics grouped by the `service` tag: `datadog.estimated_usage.logs.ingested_bytes` for log ingestion and `datadog.estimated_usage.apm.ingested_spans` for APM span ingestion. Confirm the exact metric names in your account's Metrics Explorer first — estimated-usage metric names vary by integration setup, and querying a name that does not exist returns empty rather than erroring.
 
-4. **Validate service tags** — before concluding a service has zero ingestion, call `get_datadog_metric_context` for that metric filtered to the service. Confirm the service tag actually exists on the metric. If the tag is absent, the service may emit data under a different tagging scheme.
+4. **Validate service tags** — before concluding a service has zero ingestion, retrieve the metric's tag context (via the Datadog MCP server) filtered to that service. Confirm the service tag actually exists on the metric. If the tag is absent, the service may emit data under a different tagging scheme.
 
 5. **Identify top contributors** — rank services by volume. Flag any service where volume increased >2× week-over-week.
 

--- a/packages/plugins/uniswap-integrations/skills/datadog-cost-tracker/SKILL.md
+++ b/packages/plugins/uniswap-integrations/skills/datadog-cost-tracker/SKILL.md
@@ -1,0 +1,49 @@
+---
+description: Track and analyze Datadog ingestion costs using estimated_usage metrics. Use when the user asks "what is our Datadog spend", "how much are we ingesting in Datadog", "find the top log ingesters", "break down Datadog costs by service", "why is our Datadog bill high", or "compare APM span ingestion before and after a deploy". Always consult the gotchas reference before trusting empty query results.
+allowed-tools: Task(mcp__datadog__*), Read, Glob
+model: sonnet
+---
+
+# Datadog Cost Tracker
+
+Analyze Datadog ingestion costs across logs, APM spans, and other estimated-usage metrics, broken down by service. Flags services with anomalous growth and surfaces actionable reduction opportunities.
+
+## When to Activate
+
+- User wants to understand current Datadog spend or ingestion volume
+- User wants to identify top log or APM ingesters
+- User is comparing ingestion before and after a deploy
+- User sees an unexpected spike in Datadog costs and needs root cause
+
+## Steps
+
+1. **Clarify scope** — confirm the time window (default: last 7 days) and which signal types to include (logs, APM spans, custom metrics, or all).
+
+2. **Read the gotchas reference first** — before issuing any queries, read `references/gotchas.md` in this skill directory. Empty results are often caused by known pitfalls (missing env tag, post-deploy baseline shifts) rather than zero actual ingestion.
+
+3. **Query estimated-usage metrics** — use `search_datadog_metrics` or `get_datadog_metric` on `datadog.estimated_usage.logs.ingested_bytes` and `datadog.estimated_usage.apm_hosts` (or `datadog.estimated_usage.ingested_spans`). Group by `service` tag.
+
+4. **Validate service tags** — before concluding a service has zero ingestion, call `get_datadog_metric_context` for that metric filtered to the service. Confirm the service tag actually exists on the metric. If the tag is absent, the service may emit data under a different tagging scheme.
+
+5. **Identify top contributors** — rank services by volume. Flag any service where volume increased >2× week-over-week.
+
+6. **Check for baseline invalidity** — if comparing across a known tag-normalization deploy (see gotchas), mark affected comparisons as INCONCLUSIVE rather than REGRESSION or IMPROVEMENT.
+
+7. **Report findings** — produce a ranked table of services with volume, cost estimate (if available), and week-over-week delta. Note any INCONCLUSIVE comparisons with the reason.
+
+## Output Format
+
+**Cost Summary** — total estimated ingestion for the period by signal type.
+
+**Top Ingesters** — ranked table: service | volume | WoW delta | notes.
+
+**Anomalies** — services with unusual growth, with evidence and likely cause.
+
+**Inconclusive Comparisons** — queries that returned empty or whose baseline is invalid, with the reason (e.g., missing tag, post-normalization deploy).
+
+**Recommendations** — actionable steps to reduce ingestion (sampling, exclusion filters, log-level tuning).
+
+## Notes
+
+- Requires Datadog MCP server configured in the uniswap-integrations plugin.
+- See `references/gotchas.md` for known pitfalls that produce misleading empty results.

--- a/packages/plugins/uniswap-integrations/skills/datadog-cost-tracker/references/gotchas.md
+++ b/packages/plugins/uniswap-integrations/skills/datadog-cost-tracker/references/gotchas.md
@@ -1,0 +1,47 @@
+# Datadog Cost Tracker — Known Gotchas
+
+Read this file before trusting any empty or anomalous result from a cost-tracker query.
+
+---
+
+## Gotcha 1: `env:prod` filter returns empty for Lambda/serverless services
+
+**Symptom:** Querying `datadog.estimated_usage.logs.ingested_bytes` with `env:prod` returns zero
+bytes for a service that is clearly running in production.
+
+**Root cause:** Lambda and serverless services (e.g. `unirpc-v2`, `notification-service`) do not
+emit the `env` tag on their log ingestion metrics. Filtering on `env:prod` silently drops all their
+data rather than returning an error.
+
+**Correct pattern:**
+
+1. Omit the `env` filter entirely when querying ingestion metrics for serverless services.
+2. Before trusting an empty result, call `get_datadog_metric_context` for the metric filtered to
+   the service and check whether an `env` tag is present on that metric at all. If the tag is
+   absent from the metric context, the `env:prod` filter is the cause of the empty result.
+3. Re-run the query without the `env` filter to get the true ingestion volume.
+
+**Note:** The general investigation instructions say "resolve the service tag before trusting an
+empty result." This gotcha extends that guidance: also verify the `env` tag exists on the metric
+before applying an env filter.
+
+---
+
+## Gotcha 2: Uniroute APM baseline is invalid before 2026-05-14
+
+**Symptom:** Comparing `service:uniroute,env:prod` ingested-spans volume before and after
+mid-May 2026 shows a ~22× jump, which looks like a severe regression.
+
+**Root cause:** PRs #7996, #7510, and #7998 (deployed together on 2026-05-14) changed uniroute to
+prefer `DD_ENV` over the legacy `ENV`/`ENVIRONMENT` environment variables. This tag normalization
+caused the `service:uniroute,env:prod` series to consolidate traffic that was previously split
+across multiple tag values. The 22× jump reflects data that was already being ingested but was
+previously attributed to differently-tagged series — it is **not** a traffic increase.
+
+**Correct pattern:**
+
+- Any comparison that spans the 2026-05-14 deploy boundary for `service:uniroute` APM data must be
+  marked **INCONCLUSIVE** in the report, not REGRESSION.
+- Use a post-May-14 window as the new baseline for all uniroute APM cost analysis.
+- If historical (pre-May-14) uniroute APM data is needed, query without the `env:prod` filter and
+  sum across all env tag values, acknowledging that the series are not directly comparable.

--- a/packages/plugins/uniswap-integrations/skills/datadog-cost-tracker/references/gotchas.md
+++ b/packages/plugins/uniswap-integrations/skills/datadog-cost-tracker/references/gotchas.md
@@ -16,9 +16,9 @@ data rather than returning an error.
 **Correct pattern:**
 
 1. Omit the `env` filter entirely when querying ingestion metrics for serverless services.
-2. Before trusting an empty result, call `get_datadog_metric_context` for the metric filtered to
-   the service and check whether an `env` tag is present on that metric at all. If the tag is
-   absent from the metric context, the `env:prod` filter is the cause of the empty result.
+2. Before trusting an empty result, retrieve the metric's tag context (via the Datadog MCP server)
+   filtered to the service and check whether an `env` tag is present on that metric at all. If the
+   tag is absent from the metric context, the `env:prod` filter is the cause of the empty result.
 3. Re-run the query without the `env` filter to get the true ingestion volume.
 
 **Note:** The general investigation instructions say "resolve the service tag before trusting an


### PR DESCRIPTION
## Summary

- Adds a new `datadog-cost-tracker` skill to the `uniswap-integrations` plugin that guides future cost-analysis runs against Datadog estimated-usage metrics
- Ships a `references/gotchas.md` file capturing two pitfalls discovered in a live cost-tracker session that produce silent empty results or misleading anomaly signals

## Gotchas captured

**Gotcha 1 — `env:prod` filter breaks Lambda/serverless log queries**
`datadog.estimated_usage.logs.ingested_bytes` queried with `env:prod` returns empty for Lambda/serverless services like `unirpc-v2` and `notification-service` because they don't emit that tag. Correct pattern: omit the env filter; verify the service tag exists via `get_datadog_metric_context` before trusting an empty result.

**Gotcha 2 — Uniroute APM baseline invalid before 2026-05-14**
PRs #7996, #7510, and #7998 (deployed 2026-05-14) changed uniroute to prefer `DD_ENV` over `ENV`/`ENVIRONMENT`, causing `service:uniroute,env:prod` ingested spans to jump 22x due to tag normalization — not traffic growth. Any pre-May-14 uniroute APM baseline must be marked INCONCLUSIVE rather than REGRESSION.

## Test plan

- [ ] Verify SKILL.md frontmatter parses correctly (description, allowed-tools, model fields present)
- [ ] Verify `gotchas.md` is linked from SKILL.md Step 2
- [ ] Verify `plugin.json` skills array includes `./skills/datadog-cost-tracker` and version bumped to 2.5.0

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CaswXmq8Xotq8La9SNJrSy


_Generated by [Claude Code](https://claude.ai/code)_

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## What
Adds a new **`datadog-cost-tracker`** skill to the `uniswap-integrations` plugin that guides cost-analysis runs against Datadog estimated-usage metrics (`datadog.estimated_usage.logs.ingested_bytes`, `datadog.estimated_usage.apm.ingested_spans`), broken down by service, flagging anomalous growth and reduction opportunities.
The skill ships a `references/gotchas.md` file capturing two pitfalls discovered in a live cost-tracker session that produce silent empty results or misleading anomaly signals, plus the standard plugin/marketplace wire-up.
## Why
Cost-tracker runs against Datadog estimated-usage metrics are error-prone in two specific ways that silently corrupt the analysis. Both were hit during a real session, so they're codified as a `gotchas.md` reference the skill reads *before* trusting any empty or anomalous result:
- **`env:prod` filter breaks Lambda/serverless log queries** — `datadog.estimated_usage.logs.ingested_bytes` queried with `env:prod` returns empty for serverless services like `unirpc-v2` and `notification-service` because they don't emit that tag. The filter silently drops their data rather than erroring. Correct pattern: omit the env filter and verify the tag exists on the metric before trusting an empty result.
- **Uniroute APM baseline invalid before 2026-05-14** — PRs #7996, #7510, and #7998 (deployed 2026-05-14) changed uniroute to prefer `DD_ENV` over `ENV`/`ENVIRONMENT`, consolidating `service:uniroute,env:prod` ingested spans into a ~22× jump from tag normalization, not traffic growth. Any comparison spanning that boundary must be marked INCONCLUSIVE rather than REGRESSION.
## Changes
| File | Change |
| ---- | ------ |
| `packages/plugins/uniswap-integrations/skills/datadog-cost-tracker/SKILL.md` | New skill (+49): frontmatter (`description`, `allowed-tools`, `model: sonnet`), a 7-step workflow that reads gotchas before querying, and a structured output format (Cost Summary / Top Ingesters / Anomalies / Inconclusive Comparisons / Recommendations) |
| `packages/plugins/uniswap-integrations/skills/datadog-cost-tracker/references/gotchas.md` | New reference (+47): the two pitfalls above, each with symptom, root cause, and correct pattern |
| `packages/plugins/uniswap-integrations/.claude-plugin/plugin.json` | Register `./skills/datadog-cost-tracker` in the `skills` array; `version` `2.5.0` → `2.6.0` |
| `packages/plugins/uniswap-integrations/CLAUDE.md` | Add the skill to the component list and file-structure tree |
| `packages/plugins/uniswap-integrations/README.md` | Add the `datadog-cost-tracker` row to the skills table (plus minor markdown-lint spacing fixes) |
| `CLAUDE.md` | Bump `uniswap-integrations` row in the **Current plugins** table: `2.5.0` → `2.6.0` |
Total diff: +104 / -2 across 6 files.
## Why minor (not patch)
A new user-invocable skill is a backward-compatible feature addition, which matches the minor-bump criteria in the root policy ("new skills, agents, commands, or MCP servers added").
## Test plan
- [x] `SKILL.md` frontmatter parses (`description`, `allowed-tools`, `model` present)
- [x] `gotchas.md` is linked from `SKILL.md` (Step 2 and Notes)
- [x] `plugin.json` `skills` array includes `./skills/datadog-cost-tracker`
- [x] Plugin `CLAUDE.md` + `README.md` list the new skill
- [x] `plugin.json` version (`2.6.0`) matches the **Current plugins** table row in root `CLAUDE.md`
- [ ] CI green (plugin validation / lint / markdown-lint / typecheck)
- [ ] Manual: `/datadog-cost-tracker` intent is discoverable after install
## Follow-up
Per the repo docs policy, the Notion "Uniswap Claude Code Plugin Marketplace" doc should be updated to add this skill and bump the skill count. Happy to do this on request.

</details>
<!-- claude-pr-description-end -->