### PR TITLE
refactor(development-pr-workflow): convert backtest-change from command to skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,7 +225,7 @@ All plugins follow semantic versioning (semver). Key versioning rules:
 | claude-setup               | 1.0.5   |
 | development-codebase-tools | 2.6.2   |
 | development-planning       | 2.0.7   |
-| development-pr-workflow    | 2.2.0   |
+| development-pr-workflow    | 2.3.0   |
 | development-productivity   | 2.4.1   |
 | skill-management           | 1.0.2   |
 | spec-workflow              | 2.0.1   |

--- a/packages/plugins/development-pr-workflow/.claude-plugin/plugin.json
+++ b/packages/plugins/development-pr-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-pr-workflow",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Pull request review, issue resolution, and Graphite stack management",
   "author": {
     "name": "Uniswap Labs",
@@ -10,6 +10,7 @@
   "keywords": ["pull-request", "pr-review", "graphite", "git"],
   "license": "MIT",
   "skills": [
+    "./skills/backtest-change",
     "./skills/resolve-all-prs",
     "./skills/resolve-pr-issues",
     "./skills/review-code",

--- a/packages/plugins/development-pr-workflow/CLAUDE.md
+++ b/packages/plugins/development-pr-workflow/CLAUDE.md
@@ -35,13 +35,14 @@ This plugin supports two PR creation workflows:
 
 - **resolve-all-prs**: Batch resolve issues across all your open PRs in parallel with auto-commit/push
 - **resolve-pr-issues**: Orchestrated PR issue resolution — triages inline comments, review bodies, and CI failures, then dispatches `comment-resolver-agent` subagents per file group for code changes and posts replies for items that don't need action
+- **backtest-change**: Gate a data-driven change (monitor threshold, alert cadence, query, sampling rate, perf tweak) on live historical data — replay old-vs-new over the same window and refuse to ship when the data disproves the premise. **Auto-triggers** whenever someone proposes a measurable change and names a number; the number is treated as a hypothesis, not a specification
 - **review-code**: Comprehensive code review for architecture, security, performance, and style
 - **split-graphite-stack**: Split monolithic branches into logical PR stacks
 - **update-graphite-stack**: Update Graphite PR stacks by resolving comments and syncing
 
 ### Commands (./commands/)
 
-- **backtest-change**: Before opening a PR for a data-driven change (monitor threshold, alert cadence, query, sampling rate, perf tweak), pull live historical data, replay old-vs-new over the same window, and gate the PR on whether the data proves the change achieves its goal
+- **backtest-change**: Thin wrapper — deliberate, argument-taking entry point for the `backtest-change` skill above. The workflow lives in the skill so it can fire unprompted; a slash command only runs when explicitly typed
 - **review-pr**: Comprehensive multi-agent PR review for architecture, security, performance
 - **work-through-pr-comments**: Methodically work through PR comments in a conversational workflow
 - **linear-task-and-pr-from-changes**: Take local changes, create a Linear task, create a branch (optionally in a worktree), commit, and publish a PR
@@ -114,6 +115,7 @@ development-pr-workflow/
 ├── .claude-plugin/
 │   └── plugin.json
 ├── skills/
+│   ├── backtest-change/
 │   ├── resolve-all-prs/
 │   ├── resolve-pr-issues/
 │   ├── review-code/

--- a/packages/plugins/development-pr-workflow/README.md
+++ b/packages/plugins/development-pr-workflow/README.md
@@ -18,6 +18,7 @@ claude /plugin install development-pr-workflow
 
 | Skill                     | Description                                                         |
 | ------------------------- | ------------------------------------------------------------------- |
+| **backtest-change**       | Gate a data-driven change on live historical data before it ships   |
 | **resolve-all-prs**       | Batch resolve issues on all your open PRs in parallel (auto-commit) |
 | **resolve-pr-issues**     | Address PR review comments and fix CI failures                      |
 | **review-code**           | Comprehensive code review using specialized agents                  |
@@ -26,13 +27,13 @@ claude /plugin install development-pr-workflow
 
 ## Commands
 
-| Command                            | Description                                  |
-| ---------------------------------- | -------------------------------------------- |
+| Command                            | Description                                             |
+| ---------------------------------- | ------------------------------------------------------- |
 | `/backtest-change`                 | Validate a data-driven change vs live history before PR |
-| `/review-pr`                       | Review a pull request comprehensively        |
-| `/work-through-pr-comments`        | Methodically address PR comments             |
-| `/start-linear-task`               | Start working on a Linear task in a worktree |
-| `/linear-task-and-pr-from-changes` | Create Linear task and PR from local changes |
+| `/review-pr`                       | Review a pull request comprehensively                   |
+| `/work-through-pr-comments`        | Methodically address PR comments                        |
+| `/start-linear-task`               | Start working on a Linear task in a worktree            |
+| `/linear-task-and-pr-from-changes` | Create Linear task and PR from local changes            |
 
 ## Agents
 

--- a/packages/plugins/development-pr-workflow/commands/backtest-change.md
+++ b/packages/plugins/development-pr-workflow/commands/backtest-change.md
@@ -1,54 +1,27 @@
 ---
-description: Before opening a PR for a data-driven change (monitor threshold, alert routing/renotify, metric query, sampling rate, perf tweak), validate it against LIVE historical data — replay old-vs-new and report whether it actually achieves its goal. Refuses to ship (or redirects) when the data disproves the premise.
+description: Backtest a data-driven change against LIVE historical data before opening the PR — replay old-vs-new and report whether it actually achieves its goal. Refuses to ship (or redirects) when the data disproves the premise. Deliberate entry point for the `backtest-change` skill.
 argument-hint: [what you're about to change + the metric/signal it should move]
 allowed-tools: Bash(*), Read(*), Grep(*), Glob(*), AskUserQuestion(*)
 ---
 
 # Backtest a change before you PR it
 
-Validate a **data-driven change against real historical data before opening the PR** — and be willing to abandon or redirect the approach when the data says it won't work. This is the gate that stops a plausible-but-ineffective change from shipping.
+Load and follow the **`backtest-change` skill**
+(`packages/plugins/development-pr-workflow/skills/backtest-change/SKILL.md`),
+which holds the full workflow, verdict taxonomy, and output format.
 
-Use it for any change whose success is measurable: monitor thresholds, alert routing / re-notify cadence, metric/log/trace queries, sampling rates, cache TTLs, rate limits, autoscaling params, or a perf optimization with a latency/throughput target.
+Parse `$ARGUMENTS` for the two inputs the skill requires:
 
-## Inputs
+1. **The change** you intend to make (and the file(s), if known).
+2. **The goal** — which metric/signal should move, in which direction, by how
+   much. If it isn't stated, ask. A backtest is meaningless without a target.
 
-Parse `$ARGUMENTS` for: the change you intend to make (and the file(s) if known), and the **goal** it should achieve (what metric/signal should move, in which direction, by how much). If the goal isn't stated, ask for it — a backtest is meaningless without a target.
+Then run the skill's workflow and produce its backtest report.
 
-## The discipline (why this exists)
+## Why this is a thin wrapper
 
-A change that *looks* right is not the same as a change the data supports. The common failure is shipping a fix whose premise is wrong — the real driver was something else, so the metric never moves. Catch that **before** the PR, not in a post-merge validation.
-
-## Workflow
-
-1. **State the hypothesis precisely.** "Changing X will move metric M from ~A to ~B because C." Write it down. If you can't name the metric and the expected direction, stop and clarify.
-
-2. **Find the authoritative data source** and respect sampling:
-   - **Metrics** (standard Datadog metrics, `trace.*`, CloudWatch) are ~100% — use these to count rates/volumes/percentiles.
-   - For alert/page/incident questions, pull the alert system's own event history (e.g. incident.io alerts), not a proxy.
-
-3. **Pull a representative window** (typically 7–30 days; long enough to include the conditions the change targets).
-
-4. **Replay old logic vs new logic over that same window.** Compute concrete deltas: old **N** vs new **M** — alerts fired, pages, error rate, p95, cost, rows, whatever the goal metric is. For threshold/monitor changes, evaluate both the old and the new condition against the historical series and count transitions. Identify *which groups/series* change, not just the aggregate.
-
-5. **Classify the result:**
-   - **EFFECTIVE** — data shows the change achieves the goal. Capture the old-vs-new numbers for the PR body.
-   - **PARTIAL** — moves the metric but not enough / not for the cases that matter. Note the gap.
-   - **INEFFECTIVE / PREMISE DISPROVED** — the data shows the real driver is elsewhere, or the change barely moves M. **Stop. Do not open the PR.** Report what the data actually shows and propose the lever that *would* work.
-
-6. **Only if it holds up**, proceed to the change + PR, and put the backtest in the PR body: the hypothesis, the window, old-vs-new numbers, and a link to the live dashboard/query (prefer a link over stale typed numbers).
-
-## Output
-
-A short backtest report:
-
-- **Hypothesis** and goal metric.
-- **Window + data source** (and any sampling caveat applied).
-- **Old vs new** with hard numbers and which groups changed.
-- **Verdict** (EFFECTIVE / PARTIAL / INEFFECTIVE) + recommendation. If INEFFECTIVE, the alternative lever.
-
-## Principles
-
-- Backtest **before** acting; never claim a change works without replaying data.
-- Be willing to **reverse** — a disproved premise is a successful backtest, not a failure.
-- Prefer **dashboard/query links** over typed numbers that go stale.
-- When the change spans owners (e.g. an external-config change + a repo change), say which half the data supports and which is out of scope.
+The workflow lives in a skill so that it **auto-triggers**. The highest-value
+case is someone proposing a threshold without thinking to invoke a backtest —
+"add a monitor at 700 MB warn / 1.2 GB critical" — and a slash command can only
+fire when it is explicitly typed. This command remains the deliberate entry point
+for when you *do* want a backtest on demand, with arguments.

--- a/packages/plugins/development-pr-workflow/skills/backtest-change/SKILL.md
+++ b/packages/plugins/development-pr-workflow/skills/backtest-change/SKILL.md
@@ -15,6 +15,7 @@ description: >
   it and let the data override it. Always report old N vs new M with the window
   and data source. The /backtest-change command loads this same skill.
 allowed-tools: Bash, Read, Grep, Glob, AskUserQuestion
+model: opus
 ---
 
 # Backtest a change before you ship it

--- a/packages/plugins/development-pr-workflow/skills/backtest-change/SKILL.md
+++ b/packages/plugins/development-pr-workflow/skills/backtest-change/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: backtest-change
+description: >
+  Validate a data-driven change against LIVE historical data before it ships —
+  replay old-vs-new over a real window, report whether it achieves its goal, and
+  refuse to ship when the data disproves the premise. Fires whenever someone
+  proposes a measurable change and names a number: "add a monitor at 700MB",
+  "set the threshold to N", "warn at X / critical at Y", "alert when it exceeds
+  N", "raise the timeout to 5s", "change the sampling rate", "bump the cache
+  TTL", "tighten this alert", "loosen the threshold", "this should reduce the
+  noise", "that will fix the p95" — and before opening any PR for a monitor
+  threshold, alert routing or renotify cadence, metric/log/trace query, sampling
+  rate, rate limit, autoscaling parameter, or a perf change with a latency or
+  throughput target. A proposed number is a hypothesis, not a decision: backtest
+  it and let the data override it. Always report old N vs new M with the window
+  and data source. The /backtest-change command loads this same skill.
+allowed-tools: Bash, Read, Grep, Glob, AskUserQuestion
+---
+
+# Backtest a change before you ship it
+
+Validate a **data-driven change against real historical data before opening the
+PR** — and be willing to abandon or redirect the approach when the data says it
+won't work. This is the gate that stops a plausible-but-ineffective change from
+shipping.
+
+Use it for any change whose success is measurable: monitor thresholds, alert
+routing / re-notify cadence, metric/log/trace queries, sampling rates, cache
+TTLs, rate limits, autoscaling params, or a perf optimization with a
+latency/throughput target.
+
+## When this fires without being asked
+
+The most valuable case is the one nobody invokes deliberately: **someone hands
+you a number.** "Add a monitor at 700 MB warn / 1.2 GB critical." "Set the
+timeout to 5s." A named threshold arrives with an implicit claim attached — that
+it separates the bad cases from the good ones. That claim is testable, and it is
+often wrong, because the person proposing it has seen the incident population and
+not the healthy population.
+
+Treat a user-supplied number as a **hypothesis to test**, never as a
+specification to implement. Then say plainly what the data did to it.
+
+Worked example. A request arrived for a per-host memory monitor at "700 MB warn /
+1.2 GB critical", motivated by two hosts that had OOM-wedged at a 2 GiB limit. A
+30-day replay found a third host that had held **1.34–1.37 GB flat for ~21
+consecutive hours with no incident** — so the proposed critical would have paged
+continuously for most of a day. Shipped 1.6 GB instead. The warning was kept
+exactly as proposed, because a *non-paging* tier is allowed to sit inside normal
+range when its job is lead time. Both halves of that outcome came from the
+backtest, not from the proposal.
+
+## Inputs
+
+You need: the change intended (and the file(s) if known), and the **goal** it
+should achieve — which metric/signal should move, in which direction, by how
+much. If the goal isn't stated, ask. A backtest is meaningless without a target.
+
+When invoked as `/backtest-change`, parse `$ARGUMENTS` for the same two things.
+
+## The discipline (why this exists)
+
+A change that *looks* right is not the same as a change the data supports. The
+common failure is shipping a fix whose premise is wrong — the real driver was
+something else, so the metric never moves. Catch that **before** the PR, not in a
+post-merge validation.
+
+## Workflow
+
+1. **State the hypothesis precisely.** "Changing X will move metric M from ~A to
+   ~B because C." Write it down. If you can't name the metric and the expected
+   direction, stop and clarify.
+
+2. **Find the authoritative data source** and respect sampling:
+   - **Metrics** (standard Datadog metrics, `trace.*`, CloudWatch) are ~100% —
+     use these to count rates/volumes/percentiles.
+   - Spans and logs are often heavily sampled on the success path; don't count
+     volume from them.
+   - For alert/page/incident questions, pull the alert system's own event history
+     (e.g. incident.io alerts), not a proxy.
+   - Beware aggregation defaults that hide the shape you're testing — e.g. a
+     scalar query that silently averages a `max:` series returns avg-of-max and
+     will understate peaks. Set the aggregator explicitly.
+
+3. **Pull a representative window** (typically 7–30 days; long enough to include
+   the conditions the change targets).
+
+4. **Replay old logic vs new logic over that same window.** Compute concrete
+   deltas: old **N** vs new **M** — alerts fired, pages, error rate, p95, cost,
+   rows, whatever the goal metric is. For threshold/monitor changes, evaluate
+   both the old and the new condition against the historical series and count
+   transitions. Identify *which groups/series* change, not just the aggregate.
+   For a brand-new monitor, "old" is 0 — say so explicitly rather than omitting it.
+
+5. **Separate the two populations.** The threshold's whole job is to divide
+   incident from healthy. Report the highest *legitimate* value observed and the
+   lowest *incident* value. If they overlap, the threshold cannot work at any
+   setting and the signal itself needs to change — say that instead of picking a
+   number in the overlap.
+
+6. **Classify the result:**
+   - **EFFECTIVE** — data shows the change achieves the goal. Capture the
+     old-vs-new numbers for the PR body.
+   - **PARTIAL** — moves the metric but not enough / not for the cases that
+     matter. Note the gap.
+   - **INEFFECTIVE / PREMISE DISPROVED** — the data shows the real driver is
+     elsewhere, or the change barely moves M. **Stop. Do not open the PR.**
+     Report what the data actually shows and propose the lever that *would* work.
+   - **REVISED** — the goal is sound but the proposed number isn't. Ship the
+     corrected value and state prominently what you changed and why.
+
+7. **Only if it holds up**, proceed to the change + PR, and put the backtest in
+   the PR body: the hypothesis, the window, old-vs-new numbers, and a link to the
+   live dashboard/query (prefer a link over stale typed numbers).
+
+## Output
+
+A short backtest report:
+
+- **Hypothesis** and goal metric.
+- **Window + data source** (and any sampling caveat applied).
+- **Old vs new** with hard numbers and which groups changed.
+- **Population separation** — highest healthy value vs lowest incident value.
+- **Verdict** (EFFECTIVE / PARTIAL / INEFFECTIVE / REVISED) + recommendation. If
+  INEFFECTIVE, the alternative lever.
+
+## Principles
+
+- Backtest **before** acting; never claim a change works without replaying data.
+- A user-supplied number is a hypothesis. Testing it is the job, not overriding
+  the request — but when the data rejects it, say so and ship the corrected value.
+- Be willing to **reverse** — a disproved premise is a successful backtest, not a
+  failure.
+- Prefer **dashboard/query links** over typed numbers that go stale.
+- Distinguish tiers by consequence: a chatty non-paging warning can be
+  acceptable; a chatty page destroys trust in the monitor.
+- When the change spans owners (e.g. an external-config change + a repo change),
+  say which half the data supports and which is out of scope.


### PR DESCRIPTION
## What

Converts `backtest-change` from a **command** into a **skill**, leaving the command as a thin wrapper that delegates to it.

## Why

`backtest-change` has gate semantics — its description literally reads *"**Before opening a PR** for a data-driven change… **Refuses to ship** when the data disproves the premise."* Its entire value is firing at a moment the user will not think to invoke it.

But commands only run when explicitly typed. **A gate implemented as a command can never fire.**

Observed live: during INC-357 a request came in to *"add a monitor on container.memory.rss by host at ~700 MB warn / ~1.2 GB alert"* — a textbook match for this command's description, right down to "monitor threshold". The command never entered the picture. The backtest happened only because a memory file independently said to always backtest tunes.

That backtest then rejected the proposed number: a third host had held **1.34–1.37 GB flat for ~21 consecutive hours with no incident**, so a 1.2 GB critical would have paged for most of a day. Shipped 1.6 GB instead ([Uniswap/backend#11074](https://github.com/Uniswap/backend/pull/11074)). Exactly the outcome this gate exists to produce — reached without it.

## Audit context

Reviewed all 7 commands across the toolkit. This is the **only** miscategorisation:

| Command | Verdict |
|---|---|
| `backtest-change` | **Gate semantics, no skill counterpart — can never fire.** Converted here |
| `review-pr` | Correct. Skill counterpart `review-code` already handles auto-trigger |
| `update-claude-md`, `claude-init-plus` | Correct. Skill counterpart `update-claude-docs` handles auto-trigger |
| `linear-task-and-pr-from-changes`, `start-linear-task`, `work-through-pr-comments` | Correct. User-initiated, flag-driven, side-effectful or explicitly interactive |

The toolkit already uses a deliberate **dual pattern** — skill for the unprompted case, command for the parameterized run — which is what makes `backtest-change` conspicuous as the only gate with no skill half. This PR gives it one.

## Changes

- **New** `skills/backtest-change/SKILL.md` — the full workflow, with a description carrying upstream triggers so it fires when a number is *proposed*, not only when a PR is imminent: *"add a monitor at 700MB"*, *"set the threshold to N"*, *"warn at X / critical at Y"*, *"change the sampling rate"*, *"tighten this alert"*.
- **Rewrote** `commands/backtest-change.md` as a thin wrapper preserving `argument-hint` and `$ARGUMENTS` parsing, so `/backtest-change` still works for deliberate runs.
- **Updated** the plugin `CLAUDE.md` — skill list, command list, directory tree.

Two additions to the workflow, both learned from the INC-357 run:

- **Population separation step** — report the highest *legitimate* value against the lowest *incident* value. If they overlap the threshold cannot work at any setting, and the signal itself needs to change.
- **`REVISED` verdict** — the goal is sound but the proposed number isn't. The existing taxonomy only had EFFECTIVE / PARTIAL / INEFFECTIVE, which didn't cover the most common real outcome.

Plus a framing line stated explicitly: *a user-supplied number is a hypothesis, not a specification.*

## Blast radius

Additive. `/backtest-change` keeps working with the same arguments and same behaviour. No other command, skill, or agent is touched. Docs/markdown only — no code, no hooks, no CI.

## Correction (review round 1)

The first revision of this body claimed *"skills are auto-discovered from `skills/` — no `plugin.json` change needed"*, and ticked that as validated. **That was wrong**, and the review caught it as blocking.

Skills in this repo are **not** auto-discovered — `CLAUDE.md` is explicit that a `skills` array entry is required, and `.claude/rules/plugin-docs.md` makes "plugin.json skills array matches actual skill directories" a required verification step. Without it this PR would have shipped the file but not the behaviour it is justified by, which is the one failure mode the PR is supposed to prevent.

I generalised from a different marketplace whose manifest omits the `skills` array, and did not check this repo's. Both blocking items are fixed in `030fb90`; the version bump was also missed and is included.

## Validation

- [x] `quick_validate.py` passes on the new skill
- [x] Description under 1024 chars, no angle brackets
- [x] Registered `./skills/backtest-change` in `plugin.json` and bumped the plugin `2.2.0` → `2.3.0` (minor, per CLAUDE.md: new skill)
- [x] Verified the `skills` manifest exactly matches the `skills/` directory listing — no manifest-only or dir-only entries
- [x] `model: opus` added, matching 4 of 5 sibling skills
- [x] Command frontmatter keeps `argument-hint` + `allowed-tools`, so `/backtest-change` is unchanged from a caller's view
- [ ] Not yet verified that the skill actually auto-triggers in a live session — worth one deliberate test ("add a monitor at N") before merge

## Not in this PR

The audit also flagged that `update-claude-md` exists as a **command** here and as a **skill** in the Uniswap backend repo. A rename would be the correct fix but it touches **22 files**, including `scripts/lefthook/update-claude-docs.sh`, which shells out to `claude -p "/update-claude-md"` from a git hook. That is a separate change with a real breakage path and does not belong bundled with this one. Details in the PR discussion.

Left as a **draft** for review.


