### PR TITLE
fix(skill-management): PR-open hook matcher never matched MCP create_pull_request tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,7 +227,7 @@ All plugins follow semantic versioning (semver). Key versioning rules:
 | development-planning       | 2.0.7   |
 | development-pr-workflow    | 2.2.0   |
 | development-productivity   | 2.4.1   |
-| skill-management           | 1.0.1   |
+| skill-management           | 1.0.2   |
 | spec-workflow              | 2.0.1   |
 | uniswap-integrations       | 2.6.0   |
 

--- a/packages/plugins/skill-management/.claude-plugin/plugin.json
+++ b/packages/plugins/skill-management/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-management",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Audit, map, mine, and improve your Claude Code skills, agents, and slash commands. Inventories your whole customization surface, flags overlaps/gaps/weak triggering descriptions, and mines sessions for workflows worth codifying into new skills or agents.",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/skill-management/CLAUDE.md
+++ b/packages/plugins/skill-management/CLAUDE.md
@@ -28,10 +28,14 @@ session for workflows worth codifying into a new or edited skill or agent.
 
 ### Hooks (./hooks/)
 
-- **pr-skill-doctor-prompt.cjs**: PostToolUse hook (matcher `Bash|create_pull_request`). When a PR is
-  opened, injects a one-time, per-session `additionalContext` nudge asking whether the user wants to
-  run `/skill-mine`. Never blocks the PR; guarded by a session-keyed sentinel under the OS temp dir so
-  it fires at most once per session. Pure Node (`.cjs`) so it needs no `tsx`/`bun`/`jq`.
+- **pr-skill-doctor-prompt.cjs**: PostToolUse hook (matcher `Bash|mcp__.+__create_pull_request`).
+  When a PR is opened, injects a one-time, per-session `additionalContext` nudge asking whether the
+  user wants to run `/skill-mine`. Never blocks the PR; guarded by a session-keyed sentinel under the
+  OS temp dir so it fires at most once per session. Pure Node (`.cjs`) so it needs no `tsx`/`bun`/`jq`.
+  The `.+` in the matcher is load-bearing: a matcher made only of letters, digits, `_`, `-`, spaces,
+  `,`, and `|` is evaluated as a list of exact tool names, so a plain `create_pull_request` entry
+  would never match namespaced MCP tools like `mcp__github__create_pull_request`. The regex
+  metacharacters flip the whole matcher into (unanchored) regex mode.
 
 ## Design notes
 

--- a/packages/plugins/skill-management/hooks/hooks.json
+++ b/packages/plugins/skill-management/hooks/hooks.json
@@ -3,7 +3,7 @@
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "Bash|create_pull_request",
+        "matcher": "Bash|mcp__.+__create_pull_request",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary

The `pr-skill-doctor-prompt.cjs` PostToolUse hook is supposed to fire when a PR is opened via `gh pr create`/`gt submit` (Bash) **or** via a GitHub MCP `create_pull_request` tool. The MCP path has never worked: the matcher in `hooks/hooks.json` was `"Bash|create_pull_request"`, and per the [Claude Code hooks docs](https://code.claude.com/docs/en/hooks), a matcher composed only of letters, digits, `_`, `-`, spaces, `,`, and `|` is evaluated as a **list of exact tool names**, not a regex. Regex mode activates only when the pattern contains a character outside that set.

No MCP tool is named bare `create_pull_request` — they are namespaced (`mcp__github__create_pull_request`, `mcp__plugin_uniswap-integrations_github__create_pull_request`, etc.) — so the hook never fired for MCP-created PRs, the script's `toolName.endsWith('create_pull_request')` branch was unreachable dead code, and the once-per-session `/skill-mine` nudge was silently lost whenever a PR was opened through MCP.

## Fix

One line: matcher becomes `"Bash|mcp__.+__create_pull_request"`. The `.+` metacharacters flip the whole matcher into (unanchored) JavaScript regex mode, so it matches `Bash` and any `mcp__<server>__create_pull_request` tool name.

Edge case checked: in regex mode the unanchored `Bash` alternative also matches `BashOutput`, but `isPrOpen()` in the hook script requires `toolName === 'Bash'` exactly (else the `endsWith` check), so the only cost is a no-op hook invocation — no spurious prompts.

Also in this PR:
- `skill-management` plugin version 1.0.1 → 1.0.2 (patch, per repo semver policy) + root CLAUDE.md version table
- Plugin CLAUDE.md updated to cite the new matcher and document why the `.+` is load-bearing, so this doesn't regress in a future "simplification"

Same fix already shipped and verified in Utility-NYC/closet-ai#57 (`plugins/closet-ai-meta/hooks/hooks.json`).

## Test plan

- Matcher semantics verified against the Claude Code hooks docs (exact-string-list vs regex-mode split, unanchored `RegExp.test`)
- `node scripts/validate-plugin.cjs packages/plugins/skill-management` passes
- `bunx nx affected --target=lint --base=origin/next` green; `bunx markdownlint-cli2` 0 errors
- Independent code-reviewer agent pass on the diff: READY TO MERGE, zero findings