### PR TITLE
fix(slack-oauth-backend): deliver refresh token on re-auth (DM + page fallback)

### DIFF
--- a/apps/slack-oauth-backend/src/oauth/handler.ts
+++ b/apps/slack-oauth-backend/src/oauth/handler.ts
@@ -132,9 +132,11 @@ export class SlackOAuthHandler implements OAuthHandler {
         // Surface the fresh bot token so the route can authenticate post-install
         // actions (DM delivery) without a static, rotation-incompatible token.
         botAccessToken: tokenResponse.access_token,
-        // The authed user's ID straight from the exchange. Always present here,
-        // so DM delivery can target it even when the users.info enrichment below
-        // returns undefined.
+        // The authed user's ID straight from the exchange. Present on a
+        // user-token install (so DM delivery can target it even when the
+        // users.info enrichment below returns undefined), but undefined on a
+        // bot-only install where Slack returns no authed_user. The route guards
+        // for that and falls back to the success page.
         userId: tokenResponse.authed_user?.id,
         user: userInfo,
         details: {

--- a/apps/slack-oauth-backend/src/oauth/handler.ts
+++ b/apps/slack-oauth-backend/src/oauth/handler.ts
@@ -132,6 +132,10 @@ export class SlackOAuthHandler implements OAuthHandler {
         // Surface the fresh bot token so the route can authenticate post-install
         // actions (DM delivery) without a static, rotation-incompatible token.
         botAccessToken: tokenResponse.access_token,
+        // The authed user's ID straight from the exchange. Always present here,
+        // so DM delivery can target it even when the users.info enrichment below
+        // returns undefined.
+        userId: tokenResponse.authed_user?.id,
         user: userInfo,
         details: {
           team: tokenResponse.team,

--- a/apps/slack-oauth-backend/src/oauth/types.ts
+++ b/apps/slack-oauth-backend/src/oauth/types.ts
@@ -106,9 +106,15 @@ export interface OAuthResult {
   botAccessToken?: string;
   /**
    * Authenticated user's Slack ID, taken directly from the token exchange
-   * (authed_user.id). Always present on success, unlike `user`, which depends
-   * on a users.info enrichment call that can fail. Use this as the DM target so
-   * delivery does not hinge on enrichment succeeding.
+   * (authed_user.id). Present on a user-token install (the common case) and
+   * more reliable than `user` — which additionally depends on a users.info
+   * enrichment call that can fail. Use this as the DM target so delivery does
+   * not hinge on enrichment succeeding.
+   *
+   * Absent on a bot-only install (no user scopes granted, so Slack returns no
+   * `authed_user`); that flow still reports `success: true`. Callers must treat
+   * it as optional — when undefined, DM delivery is skipped and the success
+   * page is the only delivery channel.
    */
   userId?: string;
   /** User information if successful (enrichment; may be absent if users.info fails) */

--- a/apps/slack-oauth-backend/src/oauth/types.ts
+++ b/apps/slack-oauth-backend/src/oauth/types.ts
@@ -104,7 +104,14 @@ export interface OAuthResult {
    * token rotation these expire (~12h), so callers must use it inline.
    */
   botAccessToken?: string;
-  /** User information if successful */
+  /**
+   * Authenticated user's Slack ID, taken directly from the token exchange
+   * (authed_user.id). Always present on success, unlike `user`, which depends
+   * on a users.info enrichment call that can fail. Use this as the DM target so
+   * delivery does not hinge on enrichment succeeding.
+   */
+  userId?: string;
+  /** User information if successful (enrichment; may be absent if users.info fails) */
   user?: SlackUserInfo;
   /** Error message if failed */
   error?: string;

--- a/apps/slack-oauth-backend/src/routes/oauth.spec.ts
+++ b/apps/slack-oauth-backend/src/routes/oauth.spec.ts
@@ -16,15 +16,19 @@ jest.mock('../config', () => ({
   },
 }));
 
-// Silence logging.
-jest.mock('../utils/logger', () => ({
-  logger: {
-    warn: jest.fn(),
-    info: jest.fn(),
-    error: jest.fn(),
-    child: jest.fn().mockReturnThis(),
-  },
-}));
+// Silence logging. Stable singleton so the spies survive jest.isolateModules
+// (used by createTestApp): a fresh module registry re-runs this factory, but we
+// return the same `mockLogger` object every time, so the route under test and
+// the test assertions share the same `error`/`warn` spies. `child()` returns
+// the same logger, so `requestLogger.error` IS `mockLogger.error`.
+const mockLogger = {
+  warn: jest.fn(),
+  info: jest.fn(),
+  error: jest.fn(),
+  child: jest.fn(),
+};
+mockLogger.child.mockReturnValue(mockLogger);
+jest.mock('../utils/logger', () => ({ logger: mockLogger }));
 
 // Avoid real Slack DM delivery on the success path.
 const mockSendDirectMessage = jest.fn().mockResolvedValue({ ok: true });
@@ -271,6 +275,74 @@ describe('OAuth routes — browser-bound state (double-submit cookie)', () => {
         'U123456',
         expect.any(String),
         expect.anything()
+      );
+    });
+
+    it('does NOT render any token on the success page when the DM succeeds', async () => {
+      const app = createTestApp();
+
+      // Rotation-enabled token would be available, but the DM goes out, so the
+      // page must be the no-secrets variant: the fallback is gated on !dmSent,
+      // and this pins that gate so a future change can't leak secrets on the
+      // happy path.
+      (WebClient as jest.MockedClass<typeof WebClient>).mockImplementation(
+        () =>
+          ({
+            oauth: {
+              v2: {
+                access: jest.fn().mockResolvedValue({
+                  ...tokenExchangeResponse,
+                  authed_user: {
+                    ...tokenExchangeResponse.authed_user,
+                    refresh_token: 'xoxe-user-refresh-token',
+                  },
+                }),
+              },
+            },
+            users: { info: jest.fn().mockResolvedValue(userInfoResponse) },
+          } as any)
+      );
+      mockSendDirectMessage.mockResolvedValue({ ok: true });
+
+      const { nonce, state } = await startFlow(app);
+      const res = await request(app)
+        .get('/slack/oauth/callback')
+        .query({ code: 'valid-auth-code', state })
+        .set('Cookie', `${COOKIE_NAME}=${nonce}`)
+        .expect(200);
+
+      // DM was delivered, so the page shows none of the secrets.
+      expect(res.text).not.toContain('xoxp-user-token'); // access token
+      expect(res.text).not.toContain('xoxe-user-refresh-token'); // refresh token
+      expect(res.text).not.toContain('Refresh Token');
+    });
+
+    it('logs the underlying Slack error code (not the token) when the DM fails', async () => {
+      const app = createTestApp();
+
+      // Reproduce the shape of a real SlackApiError wrapping the Slack WebAPI
+      // error, whose code lives at details.originalError.data.error. The route
+      // must extract that code into `slackError`, never the token.
+      const slackApiError = Object.assign(new Error('Failed to open DM channel'), {
+        code: 'SLACK_API_ERROR',
+        details: { originalError: { data: { error: 'channel_not_found' } } },
+      });
+      mockSendDirectMessage.mockRejectedValue(slackApiError);
+
+      const { nonce, state } = await startFlow(app);
+      await request(app)
+        .get('/slack/oauth/callback')
+        .query({ code: 'valid-auth-code', state })
+        .set('Cookie', `${COOKIE_NAME}=${nonce}`)
+        .expect(200);
+
+      // logger.child() returns the same mocked logger, so logger.error is the spy.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { logger } = require('../utils/logger');
+      expect(logger.error).toHaveBeenCalledWith(
+        'Failed to send token via DM',
+        slackApiError,
+        expect.objectContaining({ slackError: 'channel_not_found' })
       );
     });
   });

--- a/apps/slack-oauth-backend/src/routes/oauth.spec.ts
+++ b/apps/slack-oauth-backend/src/routes/oauth.spec.ts
@@ -207,5 +207,71 @@ describe('OAuth routes — browser-bound state (double-submit cookie)', () => {
       expect(res.text).toContain('Security validation failed.');
       expect(mockSendDirectMessage).not.toHaveBeenCalled();
     });
+
+    it('renders BOTH access and refresh tokens on the success page when the DM fails', async () => {
+      const app = createTestApp();
+
+      // Rotation-enabled user token comes back with a refresh token.
+      (WebClient as jest.MockedClass<typeof WebClient>).mockImplementation(
+        () =>
+          ({
+            oauth: {
+              v2: {
+                access: jest.fn().mockResolvedValue({
+                  ...tokenExchangeResponse,
+                  authed_user: {
+                    ...tokenExchangeResponse.authed_user,
+                    refresh_token: 'xoxe-user-refresh-token',
+                  },
+                }),
+              },
+            },
+            users: { info: jest.fn().mockResolvedValue(userInfoResponse) },
+          } as any)
+      );
+      // DM delivery fails -> the page is the fallback and must carry both tokens,
+      // or the user has no way to obtain their refresh token (the Jun 2026 regression).
+      mockSendDirectMessage.mockRejectedValue(new Error('channel_not_found'));
+
+      const { nonce, state } = await startFlow(app);
+      const res = await request(app)
+        .get('/slack/oauth/callback')
+        .query({ code: 'valid-auth-code', state })
+        .set('Cookie', `${COOKIE_NAME}=${nonce}`)
+        .expect(200);
+
+      expect(res.text).toContain('xoxp-user-token'); // access token
+      expect(res.text).toContain('xoxe-user-refresh-token'); // refresh token (regression guard)
+      expect(res.text).toContain('Refresh Token');
+    });
+
+    it('still sends the DM via authed_user.id when users.info enrichment fails', async () => {
+      const app = createTestApp();
+
+      // Enrichment fails (users.info throws) -> handler returns user: undefined,
+      // but userId (authed_user.id) is still populated. DM must NOT be skipped.
+      (WebClient as jest.MockedClass<typeof WebClient>).mockImplementation(
+        () =>
+          ({
+            oauth: { v2: { access: jest.fn().mockResolvedValue(tokenExchangeResponse) } },
+            users: { info: jest.fn().mockRejectedValue(new Error('missing_scope')) },
+          } as any)
+      );
+      mockSendDirectMessage.mockResolvedValue({ ok: true });
+
+      const { nonce, state } = await startFlow(app);
+      await request(app)
+        .get('/slack/oauth/callback')
+        .query({ code: 'valid-auth-code', state })
+        .set('Cookie', `${COOKIE_NAME}=${nonce}`)
+        .expect(200);
+
+      expect(mockSendDirectMessage).toHaveBeenCalledTimes(1);
+      expect(mockSendDirectMessage).toHaveBeenCalledWith(
+        'U123456',
+        expect.any(String),
+        expect.anything()
+      );
+    });
   });
 });

--- a/apps/slack-oauth-backend/src/routes/oauth.ts
+++ b/apps/slack-oauth-backend/src/routes/oauth.ts
@@ -154,6 +154,17 @@ router.get(
             userId: result.userId,
           });
           dmSent = true;
+        } else {
+          // Successful exchange but DM preconditions unmet: most likely a
+          // bot-only install (no user scopes granted -> no authed_user.id, so
+          // result.userId is undefined). The success-page fallback still
+          // delivers the tokens, but surface a warn so a missing-user-scope
+          // misconfiguration is diagnosable rather than inferred from the
+          // info-level 'OAuth flow successful' breadcrumb.
+          requestLogger.warn('DM skipped: missing userId or accessToken on successful exchange', {
+            hasUserId: !!result.userId,
+            hasAccessToken: !!result.accessToken,
+          });
         }
       } catch (dmError) {
         // Don't fail the flow (the success-page fallback still delivers tokens),

--- a/apps/slack-oauth-backend/src/routes/oauth.ts
+++ b/apps/slack-oauth-backend/src/routes/oauth.ts
@@ -124,38 +124,49 @@ router.get(
       }
 
       requestLogger.info('OAuth flow successful', {
-        userId: result.user?.id,
+        userId: result.userId,
         teamId: result.user?.team_id,
       });
 
-      // Send token via Slack DM
+      // Send token via Slack DM. Target the authed user's ID from the exchange
+      // (result.userId), NOT the users.info enrichment (result.user): enrichment
+      // can fail independently, and gating delivery on it silently drops the DM
+      // even though we have everything needed to send one.
       let dmSent = false;
       try {
-        if (result.user?.id && result.accessToken) {
+        if (result.userId && result.accessToken) {
           // Authenticate the DM with the bot token freshly issued by this
           // exchange (not a static env var, which dies under token rotation).
           const slackClient = createSlackClient(undefined, result.botAccessToken);
           const tokenMessage = formatTokenMessage(
             result.accessToken,
-            result.user.name,
+            result.user?.name,
             result.refreshToken
           );
 
           await slackClient.sendDirectMessage(
-            result.user.id,
+            result.userId,
             tokenMessage.text,
             tokenMessage.blocks
           );
 
           requestLogger.info('Token sent via DM', {
-            userId: result.user.id,
+            userId: result.userId,
           });
           dmSent = true;
         }
       } catch (dmError) {
-        // Log error but don't fail the flow
+        // Don't fail the flow (the success-page fallback still delivers tokens),
+        // but surface the underlying Slack error so DM failures are diagnosable
+        // instead of vanishing into a generic message.
+        const slackError =
+          (dmError as { details?: { originalError?: { data?: { error?: string } } } })?.details
+            ?.originalError?.data?.error ??
+          (dmError as { code?: string })?.code ??
+          (dmError instanceof Error ? dmError.message : 'unknown');
         requestLogger.error('Failed to send token via DM', dmError, {
-          userId: result.user?.id,
+          userId: result.userId,
+          slackError,
         });
         dmSent = false;
       }
@@ -163,13 +174,16 @@ router.get(
       // Send success page with token displayed if DM failed
       // Generate refresh URL based on request host
       const refreshUrl = `${req.protocol}://${req.get('host')}/slack/refresh`;
-      // Never render the refresh token in HTML; the page can be cached by
-      // intermediaries. The access-token fallback display is the accepted
-      // compromise so the user can still copy a token if the DM failed.
+      // Fallback delivery when the DM didn't go out: render BOTH tokens so the
+      // user can complete setup. The no-store/no-cache headers set below keep
+      // this response out of shared caches, and the access token (also a secret)
+      // is shown under those same headers, so the refresh token is no less safe
+      // to display here. Without this, a failed DM leaves the user with no way
+      // to obtain their refresh token.
       const successPage = formatSuccessPage(
         result.user?.name,
         dmSent ? undefined : result.accessToken,
-        undefined,
+        dmSent ? undefined : result.refreshToken,
         dmSent ? undefined : refreshUrl
       );
       res.set({

--- a/apps/slack-oauth-backend/tests/integration/oauth-flow.spec.ts
+++ b/apps/slack-oauth-backend/tests/integration/oauth-flow.spec.ts
@@ -459,7 +459,8 @@ describe('OAuth Flow Integration Tests', () => {
       // User info fails (non-critical)
       mockUsersInfo.mockRejectedValue(new Error('User info failed'));
 
-      // DM operations would succeed if attempted, but won't be called
+      // DM operations succeed: the DM IS attempted here (it targets
+      // authed_user.id, not the failed enrichment), so stub them as ok.
       mockConversationsOpen.mockResolvedValue({
         ok: true,
         channel: { id: 'D777777' },

--- a/apps/slack-oauth-backend/tests/integration/oauth-flow.spec.ts
+++ b/apps/slack-oauth-backend/tests/integration/oauth-flow.spec.ts
@@ -479,9 +479,20 @@ describe('OAuth Flow Integration Tests', () => {
       expect(response.status).toBe(200);
       expect(response.text).toContain('Success!'); // No username since user info failed
 
-      // DM cannot be sent without user info (no user ID available)
-      expect(mockChatPostMessage).not.toHaveBeenCalled();
-      expect(mockConversationsOpen).not.toHaveBeenCalled();
+      // users.info enrichment is non-critical. The DM is still delivered: it
+      // targets authed_user.id from the exchange (U777777), which is available
+      // even when enrichment fails. (Previously the DM was wrongly gated on the
+      // enrichment result and silently skipped here.)
+      expect(mockConversationsOpen).toHaveBeenCalledTimes(1);
+      expect(mockConversationsOpen).toHaveBeenCalledWith(
+        expect.objectContaining({ users: 'U777777' })
+      );
+      expect(mockChatPostMessage).toHaveBeenCalledTimes(1);
+      expect(mockChatPostMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining('xoxp-partial-token'),
+        })
+      );
     });
   });
 


### PR DESCRIPTION
## Problem

Re-authing against the Slack OAuth backend returns an **access token but no refresh token**, which breaks the downstream token-rotation keeper (it can no longer refresh, surfacing as opaque 500s).

Two linked causes, both from the Jun 25 2026 security hardening:
1. `routes/oauth.ts` hardcoded the success-page refresh-token arg to `undefined`, so the HTML fallback (shown when the DM fails) no longer carries the refresh token.
2. DM delivery was gated on the `users.info` enrichment result (`result.user?.id`). When enrichment fails, the DM is silently skipped even though `authed_user.id` is available — so neither channel delivers the refresh token.

## Fix

- **Restore the refresh token on the no-store success-page fallback.** Only rendered when the DM fails (`dmSent ? undefined : result.refreshToken`), under the same `Cache-Control: no-store, no-cache, must-revalidate, private` headers that already protect the access token (also a secret) on that page. Both are HTML-escaped.
- **Decouple DM delivery from `users.info`.** Surface `authed_user.id` as `OAuthResult.userId` and send the DM to it, so an enrichment failure no longer skips the DM. When the precondition genuinely can't be met (bot-only install, no `authed_user`), log a `warn` (booleans only) instead of skipping silently.
- **Surface the underlying Slack error on DM failure** (the error *code*, never the token) for diagnosability.

## Security note

Rendering the refresh token in the success-page fallback is consistent with the access token already rendered there under no-store headers; the "page can be cached" concern the prior commit cited is mitigated by those headers. The prior change broke a real delivery path for a marginal, inconsistent gain.

## Test plan

- `nx test slack-oauth-backend`: **106 passed** (+2 new regression guards: refresh-token-on-page when DM fails; DM sent via `authed_user.id` when `users.info` fails; plus a negative test that the refresh token is NOT rendered when the DM succeeds, and a `SlackApiError`-shaped DM-failure log assertion).
- `nx typecheck slack-oauth-backend`: clean.
- `nx lint slack-oauth-backend`: 0 errors (38 pre-existing `no-explicit-any` warnings, out of scope).
- `nx build slack-oauth-backend`: compiles.
- Reviewed via `/review-fix-loop` (specialist reviewers, two rounds → zero findings); the regression-guard tests were verified to fail against the pre-fix code.

https://claude.ai/code/session_012LLEFGoEDgLpQXRubeMK7w