### PR TITLE
chore(workflows): update model references to claude-sonnet-5

### DIFF
--- a/.github/REUSABLE_WORKFLOWS.md
+++ b/.github/REUSABLE_WORKFLOWS.md
@@ -218,7 +218,7 @@ Notify Release (_notify-release.yml)
 
 | Input                           | Required | Default                          | Description                                                                        |
 | ------------------------------- | -------- | -------------------------------- | ---------------------------------------------------------------------------------- |
-| `model`                         | No       | `'claude-sonnet-4-6'`            | Claude model to use (Sonnet 4.6, Opus 4.8, or Haiku 4.5)                           |
+| `model`                         | No       | `'claude-sonnet-5'`              | Claude model to use (Sonnet 5, Opus 4.8, or Haiku 4.5)                             |
 | `allowed_tools`                 | No       | (permissive defaults, see below) | YAML string specifying which tools Claude can use (file operations, bash commands) |
 | `custom_instructions`           | No       | `'Be sure to follow rules...'`   | Additional instructions for Claude beyond CLAUDE.md files                          |
 | `timeout_minutes`               | No       | `'10'`                           | Maximum execution time in minutes (prevents runaway costs)                         |
@@ -282,7 +282,7 @@ The following settings are intentionally fixed to ensure consistent security and
 
 - **Interactive AI Assistance**: Respond to `@claude` mentions anywhere in GitHub
 - **Multiple Trigger Points**: Works in issue comments, PR comments, review comments, and reviews
-- **Configurable Model**: Choose between Sonnet 4.6 (balanced), Opus 4.8 (thorough), or Haiku 4.5 (fast)
+- **Configurable Model**: Choose between Sonnet 5 (balanced), Opus 4.8 (thorough), or Haiku 4.5 (fast)
 - **Flexible Tool Permissions**: Control what Claude can do (read-only, read-write, or custom)
 - **Custom Instructions**: Add repository-specific guidelines and standards
 - **Bot Filtering**: Automatically excludes bot comments to prevent loops
@@ -410,7 +410,7 @@ jobs:
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     with:
-      model: 'claude-sonnet-4-6'
+      model: 'claude-sonnet-5'
 
   claude-opus:
     if: |
@@ -511,7 +511,7 @@ Worried about Anthropic API costs
 
 **Solutions**:
 
-- Use `claude-sonnet-4-6` (default) instead of Opus for most tasks (~80% cheaper)
+- Use `claude-sonnet-5` (default) instead of Opus for most tasks (~80% cheaper)
 - Reduce `timeout_minutes` to limit execution time (default: 10)
 - The workflow includes concurrency control to prevent duplicate runs
 - Monitor usage at console.anthropic.com
@@ -545,7 +545,7 @@ Claude says it doesn't have permission to perform action
 
 2. **Choose the Right Model**:
 
-   - **Sonnet 4.6** (default): Best balance of speed, capability, and cost for 90% of use cases
+   - **Sonnet 5** (default): Best balance of speed, capability, and cost for 90% of use cases
    - **Opus 4.8**: Reserve for complex architectural reviews or critical security analysis
    - **Haiku 4.5**: Fast and cost-effective for simple questions, quick lookups, or high-volume usage
 
@@ -606,7 +606,7 @@ jobs:
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     with:
-      model: 'claude-sonnet-4-6'
+      model: 'claude-sonnet-5'
       timeout_minutes: '5'
 
   claude-pr-reviews:
@@ -690,7 +690,7 @@ Tips for managing Claude API costs effectively:
 1. **Model Selection Impact**:
 
    - Haiku 4.5: Most cost-effective for simple tasks
-   - Sonnet 4.6: ~$3 per 1M input tokens, ~$15 per 1M output tokens (default, recommended)
+   - Sonnet 5: ~$2 per 1M input tokens, ~$10 per 1M output tokens (introductory pricing through Aug 31, 2026; default, recommended)
    - Opus 4.8: ~$5 per 1M input tokens, ~$25 per 1M output tokens (reserve for complex tasks)
    - Typical interaction: 5K-50K tokens (mostly input)
 
@@ -721,7 +721,7 @@ Tips for managing Claude API costs effectively:
 
 - 50 @claude mentions per week
 - Average 20K tokens per interaction
-- Using Sonnet 4.6
+- Using Sonnet 5
 
 ```
 50 mentions × 20K tokens = 1M tokens/week
@@ -984,7 +984,7 @@ jobs:
 | ------------------------------- | -------- | ------------------------------------ | ----------------------------------------------------------------------------------------- |
 | `pr_number`                     | Yes      | -                                    | Pull request number to review                                                             |
 | `base_ref`                      | Yes      | -                                    | Base branch name (e.g., main, master)                                                     |
-| `model`                         | No       | `'claude-sonnet-4-6'`                | Claude model to use for review                                                            |
+| `model`                         | No       | `'claude-sonnet-5'`                  | Claude model to use for review                                                            |
 | `max_turns`                     | No       | `15`                                 | Maximum conversation turns for Claude                                                     |
 | `custom_prompt`                 | No       | `''`                                 | Custom prompt text (overrides file and default). Verdict logic is automatically appended. |
 | `custom_prompt_path`            | No       | `'.claude/prompts/claude-pr-bot.md'` | Path to custom prompt file in repository                                                  |
@@ -1117,7 +1117,7 @@ jobs:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
       # Use Opus for PRs with 'claude-opus' label, otherwise Sonnet
-      model: ${{ contains(github.event.pull_request.labels.*.name, 'claude-opus') && 'claude-opus-4-8' || 'claude-sonnet-4-6' }}
+      model: ${{ contains(github.event.pull_request.labels.*.name, 'claude-opus') && 'claude-opus-4-8' || 'claude-sonnet-5' }}
       max_turns: 20 # Allow more turns for thorough Opus reviews
       timeout_minutes: 45 # Longer timeout for complex reviews
     secrets:
@@ -1500,7 +1500,7 @@ Claude submitted multiple reviews instead of updating one
 
 2. **Model Selection**:
 
-   - **Sonnet 4.6** (default): Best balance for most PRs (~80% of use cases)
+   - **Sonnet 5** (default): Best balance for most PRs (~80% of use cases)
    - **Opus 4.8**: Reserve for critical code, security-sensitive changes, or complex architectures
    - Use labels to let developers request deeper reviews when needed
 
@@ -1584,7 +1584,7 @@ jobs:
     with:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
-      model: 'claude-sonnet-4-6'
+      model: 'claude-sonnet-5'
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
@@ -1639,7 +1639,7 @@ Example cost calculation:
 
 - 20 PRs per week
 - Average 2 review iterations per PR (initial + update)
-- Using Sonnet 4.6
+- Using Sonnet 5
 - ~30K tokens per review
 
 ```

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -110,7 +110,7 @@ If both are provided, OAuth token takes precedence. At least one authentication 
 | Input                           | Required | Default                                                 | Description                                                         |
 | ------------------------------- | -------- | ------------------------------------------------------- | ------------------------------------------------------------------- |
 | `prompt`                        | No       | `""`                                                    | Direct automation prompt (enables automation mode)                  |
-| `model`                         | No       | `claude-sonnet-4-6`                                     | Claude model to use                                                 |
+| `model`                         | No       | `claude-sonnet-5`                                       | Claude model to use                                                 |
 | `allowed_tools`                 | No       | `""`                                                    | Comma-separated list of allowed tools                               |
 | `disallowed_tools`              | No       | `""`                                                    | Comma-separated list of disallowed tools                            |
 | `custom_instructions`           | No       | CLAUDE.md instructions                                  | Additional system prompt instructions                               |
@@ -145,7 +145,7 @@ You can use the `plugin_marketplaces` and `plugins` inputs to install **addition
 ```yaml
 uses: Uniswap/ai-toolkit/.github/workflows/_claude-main.yml@main
 with:
-  model: 'claude-sonnet-4-6'
+  model: 'claude-sonnet-5'
   custom_instructions: |
     Focus on code quality and security.
     Follow CLAUDE.md guidelines.
@@ -158,7 +158,7 @@ secrets:
 ```yaml
 uses: Uniswap/ai-toolkit/.github/workflows/_claude-main.yml@main
 with:
-  model: 'claude-sonnet-4-6'
+  model: 'claude-sonnet-5'
 secrets:
   CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 ```
@@ -168,7 +168,7 @@ secrets:
 ```yaml
 uses: Uniswap/ai-toolkit/.github/workflows/_claude-main.yml@main
 with:
-  model: 'claude-sonnet-4-6'
+  model: 'claude-sonnet-5'
 secrets:
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -302,7 +302,7 @@ You must enable GitHub Actions to create and approve pull requests:
 | `pr_number`                           | Yes      | -                                                       | Pull request number to review                                                                                                  |
 | `base_ref`                            | No       | -                                                       | Base branch name (e.g., main, master). If not provided, fetched via GitHub API.                                                |
 | `force_review`                        | No       | `false`                                                 | Force a full review even if the code hasn't changed (bypasses patch-ID cache)                                                  |
-| `model`                               | No       | `claude-sonnet-4-6`                                     | Claude model to use for review                                                                                                 |
+| `model`                               | No       | `claude-sonnet-5`                                       | Claude model to use for review                                                                                                 |
 | `max_turns`                           | No       | unlimited                                               | Maximum conversation turns for Claude                                                                                          |
 | `prompt_override_files_to_skip`       | No       | `""`                                                    | Path to markdown file overriding "Files to Skip" section                                                                       |
 | `prompt_override_review_priorities`   | No       | `""`                                                    | Path to markdown file overriding "Review Priorities" section                                                                   |
@@ -387,7 +387,7 @@ uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@main
 with:
   pr_number: ${{ github.event.pull_request.number }}
   base_ref: ${{ github.base_ref }}
-  model: 'claude-sonnet-4-6'
+  model: 'claude-sonnet-5'
   toolkit_ref: 'main' # or 'next' to test unreleased changes
 secrets:
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -401,7 +401,7 @@ uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@main
 with:
   pr_number: ${{ github.event.pull_request.number }}
   base_ref: ${{ github.base_ref }}
-  model: 'claude-sonnet-4-6'
+  model: 'claude-sonnet-5'
 secrets:
   CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
   WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}
@@ -560,7 +560,7 @@ If both are provided, OAuth token takes precedence. At least one authentication 
 | `auto_commit`             | No       | `false`                                                 | Auto-commit and push suggestions to PR branch (bypasses suggestion_mode)                           |
 | `fail_on_missing_docs`    | No       | `true`                                                  | Whether missing documentation should cause workflow to fail                                        |
 | `fail_on_missing_version` | No       | `true`                                                  | Whether missing plugin version bumps should cause workflow to fail                                 |
-| `model`                   | No       | `claude-sonnet-4-6`                                     | Claude model to use                                                                                |
+| `model`                   | No       | `claude-sonnet-5`                                       | Claude model to use                                                                                |
 | `max_turns`               | No       | unlimited                                               | Maximum conversation turns for Claude                                                              |
 | `timeout_minutes`         | No       | `15`                                                    | Job timeout in minutes                                                                             |
 | `toolkit_ref`             | No       | `main`                                                  | Git ref of ai-toolkit to use for scripts                                                           |
@@ -1067,15 +1067,15 @@ If both are provided, OAuth token takes precedence. At least one authentication 
 
 **Configuration:**
 
-| Input                     | Default             | Description                                     |
-| ------------------------- | ------------------- | ----------------------------------------------- |
-| `branch_name`             | required            | Branch to work on                               |
-| `target_branch`           | `main`              | Base branch for PR                              |
-| `dry_run`                 | `false`             | Analyze only, skip PR creation                  |
-| `model`                   | `claude-sonnet-4-6` | Claude model to use                             |
-| `timeout_minutes`         | `30`                | Maximum execution time                          |
-| `debug_mode`              | `true`              | Show full Claude output                         |
-| `install_uniswap_plugins` | `true`              | Auto-install uniswap plugins (false to opt out) |
+| Input                     | Default           | Description                                     |
+| ------------------------- | ----------------- | ----------------------------------------------- |
+| `branch_name`             | required          | Branch to work on                               |
+| `target_branch`           | `main`            | Base branch for PR                              |
+| `dry_run`                 | `false`           | Analyze only, skip PR creation                  |
+| `model`                   | `claude-sonnet-5` | Claude model to use                             |
+| `timeout_minutes`         | `30`              | Maximum execution time                          |
+| `debug_mode`              | `true`            | Show full Claude output                         |
+| `install_uniswap_plugins` | `true`            | Auto-install uniswap plugins (false to opt out) |
 
 **Example Transformation:**
 
@@ -1216,13 +1216,13 @@ The Notion integration needs access to:
 
 **Configuration Inputs:**
 
-| Input                    | Default             | Description                                                                                       |
-| ------------------------ | ------------------- | ------------------------------------------------------------------------------------------------- |
-| `days_back`              | `7`                 | Number of days to look back for content                                                           |
-| `model`                  | `claude-sonnet-4-6` | Claude model to use                                                                               |
-| `dry_run`                | `false`             | Generate but don't publish to Notion                                                              |
-| `debug_mode`             | `true`              | Enable full Claude output for debugging                                                           |
-| `slack_post_channel_ids` | `C091XE1DNP2`       | Comma-separated Slack channel IDs to post newsletter announcement (e.g., C091XE1DNP2,C094URH6C13) |
+| Input                    | Default           | Description                                                                                       |
+| ------------------------ | ----------------- | ------------------------------------------------------------------------------------------------- |
+| `days_back`              | `7`               | Number of days to look back for content                                                           |
+| `model`                  | `claude-sonnet-5` | Claude model to use                                                                               |
+| `dry_run`                | `false`           | Generate but don't publish to Notion                                                              |
+| `debug_mode`             | `true`            | Enable full Claude output for debugging                                                           |
+| `slack_post_channel_ids` | `C091XE1DNP2`     | Comma-separated Slack channel IDs to post newsletter announcement (e.g., C091XE1DNP2,C094URH6C13) |
 
 **Manual Trigger:**
 
@@ -1363,7 +1363,7 @@ jobs:
   call-claude:
     uses: ./.github/workflows/_claude-main.yml
     with:
-      model: 'claude-sonnet-4-6'
+      model: 'claude-sonnet-5'
       allowed_tools: 'read-write'
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -1709,7 +1709,7 @@ Many workflows support manual triggering via GitHub UI or CLI:
 ```bash
 gh workflow run claude-code-review.yml \
   -f pr_number=123 \
-  -f model="claude-sonnet-4-6"
+  -f model="claude-sonnet-5"
 ```
 
 ## Troubleshooting

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -75,7 +75,7 @@ Workflows designed to be called by other workflows using `workflow_call`. These 
 
   - Interactive AI assistance via @claude mentions
   - Works in issue comments, PR comments, review comments, and reviews
-  - Configurable models (Sonnet 4.6, Opus 4.8, Haiku 4.5)
+  - Configurable models (Sonnet 5, Opus 4.8, Haiku 4.5)
   - Flexible tool permissions (read-only, read-write, or custom)
   - Custom instructions for repository-specific standards
   - Fixed security settings (Bullfrog scanning, immutable permissions)

--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -70,7 +70,7 @@ on:
         description: "Claude model to use for review"
         required: false
         type: string
-        default: "claude-sonnet-4-6"
+        default: "claude-sonnet-5"
 
       max_turns:
         description: "Maximum conversation turns for Claude. Omit to use unlimited turns."

--- a/.github/workflows/_claude-docs-check.yml
+++ b/.github/workflows/_claude-docs-check.yml
@@ -83,7 +83,7 @@ on:
         description: "Claude model to use"
         required: false
         type: string
-        default: "claude-sonnet-4-6"
+        default: "claude-sonnet-5"
 
       max_turns:
         description: "Maximum conversation turns for Claude"

--- a/.github/workflows/_claude-main.yml
+++ b/.github/workflows/_claude-main.yml
@@ -38,11 +38,11 @@
 #     secrets:
 #       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 #     with:
-#       model: 'claude-sonnet-4-6'
+#       model: 'claude-sonnet-5'
 #
 # INPUTS:
 # - prompt (optional): Direct automation prompt (enables automation mode)
-# - model (optional): Claude model to use (default: claude-sonnet-4-6)
+# - model (optional): Claude model to use (default: claude-sonnet-5)
 # - allowed_tools (optional): Comma-separated list of allowed tools
 # - disallowed_tools (optional): Comma-separated list of disallowed tools
 # - custom_instructions (optional): Additional instructions for Claude (system prompt)
@@ -78,14 +78,14 @@ on:
           Claude model to use for this execution.
 
           Available models:
-          - claude-sonnet-4-6 (default, recommended) - Latest Sonnet model with best balance of speed and capability
+          - claude-sonnet-5 (default, recommended) - Latest Sonnet model with best balance of speed and capability
           - claude-opus-4-8 - Most capable model for complex tasks
           - claude-haiku-4-5-20251001 - Fast, cost-effective model for simpler tasks
 
-          Default: claude-sonnet-4-6
+          Default: claude-sonnet-5
         required: false
         type: string
-        default: "claude-sonnet-4-6"
+        default: "claude-sonnet-5"
 
       allowed_tools:
         description: |

--- a/.github/workflows/_claude-task-worker.yml
+++ b/.github/workflows/_claude-task-worker.yml
@@ -20,7 +20,7 @@
 #       issue_url: ${{ matrix.issue_url }}
 #       branch_name: ${{ matrix.branch_name }}
 #       target_branch: 'next'
-#       model: 'claude-sonnet-4-6'
+#       model: 'claude-sonnet-5'
 #     secrets:
 #       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 #       LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
@@ -33,7 +33,7 @@
 # - issue_url: Linear issue URL
 # - branch_name: Branch to create (e.g., "claude/dai-123-fix-bug")
 # - target_branch: Branch to create PR against (default: "next")
-# - model: Claude model to use (default: claude-sonnet-4-6)
+# - model: Claude model to use (default: claude-sonnet-5)
 # - timeout_minutes: Execution timeout (default: 60)
 # - linear_task_utils_tag: npm tag for @uniswap/ai-toolkit-linear-task-utils (default: "latest")
 # - debug_mode: Enable full Claude Code output for debugging (default: true)
@@ -89,7 +89,7 @@ on:
       model:
         description: |
           Claude model to use.
-          Options: claude-sonnet-4-6, claude-opus-4-8, claude-haiku-4-5-20251001
+          Options: claude-sonnet-5, claude-opus-4-8, claude-haiku-4-5-20251001
         required: false
         type: string
         default: "claude-opus-4-8"

--- a/.github/workflows/_update-action-versions-worker.yml
+++ b/.github/workflows/_update-action-versions-worker.yml
@@ -21,7 +21,7 @@
 #   - branch_name: Branch to work on (required)
 #   - target_branch: Base branch for PR (default: main)
 #   - dry_run: Skip PR creation, report only (default: false)
-#   - model: Claude model to use (default: claude-sonnet-4-6)
+#   - model: Claude model to use (default: claude-sonnet-5)
 #   - timeout_minutes: Execution timeout (default: 30)
 #   - debug_mode: Show full Claude output (default: true)
 #
@@ -56,7 +56,7 @@ on:
         description: "Claude model to use"
         required: false
         type: string
-        default: "claude-sonnet-4-6"
+        default: "claude-sonnet-5"
 
       timeout_minutes:
         description: "Maximum execution time in minutes"

--- a/.github/workflows/claude-auto-tasks.yml
+++ b/.github/workflows/claude-auto-tasks.yml
@@ -52,7 +52,7 @@ on:
         required: false
         type: choice
         options:
-          - "claude-sonnet-4-6"
+          - "claude-sonnet-5"
           - "claude-opus-4-8"
           - "claude-haiku-4-5"
         default: "claude-opus-4-8"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -231,7 +231,7 @@ jobs:
       # Opus is more capable at following complex multi-step instructions
       # Uncomment one of these to use a different model for reviews:
       # model: 'claude-haiku-4-5'
-      # model: 'claude-sonnet-4-6'
+      # model: 'claude-sonnet-5'
       model: "claude-opus-4-8"
 
       # Allow standard review conversation turns

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -37,8 +37,8 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     with:
-      # Use default Sonnet 4.6 model
-      model: 'claude-sonnet-4-6'
+      # Use default Sonnet 5 model
+      model: 'claude-sonnet-5'
 
       # Repository-specific instructions
       custom_instructions: |

--- a/.github/workflows/claude-docs-check.yml
+++ b/.github/workflows/claude-docs-check.yml
@@ -69,7 +69,7 @@ jobs:
       suggestion_mode: ${{ github.event.inputs.suggestion_mode || 'suggest' }}
       auto_commit: ${{ github.event.inputs.auto_commit == 'true' }}
       # Use sonnet for faster, cheaper checks
-      model: "claude-sonnet-4-6"
+      model: "claude-sonnet-5"
       # Fail if plugin versions aren't bumped
       fail_on_missing_version: true
       # Don't fail on missing docs (just warn)

--- a/.github/workflows/dev-ai-newsletter.yml
+++ b/.github/workflows/dev-ai-newsletter.yml
@@ -96,9 +96,9 @@ on:
         required: false
         type: choice
         options:
-          - "claude-sonnet-4-6"
+          - "claude-sonnet-5"
           - "claude-opus-4-8"
-        default: "claude-sonnet-4-6"
+        default: "claude-sonnet-5"
 
       dry_run:
         description: "Dry run (generate but don't publish to Notion)"
@@ -128,7 +128,7 @@ concurrency:
 
 env:
   DAYS_BACK: ${{ inputs.days_back || '7' }}
-  MODEL: ${{ inputs.model || 'claude-sonnet-4-6' }}
+  MODEL: ${{ inputs.model || 'claude-sonnet-5' }}
   DRY_RUN: ${{ inputs.dry_run || 'false' }}
   DEBUG_MODE: ${{ inputs.debug_mode || 'true' }}
 

--- a/.github/workflows/examples/06-claude-main-basic.yml
+++ b/.github/workflows/examples/06-claude-main-basic.yml
@@ -55,8 +55,8 @@ jobs:
     with:
       # All inputs are optional - sensible defaults are provided
 
-      # OPTIONAL: Claude model to use (default: claude-sonnet-4-6)
-      # model: 'claude-sonnet-4-6'
+      # OPTIONAL: Claude model to use (default: claude-sonnet-5)
+      # model: 'claude-sonnet-5'
 
       # OPTIONAL: Maximum execution time in minutes (default: 10)
       # timeout_minutes: '10'
@@ -190,7 +190,7 @@ jobs:
 #     secrets:
 #       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 #     with:
-#       model: 'claude-sonnet-4-6'
+#       model: 'claude-sonnet-5'
 #
 #   # Claude Opus for thorough reviews (when 'claude-opus' label is present)
 #   claude-opus:
@@ -234,7 +234,7 @@ jobs:
 #
 # Problem: API rate limit or cost concerns
 # Solution:
-#   - Use claude-sonnet-4-6 (default) instead of Opus for most tasks
+#   - Use claude-sonnet-5 (default) instead of Opus for most tasks
 #   - Reduce timeout_minutes to limit execution time
 #   - Add rate limiting via GitHub Actions concurrency groups (already included)
 #
@@ -254,7 +254,7 @@ jobs:
 #
 # Before deploying this workflow:
 # ☐ Configure ANTHROPIC_API_KEY secret in repository settings
-# ☐ Choose appropriate model (Sonnet 4.6 for most cases, Opus for complex analysis)
+# ☐ Choose appropriate model (Sonnet 5 for most cases, Opus for complex analysis)
 # ☐ Set timeout_minutes based on repository size and expected tasks
 # ☐ Decide on tool permissions (default permissive vs restricted read-only)
 # ☐ Add custom_instructions if you have specific coding standards
@@ -270,14 +270,14 @@ jobs:
 # If you're migrating from the universe repository's claude.yml workflow:
 # 1. Replace the old workflow file with this one
 # 2. Update the secret name if different (default: ANTHROPIC_API_KEY)
-# 3. The model has been updated to claude-sonnet-4-6 (latest)
+# 3. The model has been updated to claude-sonnet-5 (latest)
 # 4. allowed_tools now defaults to a more permissive set (read + write)
 # 5. Security settings (bullfrog, permissions) are now fixed and cannot be overridden
 # 6. Test the new workflow with a @claude mention
 #
 # Key differences from universe:
 # - Reusable workflow pattern (uses: instead of inline)
-# - Updated default model (Sonnet 4.6 by default)
+# - Updated default model (Sonnet 5 by default)
 # - More permissive default tools (includes write_file, edit_file)
 # - Fixed security and permission settings
 # - Centralized in ai-toolkit for organization-wide consistency

--- a/.github/workflows/examples/07-claude-main-custom.yml
+++ b/.github/workflows/examples/07-claude-main-custom.yml
@@ -47,7 +47,7 @@ jobs:
     with:
       # MODEL SELECTION
       # Choose the Claude model based on your needs:
-      # - claude-sonnet-4-6: Latest, best balance (RECOMMENDED)
+      # - claude-sonnet-5: Latest, best balance (RECOMMENDED)
       # - claude-opus-4-8: Most capable, slower, higher cost
       # - claude-haiku-4-5: Fast, cost-effective for simpler tasks
       model: "claude-opus-4-8"
@@ -149,7 +149,7 @@ jobs:
 # Use when you trust Claude to make direct code changes:
 #
 #     with:
-#       model: 'claude-sonnet-4-6'
+#       model: 'claude-sonnet-5'
 #       timeout_minutes: '10'
 #       allowed_tools: |
 #         # File operations (read AND write)
@@ -171,7 +171,7 @@ jobs:
 # Allow file edits but restrict bash commands:
 #
 #     with:
-#       model: 'claude-sonnet-4-6'
+#       model: 'claude-sonnet-5'
 #       timeout_minutes: '10'
 #       allowed_tools: |
 #         # File operations (read and write)
@@ -196,7 +196,7 @@ jobs:
 # Minimal permissions for pure code review assistance:
 #
 #     with:
-#       model: 'claude-sonnet-4-6'
+#       model: 'claude-sonnet-5'
 #       timeout_minutes: '10'
 #       custom_instructions: |
 #         You are in READ-ONLY mode for code review.
@@ -220,7 +220,7 @@ jobs:
 #       ANTHROPIC_API_KEY: ${{ secrets.MY_CUSTOM_CLAUDE_KEY }}
 #     with:
 #       anthropic_api_key_secret_name: 'MY_CUSTOM_CLAUDE_KEY'
-#       model: 'claude-sonnet-4-6'
+#       model: 'claude-sonnet-5'
 #
 
 # -----------------------------------------------------------------------------
@@ -243,7 +243,7 @@ jobs:
 #     secrets:
 #       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 #     with:
-#       model: 'claude-sonnet-4-6'  # Fast for questions
+#       model: 'claude-sonnet-5'  # Fast for questions
 #       timeout_minutes: '5'
 #
 #   claude-pr-reviews:
@@ -354,7 +354,7 @@ jobs:
 # Solution:
 #   1. Increase timeout_minutes (e.g., from 10 to 15 or 20)
 #   2. Simplify custom_instructions to reduce processing time
-#   3. Use a faster model (Sonnet 4.6 instead of Opus)
+#   3. Use a faster model (Sonnet 5 instead of Opus)
 #   4. Restrict allowed_tools to reduce tool exploration time
 #
 # Problem: Different behavior than expected with tool restrictions
@@ -367,7 +367,7 @@ jobs:
 # Problem: Custom model not available or failing
 # Solution:
 #   1. Verify model name exactly matches available models:
-#      - claude-sonnet-4-6
+#      - claude-sonnet-5
 #      - claude-opus-4-8
 #      - claude-haiku-4-5
 #   2. Check Anthropic API key has access to requested model
@@ -417,7 +417,7 @@ jobs:
 #
 # 1. **Choose the right model**:
 #    - Haiku 4.5: Most cost-effective for simple tasks and high-volume usage
-#    - Sonnet 4.6: Best balance for most tasks (~80% cheaper than Opus)
+#    - Sonnet 5: Best balance for most tasks (~80% cheaper than Opus)
 #    - Opus: Reserve for complex analysis or critical reviews
 #
 # 2. **Set appropriate timeouts**:

--- a/.github/workflows/examples/08-claude-code-review-basic.yml
+++ b/.github/workflows/examples/08-claude-code-review-basic.yml
@@ -47,7 +47,7 @@ jobs:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
       # All other inputs use defaults:
-      # - model: claude-sonnet-4-6
+      # - model: claude-sonnet-5
       # - max_turns: 15
       # - timeout_minutes: 30
       # - custom_prompt: (uses default from ai-toolkit)

--- a/.github/workflows/examples/10-claude-code-review-advanced.yml
+++ b/.github/workflows/examples/10-claude-code-review-advanced.yml
@@ -12,7 +12,7 @@ name: 'Example: Claude Code Review - Advanced'
 # - Auto-fix with WORKFLOW_PAT for triggering subsequent reviews
 #
 # Model Selection:
-# - Default: Claude Sonnet 4.6 (fast, cost-effective)
+# - Default: Claude Sonnet 5 (fast, cost-effective)
 # - With 'claude-opus' label: Claude Opus 4.8 (more thorough, slower)
 #
 # Use Cases:
@@ -55,7 +55,7 @@ jobs:
 
       # Model selection based on PR labels
       # Add 'claude-opus' label to PRs that need more thorough review
-      model: ${{ contains(github.event.pull_request.labels.*.name, 'claude-opus') && 'claude-opus-4-8' || 'claude-sonnet-4-6' }}
+      model: ${{ contains(github.event.pull_request.labels.*.name, 'claude-opus') && 'claude-opus-4-8' || 'claude-sonnet-5' }}
 
       # Allow more turns for complex reviews
       # Default is 15, increase for PRs that need deeper analysis

--- a/.github/workflows/examples/11-autonomous-linear-tasks.yml
+++ b/.github/workflows/examples/11-autonomous-linear-tasks.yml
@@ -62,7 +62,7 @@ on:
         required: false
         type: choice
         options:
-          - "claude-sonnet-4-6" # Balanced (recommended)
+          - "claude-sonnet-5" # Balanced (recommended)
           - "claude-opus-4-8" # Most capable
           - "claude-haiku-4-5" # Fast & economical
         default: "claude-opus-4-8"

--- a/.github/workflows/examples/12-generate-pr-metadata-basic.yml
+++ b/.github/workflows/examples/12-generate-pr-metadata-basic.yml
@@ -49,7 +49,7 @@ jobs:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
       # All other inputs use defaults:
-      # - model: claude-sonnet-4-6
+      # - model: claude-sonnet-5
       # - timeout_minutes: 15
       # - commit_history_count: 30
       # - pr_history_count: 10

--- a/.github/workflows/examples/13-generate-pr-metadata-custom.yml
+++ b/.github/workflows/examples/13-generate-pr-metadata-custom.yml
@@ -47,7 +47,7 @@ jobs:
       base_ref: ${{ github.base_ref }}
 
       # Use a faster model for quick generation
-      model: 'claude-sonnet-4-6'
+      model: 'claude-sonnet-5'
 
       # Increase timeout for complex PRs
       timeout_minutes: 20

--- a/.github/workflows/examples/CLAUDE.md
+++ b/.github/workflows/examples/CLAUDE.md
@@ -141,7 +141,7 @@ Most examples accept these inputs:
 inputs:
   model:
     description: 'Claude model to use'
-    default: 'claude-sonnet-4-6'
+    default: 'claude-sonnet-5'
 
   custom_prompt_path:
     description: 'Path to custom prompt file'

--- a/.github/workflows/generate-pr-title-description.yml
+++ b/.github/workflows/generate-pr-title-description.yml
@@ -49,7 +49,7 @@ jobs:
       generation_mode: "title,description"
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
-      # Use default model (claude-sonnet-4-6)
+      # Use default model (claude-sonnet-5)
       # Use default timeout (15 minutes)
       # Use default prompt from ai-toolkit
       commit_history_count: 30

--- a/.github/workflows/update-action-versions.yml
+++ b/.github/workflows/update-action-versions.yml
@@ -42,10 +42,10 @@ on:
       model:
         description: 'Claude model to use'
         required: false
-        default: 'claude-sonnet-4-6'
+        default: 'claude-sonnet-5'
         type: choice
         options:
-          - 'claude-sonnet-4-6'
+          - 'claude-sonnet-5'
           - 'claude-opus-4-8'
       target_branch:
         description: 'Base branch for the PR'
@@ -95,7 +95,7 @@ jobs:
           fi
 
           if [ -z "$INPUT_MODEL" ]; then
-            echo "model=claude-sonnet-4-6" >> $GITHUB_OUTPUT
+            echo "model=claude-sonnet-5" >> $GITHUB_OUTPUT
           else
             echo "model=$INPUT_MODEL" >> $GITHUB_OUTPUT
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,7 +223,7 @@ All plugins follow semantic versioning (semver). Key versioning rules:
 | Plugin                     | Version |
 | -------------------------- | ------- |
 | claude-setup               | 1.0.5   |
-| development-codebase-tools | 2.6.1   |
+| development-codebase-tools | 2.6.2   |
 | development-planning       | 2.0.7   |
 | development-pr-workflow    | 2.2.0   |
 | development-productivity   | 2.4.1   |

--- a/docs/guides/autonomous-claude-tasks.md
+++ b/docs/guides/autonomous-claude-tasks.md
@@ -59,9 +59,9 @@ on:
         description: 'Claude model'
         type: choice
         options:
-          - 'claude-sonnet-4-6'
+          - 'claude-sonnet-5'
           - 'claude-opus-4-8'
-        default: 'claude-sonnet-4-6'
+        default: 'claude-sonnet-5'
       target_branch:
         description: 'Branch to create PRs against'
         default: 'main'
@@ -130,21 +130,21 @@ See the full example at `.github/workflows/examples/11-autonomous-linear-tasks.y
 
 ### Workflow Inputs
 
-| Input           | Default             | Description            |
-| --------------- | ------------------- | ---------------------- |
-| `linear_team`   | "Developer AI"      | Linear team to query   |
-| `linear_label`  | "claude"            | Label to filter issues |
-| `max_issues`    | 3                   | Maximum issues per run |
-| `model`         | "claude-sonnet-4-6" | Claude model to use    |
-| `target_branch` | "next"              | Branch for PRs         |
+| Input           | Default           | Description            |
+| --------------- | ----------------- | ---------------------- |
+| `linear_team`   | "Developer AI"    | Linear team to query   |
+| `linear_label`  | "claude"          | Label to filter issues |
+| `max_issues`    | 3                 | Maximum issues per run |
+| `model`         | "claude-sonnet-5" | Claude model to use    |
+| `target_branch` | "next"            | Branch for PRs         |
 
 ### Model Selection
 
-| Model               | Best For                                  |
-| ------------------- | ----------------------------------------- |
-| `claude-sonnet-4-6` | Balance of speed and capability (default) |
-| `claude-opus-4-8`   | Complex tasks requiring deep reasoning    |
-| `claude-haiku-4-5`  | Simple tasks, cost optimization           |
+| Model              | Best For                                  |
+| ------------------ | ----------------------------------------- |
+| `claude-sonnet-5`  | Balance of speed and capability (default) |
+| `claude-opus-4-8`  | Complex tasks requiring deep reasoning    |
+| `claude-haiku-4-5` | Simple tasks, cost optimization           |
 
 ## Creating Good Task Descriptions
 

--- a/docs/guides/claude-integration.md
+++ b/docs/guides/claude-integration.md
@@ -324,7 +324,7 @@ Claude: [Analyzes the PR files and responds with explanation]
 **Configuration:**
 
 ```yaml
-model: 'claude-sonnet-4-6'
+model: 'claude-sonnet-5'
 timeout_minutes: 10
 custom_instructions: |
   - Follow rules in all CLAUDE.md files
@@ -430,7 +430,7 @@ jobs:
   claude-task:
     uses: ./.github/workflows/_claude-main.yml
     with:
-      model: 'claude-sonnet-4-6'
+      model: 'claude-sonnet-5'
       custom_instructions: |
         Your task-specific instructions here
       timeout_minutes: 15

--- a/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
+++ b/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-codebase-tools",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Codebase exploration, refactoring, and quality analysis",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/development-codebase-tools/agents/context-loader.md
+++ b/packages/plugins/development-codebase-tools/agents/context-loader.md
@@ -1,7 +1,7 @@
 ---
 name: context-loader-agent
 description: 'Analyzes and summarizes a specific codebase area so other agents can implement or debug it correctly. Use when an orchestrator needs deep understanding of a subsystem before delegating work. Trigger phrases: "analyze this area", "load context for", "summarize the X module", "understand how X works", "prepare context before implementation", "what patterns does X use", "give me context on".'
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 ---
 
 You are **context-loader-agent**, a read-only reconnaissance subagent. Your job is to deeply understand a specific area of the codebase and return a structured summary that other agents can use to do their work correctly.

--- a/packages/plugins/development-codebase-tools/agents/style-enforcer.md
+++ b/packages/plugins/development-codebase-tools/agents/style-enforcer.md
@@ -1,7 +1,7 @@
 ---
 name: style-enforcer-agent
 description: Enforces code style and conventions across any language or framework. Use when the user asks to check code style, find style violations, enforce naming conventions, detect code smells or anti-patterns, audit formatting consistency, analyze complexity, or improve readability. Trigger phrases include "fix style issues", "check for lint errors", "enforce our style guide", "clean up naming/formatting", "find code smells", "check for anti-patterns", and "enforce consistency".
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 ---
 
 You are **style-enforcer-agent**, a code style and consistency specialist. You analyze code for formatting violations, naming inconsistencies, complexity hotspots, and anti-patterns, then produce actionable findings and targeted fixes.


### PR DESCRIPTION
## Summary

Anthropic released **Claude Sonnet 5** (`claude-sonnet-5`), which supersedes `claude-sonnet-4-6` as the latest Sonnet model. Per [platform.claude.com/docs/about-claude/models](https://platform.claude.com/docs/en/docs/about-claude/models), `claude-sonnet-4-6` has moved to the legacy models table.

This PR updates all git-tracked references from `claude-sonnet-4-6` to `claude-sonnet-5` across GitHub Actions workflows, docs, and agent frontmatter (26 files, 105 insertions/105 deletions). Also corrected the stale Sonnet pricing note in `REUSABLE_WORKFLOWS.md` ($3/$15 per 1M tokens → introductory $2/$10 per 1M tokens through Aug 31, 2026, per Anthropic's published Sonnet 5 pricing).

No new capabilities are being adopted in this PR — this is a like-for-like ID/prose swap. `claude-opus-4-8` and `claude-haiku-4-5` references are unchanged (still current per the model docs).

**Not adopted here (out of scope for this job):** Claude Fable 5 (`claude-fable-5`, now the most capable widely-released model) and invitation-only Claude Mythos 5 — noting these in the model-watch state backlog for future capability evaluation, not implementing feature changes in this maintenance PR.

## Components updated
- `.github/workflows/*.yml` (main, task-worker, code-review, docs-check, action-versions, newsletter, examples)
- `.github/REUSABLE_WORKFLOWS.md`, `.github/workflows/README.md`, `.github/workflows/CLAUDE.md`, `.github/workflows/examples/CLAUDE.md`
- `docs/guides/autonomous-claude-tasks.md`, `docs/guides/claude-integration.md`
- `packages/plugins/development-codebase-tools/agents/context-loader.md`
- `packages/plugins/development-codebase-tools/agents/style-enforcer.md`

## Test plan
- [x] `npx nx run-many --target=validate --all` — 7 plugins passed
- [x] `npm exec markdownlint-cli2 -- --fix` — 0 errors across 192 files
- [x] `npx nx format:write --uncommitted` — fixed table column alignment after ID-length change
- [x] Pre-commit hooks (format, lint, lint-markdown, test, typecheck, update-lockfile) all passed
- [x] Exhaustive `git ls-files | grep` confirms zero remaining `claude-sonnet-4-6` or "Sonnet 4.6" references