### PR TITLE
chore(development-productivity): rename /update-claude-md command to /sync-claude-md

### DIFF
--- a/.github/prompts/CLAUDE.md
+++ b/.github/prompts/CLAUDE.md
@@ -331,4 +331,4 @@ Check prompt outputs for:
 
 ## Auto-Update Instructions
 
-IMPORTANT: After changes to files in this directory, Claude Code MUST run `/update-claude-md` before presenting results to ensure this documentation stays synchronized with the codebase.
+IMPORTANT: After changes to files in this directory, Claude Code MUST run `/sync-claude-md` before presenting results to ensure this documentation stays synchronized with the codebase.

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -1740,4 +1740,4 @@ ACTIONS_RUNNER_DEBUG=true
 
 ## Auto-Update Instructions
 
-IMPORTANT: After changes to files in this directory or subdirectories, Claude Code MUST run `/update-claude-md` before presenting results to ensure this documentation stays synchronized with the codebase.
+IMPORTANT: After changes to files in this directory or subdirectories, Claude Code MUST run `/sync-claude-md` before presenting results to ensure this documentation stays synchronized with the codebase.

--- a/.github/workflows/examples/CLAUDE.md
+++ b/.github/workflows/examples/CLAUDE.md
@@ -223,4 +223,4 @@ inputs:
 
 ## Auto-Update Instructions
 
-IMPORTANT: After changes to files in this directory, Claude Code MUST run `/update-claude-md` before presenting results to ensure this documentation stays synchronized with the codebase.
+IMPORTANT: After changes to files in this directory, Claude Code MUST run `/sync-claude-md` before presenting results to ensure this documentation stays synchronized with the codebase.

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -263,4 +263,4 @@ module.exports = limiter(async (req, res) => {
 
 ## Auto-Update Instructions
 
-IMPORTANT: After changes to files in this directory, Claude Code MUST run `/update-claude-md` before presenting results to ensure this documentation stays synchronized with the codebase.
+IMPORTANT: After changes to files in this directory, Claude Code MUST run `/sync-claude-md` before presenting results to ensure this documentation stays synchronized with the codebase.

--- a/apps/slack-oauth-backend/CLAUDE.md
+++ b/apps/slack-oauth-backend/CLAUDE.md
@@ -40,7 +40,7 @@ apps/slack-oauth-backend/
 
 ## Dependencies
 
-<!-- AUTO-GENERATED - Updated by /update-claude-md -->
+<!-- AUTO-GENERATED - Updated by /sync-claude-md -->
 
 - **@slack/web-api** (^7.10.0) - Official Slack Web API client for Node.js
 - **express** (^5.1.0) - Fast, unopinionated web framework for Node.js
@@ -96,4 +96,4 @@ Configure the `deploy` target in `project.json` for your platform (AWS, GCP, Azu
 
 ## Auto-Update Instructions
 
-IMPORTANT: After changes to files in this directory or subdirectories, Claude Code MUST run `/update-claude-md` before presenting results to ensure this documentation stays synchronized with the codebase.
+IMPORTANT: After changes to files in this directory or subdirectories, Claude Code MUST run `/sync-claude-md` before presenting results to ensure this documentation stays synchronized with the codebase.

--- a/apps/slack-oauth-backend/src/oauth/CLAUDE.md
+++ b/apps/slack-oauth-backend/src/oauth/CLAUDE.md
@@ -302,4 +302,4 @@ SLACK_REDIRECT_URI=https://yourdomain.com/auth/slack/callback
 
 ## Auto-Update Instructions
 
-IMPORTANT: After changes to files in this directory, Claude Code MUST run `/update-claude-md` before presenting results to ensure this documentation stays synchronized with the codebase.
+IMPORTANT: After changes to files in this directory, Claude Code MUST run `/sync-claude-md` before presenting results to ensure this documentation stays synchronized with the codebase.

--- a/docs/examples/CLAUDE.md
+++ b/docs/examples/CLAUDE.md
@@ -189,4 +189,4 @@ How it works...
 
 ## Auto-Update Instructions
 
-IMPORTANT: After changes to files in this directory, Claude Code MUST run `/update-claude-md` before presenting results to ensure this documentation stays synchronized with the codebase.
+IMPORTANT: After changes to files in this directory, Claude Code MUST run `/sync-claude-md` before presenting results to ensure this documentation stays synchronized with the codebase.

--- a/docs/guides/CLAUDE.md
+++ b/docs/guides/CLAUDE.md
@@ -23,7 +23,7 @@ Developer guides and tutorials for the AI Toolkit. Provides in-depth documentati
 - **File**: `claude-integration.md`
 - **Purpose**: Complete guide to Claude AI integration in the AI Toolkit
 - **Topics**:
-  - CLAUDE.md auto-generation system (`/claude-init-plus`, `/update-claude-md`)
+  - CLAUDE.md auto-generation system (`/claude-init-plus`, `/sync-claude-md`)
   - Why CLAUDE.md files are important for AI context
   - Using Claude Code locally for development
   - Claude-powered GitHub Actions workflows
@@ -144,4 +144,4 @@ Future guides to be added:
 
 ## Auto-Update Instructions
 
-IMPORTANT: After changes to files in this directory, Claude Code MUST run `/update-claude-md` before presenting results to ensure this documentation stays synchronized with the codebase.
+IMPORTANT: After changes to files in this directory, Claude Code MUST run `/sync-claude-md` before presenting results to ensure this documentation stays synchronized with the codebase.

--- a/docs/guides/claude-integration.md
+++ b/docs/guides/claude-integration.md
@@ -88,7 +88,7 @@ Actions needed:
 Proceed with generation/updates? (y/n/review)
 ```
 
-#### `/update-claude-md` - Keep Docs in Sync
+#### `/sync-claude-md` - Keep Docs in Sync
 
 Intelligently updates CLAUDE.md files based on your staged git changes.
 
@@ -96,10 +96,10 @@ Intelligently updates CLAUDE.md files based on your staged git changes.
 
 ```bash
 # Auto-detect mode (recommended) - analyzes staged changes
-/update-claude-md
+/sync-claude-md
 
 # Explicit mode - target specific directory
-/update-claude-md packages/my-package
+/sync-claude-md packages/my-package
 ```
 
 **What it does:**
@@ -245,7 +245,7 @@ git commit -m "docs: initialize CLAUDE.md files"
 
 1. Make code changes as usual
 2. Stage your changes: `git add .`
-3. Update documentation: `/update-claude-md`
+3. Update documentation: `/sync-claude-md`
 4. Review updates: `git diff **/*CLAUDE.md`
 5. Commit together: `git commit -m "feat: add feature"`
 
@@ -269,7 +269,7 @@ Claude: I'll create this in packages/plugins/development-codebase-tools/agents/
 The AI Toolkit provides several custom slash commands:
 
 - `/claude-init-plus` - Initialize CLAUDE.md files
-- `/update-claude-md [path]` - Update CLAUDE.md files
+- `/sync-claude-md [path]` - Update CLAUDE.md files
 - `/work-through-pr-comments <pr-number>` - Address PR feedback
 - And more in `.claude/commands/`
 
@@ -452,7 +452,7 @@ jobs:
 
 **DO:**
 
-- ✅ Run `/update-claude-md` after significant changes
+- ✅ Run `/sync-claude-md` after significant changes
 - ✅ Keep files concise (≤2000 characters)
 - ✅ Add context about "why" decisions were made
 - ✅ Update dependency descriptions with purpose
@@ -471,7 +471,7 @@ jobs:
 **DO:**
 
 - ✅ Let Claude read CLAUDE.md files (automatic)
-- ✅ Stage changes before running `/update-claude-md`
+- ✅ Stage changes before running `/sync-claude-md`
 - ✅ Review generated code before committing
 - ✅ Use Nx commands (Claude knows them from CLAUDE.md)
 - ✅ Ask Claude to explain its reasoning
@@ -526,7 +526,7 @@ jobs:
 - Shorten dependency descriptions
 - List only top 5-10 most important dependencies
 
-**Problem**: `/update-claude-md` doesn't detect my changes
+**Problem**: `/sync-claude-md` doesn't detect my changes
 
 **Solution**: Make sure changes are staged with `git add` first.
 
@@ -534,7 +534,7 @@ jobs:
 
 **Problem**: Claude doesn't understand project structure
 
-**Solution**: Run `/claude-init-plus` if CLAUDE.md files don't exist, or `/update-claude-md` if they're outdated.
+**Solution**: Run `/claude-init-plus` if CLAUDE.md files don't exist, or `/sync-claude-md` if they're outdated.
 
 **Problem**: Claude can't find Nx commands
 

--- a/docs/readmes/CLAUDE.md
+++ b/docs/readmes/CLAUDE.md
@@ -136,4 +136,4 @@ When updating README files:
 
 ## Auto-Update Instructions
 
-IMPORTANT: After changes to files in this directory, Claude Code MUST run `/update-claude-md` before presenting results to ensure this documentation stays synchronized with the codebase.
+IMPORTANT: After changes to files in this directory, Claude Code MUST run `/sync-claude-md` before presenting results to ensure this documentation stays synchronized with the codebase.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -62,4 +62,4 @@ pre-commit:
     #     - merge
     #     - rebase
     #     - run: '[ "$SKIP_CLAUDE" = "1" ] || [ "$CLAUDE_CODE" = "1" ]'
-    #   fail_text: 'Failed to update CLAUDE.md files. Please run `claude -p "/update-claude-md"` manually.'
+    #   fail_text: 'Failed to update CLAUDE.md files. Please run `claude -p "/sync-claude-md"` manually.'

--- a/packages/ai-toolkit-nx-claude/src/generators/addons/CLAUDE.md
+++ b/packages/ai-toolkit-nx-claude/src/generators/addons/CLAUDE.md
@@ -244,4 +244,4 @@ try {
 
 ## Auto-Update Instructions
 
-IMPORTANT: After changes to files in this directory, Claude Code MUST run `/update-claude-md` before presenting results to ensure this documentation stays synchronized with the codebase.
+IMPORTANT: After changes to files in this directory, Claude Code MUST run `/sync-claude-md` before presenting results to ensure this documentation stays synchronized with the codebase.

--- a/packages/claude-mcp-helper/src/commands/CLAUDE.md
+++ b/packages/claude-mcp-helper/src/commands/CLAUDE.md
@@ -220,4 +220,4 @@ export async function myCommand(args: string[], options: CommandOptions = {}): P
 
 ## Auto-Update Instructions
 
-IMPORTANT: After changes to files in this directory, Claude Code MUST run `/update-claude-md` before presenting results to ensure this documentation stays synchronized with the codebase.
+IMPORTANT: After changes to files in this directory, Claude Code MUST run `/sync-claude-md` before presenting results to ensure this documentation stays synchronized with the codebase.

--- a/packages/notion-publisher/src/lib/CLAUDE.md
+++ b/packages/notion-publisher/src/lib/CLAUDE.md
@@ -197,4 +197,4 @@ describe('NotionPublisher', () => {
 
 ## Auto-Update Instructions
 
-IMPORTANT: After changes to files in this directory, Claude Code MUST run `/update-claude-md` before presenting results to ensure this documentation stays synchronized with the codebase.
+IMPORTANT: After changes to files in this directory, Claude Code MUST run `/sync-claude-md` before presenting results to ensure this documentation stays synchronized with the codebase.

--- a/packages/plugins/development-productivity/.claude-plugin/plugin.json
+++ b/packages/plugins/development-productivity/.claude-plugin/plugin.json
@@ -32,5 +32,5 @@
     "./agents/researcher.md",
     "./agents/test-writer.md"
   ],
-  "commands": ["./commands/claude-init-plus.md", "./commands/update-claude-md.md"]
+  "commands": ["./commands/claude-init-plus.md", "./commands/sync-claude-md.md"]
 }

--- a/packages/plugins/development-productivity/CLAUDE.md
+++ b/packages/plugins/development-productivity/CLAUDE.md
@@ -19,7 +19,7 @@ optimization tools for Claude Code.
 ### Commands (./commands/)
 
 - **claude-init-plus**: Initialize CLAUDE.md files at all core nodes in a workspace (run once to bootstrap)
-- **update-claude-md**: Sync CLAUDE.md files based on staged git changes (run before committing)
+- **sync-claude-md**: Sync CLAUDE.md files based on staged git changes (run before committing)
 
 ### Agents (./agents/)
 
@@ -32,7 +32,7 @@ optimization tools for Claude Code.
 
 ### Hooks (./hooks/)
 
-- **claude-md-maintenance.sh**: Stop hook that reminds Claude to run `/update-claude-md` after significant structural changes. Opt-in via `.claude/development-productivity.local.md` with `enabled: true`.
+- **claude-md-maintenance.sh**: Stop hook that reminds Claude to run `/sync-claude-md` after significant structural changes. Opt-in via `.claude/development-productivity.local.md` with `enabled: true`.
 
 ## CLAUDE.md Content Model (v2.2.0)
 
@@ -49,7 +49,7 @@ disclosure best practices for CLAUDE.md content:
 ## Conventions
 
 - Skills are the primary interface; agents are invoked via `Task(subagent_type:agent-name)`
-- `claude-init-plus` runs once (bootstraps); `update-claude-md` runs on each significant change
+- `claude-init-plus` runs once (bootstraps); `sync-claude-md` runs on each significant change
 - The `documentation-agent` consolidates doc-writer, claude-docs-manager, and fact-checker agents
 - `generate-tests` supports: jest, vitest, pytest, cypress, playwright
 
@@ -68,7 +68,7 @@ development-productivity/
 │   └── update-claude-docs/
 ├── commands/
 │   ├── claude-init-plus.md
-│   └── update-claude-md.md
+│   └── sync-claude-md.md
 ├── agents/
 │   ├── documentation.md
 │   ├── claude-docs-initializer.md

--- a/packages/plugins/development-productivity/README.md
+++ b/packages/plugins/development-productivity/README.md
@@ -28,7 +28,7 @@ claude /plugin install development-productivity
 | Command             | Description                                                         |
 | ------------------- | ------------------------------------------------------------------- |
 | `/claude-init-plus` | Initialize or update CLAUDE.md files at all core nodes in workspace |
-| `/update-claude-md` | Fast CLAUDE.md sync based on staged git changes                     |
+| `/sync-claude-md` | Fast CLAUDE.md sync based on staged git changes                     |
 
 ## Agents
 
@@ -45,7 +45,7 @@ claude /plugin install development-productivity
 
 | Hook                      | Event  | Description                                                              |
 | ------------------------- | ------ | ------------------------------------------------------------------------ |
-| **claude-md-maintenance** | `Stop` | Reminds Claude to run `/update-claude-md` after significant code changes |
+| **claude-md-maintenance** | `Stop` | Reminds Claude to run `/sync-claude-md` after significant code changes |
 
 ### Enabling the CLAUDE.md Maintenance Hook
 
@@ -67,7 +67,7 @@ This hook is **opt-in** and disabled by default. To activate it for a project:
    .claude/*.local.md
    ```
 
-**What it does:** After each Claude Code session (Stop event), the hook checks git for non-trivial changes — new files, modifications to `package.json`/`project.json`, or more than 50 lines changed. If detected, it injects a reminder for Claude to run `/update-claude-md` to keep CLAUDE.md in sync. The hook is non-blocking: it never prevents Claude from finishing.
+**What it does:** After each Claude Code session (Stop event), the hook checks git for non-trivial changes — new files, modifications to `package.json`/`project.json`, or more than 50 lines changed. If detected, it injects a reminder for Claude to run `/sync-claude-md` to keep CLAUDE.md in sync. The hook is non-blocking: it never prevents Claude from finishing.
 
 ## Usage Examples
 
@@ -76,7 +76,7 @@ This hook is **opt-in** and disabled by default. To activate it for a project:
 /claude-init-plus
 
 # Quick update after changes
-/update-claude-md
+/sync-claude-md
 
 # Use skills contextually
 "Update the documentation after my changes"     # triggers update-claude-docs

--- a/packages/plugins/development-productivity/commands/claude-init-plus.md
+++ b/packages/plugins/development-productivity/commands/claude-init-plus.md
@@ -18,7 +18,7 @@ focused on conventions and gotchas that Claude cannot infer from reading code, w
 topic-specific rules factored into `.claude/rules/` files and external docs referenced
 via `@path` imports rather than inlined.
 
-Use `/claude-init-plus` **once** to initialize the workspace. Use `/update-claude-md`
+Use `/claude-init-plus` **once** to initialize the workspace. Use `/sync-claude-md`
 to keep documentation current on each significant change.
 
 ## Core Node Definition
@@ -279,5 +279,5 @@ Generate a markdown report with:
 - **Working Directories**: List with status
 - **Rules Files**: Any `.claude/rules/` stubs created
 - **Errors and Warnings**: Details for any failures
-- **Next Steps**: Checklist for user follow-up, including running `/update-claude-md` after
+- **Next Steps**: Checklist for user follow-up, including running `/sync-claude-md` after
   the next significant commit

--- a/packages/plugins/development-productivity/commands/sync-claude-md.md
+++ b/packages/plugins/development-productivity/commands/sync-claude-md.md
@@ -1,11 +1,11 @@
 ---
-name: update-claude-md
+name: sync-claude-md
 description: Fast CLAUDE.md synchronization based on staged git changes
 argument-hint: [path] (optional - auto-detects from git if omitted)
 allowed-tools: Bash(git:*), Read(*), Write(*), Edit(*), Glob(*), Grep(*)
 ---
 
-# `/update-claude-md` - Fast CLAUDE.md Synchronization
+# `/sync-claude-md` - Fast CLAUDE.md Synchronization
 
 ## Purpose
 
@@ -13,14 +13,26 @@ Update CLAUDE.md files based on staged git changes. The goal is to capture **con
 gotchas, and team preferences** that Claude cannot infer by reading code — not to inventory
 files or list dependencies. Run this **before committing** whenever staged changes reveal a non-obvious
 pattern, constraint, or workflow decision.
-constraint, or workflow decision.
+
+## Not to be confused with
+
+Three things maintain CLAUDE.md and they do different jobs:
+
+| Entry point | Scope |
+|---|---|
+| `/sync-claude-md` (this command) | **Staged git changes** → update the affected CLAUDE.md files. Explicit, pre-commit |
+| `update-claude-docs` skill (same plugin) | Same job, but **auto-triggers** after significant code changes without being asked |
+| `update-claude-md` skill (Uniswap backend repo) | **Authoring individual rules** in a CLAUDE.md — "add a rule", "Claude keeps doing X wrong". Not a git-diff sync |
+
+This command was previously also named `update-claude-md`, which collided with the
+third entry above. Renamed so the three are distinguishable at the call site.
 
 ## Usage
 
 **Auto-detect mode (recommended):**
 
 ```bash
-/update-claude-md
+/sync-claude-md
 ```
 
 Analyzes staged changes and updates affected CLAUDE.md files.
@@ -28,8 +40,8 @@ Analyzes staged changes and updates affected CLAUDE.md files.
 **Explicit mode:**
 
 ```bash
-/update-claude-md apps/slack-oauth-backend
-/update-claude-md packages/plugins/development-planning
+/sync-claude-md apps/slack-oauth-backend
+/sync-claude-md packages/plugins/development-planning
 ```
 
 Updates CLAUDE.md for a specific path.
@@ -243,6 +255,6 @@ fi
 ## Relationship to `/claude-init-plus`
 
 `/claude-init-plus` runs **once** to initialize CLAUDE.md files across the workspace.
-`/update-claude-md` runs **on each significant change** to keep them current. They are
+`/sync-claude-md` runs **on each significant change** to keep them current. They are
 complementary: init creates the foundation, update maintains it. If a CLAUDE.md does not
 exist for the relevant path, run `/claude-init-plus` first.

--- a/packages/plugins/development-productivity/hooks/claude-md-maintenance.sh
+++ b/packages/plugins/development-productivity/hooks/claude-md-maintenance.sh
@@ -156,7 +156,7 @@ fi
 # =============================================================================
 if [ "$IS_NON_TRIVIAL" = "true" ]; then
   echo "[claude-md-maintenance] Non-trivial changes detected — injecting reminder" >&2
-  printf '{"continue": true, "suppressOutput": false, "systemMessage": "CLAUDE.md Maintenance Reminder: Significant file changes were detected in this session (new files, package.json/project.json modifications, or >50 lines changed). Consider running /update-claude-md to keep CLAUDE.md documentation in sync with the codebase changes. Skip this if changes are purely internal/non-structural."}'
+  printf '{"continue": true, "suppressOutput": false, "systemMessage": "CLAUDE.md Maintenance Reminder: Significant file changes were detected in this session (new files, package.json/project.json modifications, or >50 lines changed). Consider running /sync-claude-md to keep CLAUDE.md documentation in sync with the codebase changes. Skip this if changes are purely internal/non-structural."}'
 fi
 
 exit 0

--- a/scripts/lefthook/CLAUDE.md
+++ b/scripts/lefthook/CLAUDE.md
@@ -255,4 +255,4 @@ LEFTHOOK=0 git commit -m "test"
 
 ## Auto-Update Instructions
 
-IMPORTANT: After changes to files in this directory, Claude Code MUST run `/update-claude-md` before presenting results to ensure this documentation stays synchronized with the codebase.
+IMPORTANT: After changes to files in this directory, Claude Code MUST run `/sync-claude-md` before presenting results to ensure this documentation stays synchronized with the codebase.

--- a/scripts/lefthook/update-claude-docs.sh
+++ b/scripts/lefthook/update-claude-docs.sh
@@ -18,8 +18,8 @@ if ! command -v claude &> /dev/null; then
 fi
 
 # Run Claude Code to update CLAUDE.md files
-echo "🤖 Running /update-claude-md..."
-claude -p "/update-claude-md"
+echo "🤖 Running /sync-claude-md..."
+claude -p "/sync-claude-md"
 
 # Check if any CLAUDE.md files were modified
 CHANGED_CLAUDE_FILES=$(git diff --name-only | grep "CLAUDE.md$" || true)


### PR DESCRIPTION
## What

Renames the `development-productivity` command `/update-claude-md` → `/sync-claude-md`, updating all 22 references including two live hook scripts and the plugin manifest.

## Why

Three different things were named some variant of "update claude md", and one name was shared outright:

| Entry point | Job |
|---|---|
| `/update-claude-md` **command** (this plugin) | Staged git changes → update affected CLAUDE.md files. Explicit, pre-commit |
| `update-claude-docs` **skill** (this plugin) | Same job, but auto-triggers after significant code changes |
| `update-claude-md` **skill** (Uniswap backend repo) | Authoring individual *rules* in a CLAUDE.md — "add a rule", "Claude keeps doing X wrong". Not a git-diff sync |

The first and third shared a name while doing unrelated work. Plugin namespacing (`development-productivity:update-claude-md`) mitigated it at the call site, but not for model-side selection — with three same-named entries, picking the right one came down to guessing. `sync-claude-md` also describes what the command actually does, which the old name did not.

Surfaced by a commands-vs-skills audit of the toolkit (see [#553](https://github.com/Uniswap/ai-toolkit/pull/553) for the other finding).

## The part worth reviewing carefully

The rename is mechanical but it reaches **two live hook scripts**, either of which would have broken silently:

- `scripts/lefthook/update-claude-docs.sh` — shells out to `claude -p "/update-claude-md"` from a git hook
- `packages/plugins/development-productivity/hooks/claude-md-maintenance.sh` — Stop hook whose reminder text tells Claude which command to run

And the plugin manifest lists commands explicitly:

```json
"commands": ["./commands/claude-init-plus.md", "./commands/update-claude-md.md"]
```

Missing that would have unregistered the command entirely — a rename that "worked" everywhere except actually loading. It's updated and `plugin.json` re-validates as JSON.

## Changes

- `git mv commands/update-claude-md.md → commands/sync-claude-md.md`, with `name:` frontmatter updated
- All 21 files carrying `/update-claude-md` updated to `/sync-claude-md` — mostly the boilerplate CLAUDE.md footer (*"Claude Code MUST run /sync-claude-md before presenting results"*), plus `lefthook.yml`, `docs/guides/claude-integration.md`, the plugin `README.md` and `CLAUDE.md`, and `commands/claude-init-plus.md`'s cross-reference
- Added a **"Not to be confused with"** table to the command, so the three CLAUDE.md-maintenance entry points stay distinguishable even after the rename
- Fixed a pre-existing duplicated line in the command body (`constraint, or workflow decision.` appeared twice)

**Deliberately not renamed:** two references in `skill-management/skills/skill-doctor/SKILL.md` that say *"a standing rule → an `update-claude-md` skill"*. Those point at the backend **skill** (entry 3 above), not this command, and are now more accurate rather than less.

## Blast radius

22 files, all markdown / shell / JSON. No TypeScript, no tests, no CI workflow logic. Behaviour of the command itself is unchanged — same frontmatter contract, same `$ARGUMENTS`, same workflow.

**Breaking for callers**, which is the whole point: anyone with `/update-claude-md` in muscle memory, a personal alias, or an external script gets "command not found" and needs to switch to `/sync-claude-md`. Both in-repo callers are updated here. Worth a heads-up in whatever channel announces toolkit changes.

## Validation

- [x] `grep -rn '/update-claude-md'` → **0 remaining** across `*.md`, `*.sh`, `*.yml`
- [x] `grep -rn 'update-claude-md'` in the plugin → 0 remaining (only the intentional skill-doctor references elsewhere)
- [x] `plugin.json` parses and lists `./commands/sync-claude-md.md`
- [x] Both hook scripts verified to reference the new name
- [x] `git mv` used, so history follows the file
- [ ] Not run end-to-end — worth invoking `/sync-claude-md` once and letting the lefthook path fire before merge

Left as a **draft** for review; happy to drop the rename and keep only the disambiguation table if the breaking change isn't wanted.

