### PR TITLE
docs(rules): fix stale 5-plugin claims and make plugin inventory drift-resistant

### DIFF
--- a/.claude/rules/plugin-docs.md
+++ b/.claude/rules/plugin-docs.md
@@ -47,14 +47,22 @@ find packages/plugins -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sor
 ```
 
 The two must always agree: every plugin directory needs a matching `marketplace.json` entry, and
-vice versa. Check that invariant in one command:
+vice versa. Check `source`, not just `name` - `.github/actions/validate-plugins/action.yml`
+resolves `.plugins[].source` to decide which directory to load and validate, so a copied or stale
+`source` points the marketplace at the wrong directory even when `name` looks right. Two checks:
 
 ```bash
-diff <(find packages/plugins -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort) \
-     <(jq -r '.plugins[].name' .claude-plugin/marketplace.json | sort)
+# 1. Every source resolves to a real plugin directory, and every directory is referenced once.
+diff <(find packages/plugins -mindepth 1 -maxdepth 1 -type d | sort) \
+     <(jq -r '.plugins[].source | sub("^\\./"; "")' .claude-plugin/marketplace.json | sort)
+
+# 2. Every entry's name agrees with its own source directory.
+jq -r '.plugins[] | select((.source | sub("^\\./packages/plugins/"; "")) != .name)
+       | "MISMATCH: name=\(.name) source=\(.source)"' .claude-plugin/marketplace.json
 ```
 
-Any output means the inventory is inconsistent - fix that before continuing.
+Both silent means the inventory is consistent. Any output means it is not - fix that before
+continuing.
 
 **Snapshot** (accurate as of 2026-07-30, verify with the commands above):
 

--- a/.claude/rules/plugin-docs.md
+++ b/.claude/rules/plugin-docs.md
@@ -16,7 +16,7 @@ After ANY changes to `packages/plugins/`, you MUST update the Notion Plugin Mark
 
 1. **Plugin inventory changes**: When skills, agents, commands, or MCP servers are added, removed, or renamed
 2. **Component counts**: The overview section shows totals for Skills, Agents, and Commands - keep these accurate
-3. **Per-plugin sections**: Each of the 5 plugins has its own section listing components - update the relevant section(s)
+3. **Per-plugin sections**: Each plugin has its own section listing components - update the relevant section(s)
 4. **Descriptions**: Update component descriptions when functionality changes significantly
 
 ### 2. Update Plugin CLAUDE.md Files
@@ -36,15 +36,39 @@ Before completing plugin-related work, verify:
 - [ ] Plugin `CLAUDE.md` reflects current structure
 - [ ] Notion marketplace doc is updated (if inventory changed)
 
-## The 5 Plugins
+## The Plugins
 
-For reference, these are the plugin directories:
+**Source of truth**: the directories under `packages/plugins/` and the `plugins` array in
+`.claude-plugin/marketplace.json`. Never rely on a count written in prose - including the
+snapshot below. Enumerate before acting:
 
-1. `packages/plugins/development-planning/`
-2. `packages/plugins/development-pr-workflow/`
-3. `packages/plugins/development-codebase-tools/`
-4. `packages/plugins/development-productivity/`
-5. `packages/plugins/uniswap-integrations/`
+```bash
+find packages/plugins -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort
+```
+
+The two must always agree: every plugin directory needs a matching `marketplace.json` entry, and
+vice versa. Check that invariant in one command:
+
+```bash
+diff <(find packages/plugins -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort) \
+     <(jq -r '.plugins[].name' .claude-plugin/marketplace.json | sort)
+```
+
+Any output means the inventory is inconsistent - fix that before continuing.
+
+**Snapshot** (accurate as of 2026-07-30, verify with the commands above):
+
+1. `packages/plugins/claude-setup/`
+2. `packages/plugins/development-codebase-tools/`
+3. `packages/plugins/development-planning/`
+4. `packages/plugins/development-pr-workflow/`
+5. `packages/plugins/development-productivity/`
+6. `packages/plugins/skill-management/`
+7. `packages/plugins/spec-workflow/`
+8. `packages/plugins/uniswap-integrations/`
+
+If the enumerated output above differs from this snapshot, the enumerated output wins - update
+this snapshot (and the plugin table in the root `CLAUDE.md`) as part of your change.
 
 ## When to Skip Notion Updates
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,8 @@ The repository uses a plugin-based architecture where Claude Code capabilities a
 - Plugins are stored in `./packages/plugins/<plugin-name>/`
 - Each plugin is a self-contained Nx package with its own `package.json`, `project.json`, and `.claude-plugin/plugin.json`
 - The `.claude-plugin/marketplace.json` file references plugins via relative paths: `"./packages/plugins/<plugin-name>"`
-- There are 8 plugins: claude-setup, development-codebase-tools, development-planning, development-pr-workflow, development-productivity, skill-management, spec-workflow, uniswap-integrations
+- The authoritative plugin inventory is the set of directories under `packages/plugins/` and the `plugins` array in `.claude-plugin/marketplace.json` - the two must always agree. Enumerate rather than trusting a count written in prose: `find packages/plugins -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort`. See `.claude/rules/plugin-docs.md` for the parity check.
+- As of 2026-07-30 there are 8 plugins: claude-setup, development-codebase-tools, development-planning, development-pr-workflow, development-productivity, skill-management, spec-workflow, uniswap-integrations. If the enumerated output differs, it wins - update this list and the table below.
 
 **Plugin Validation:**
 
@@ -364,7 +365,7 @@ After making any changes to files in this repository, Claude Code MUST:
 
 3. **Keep stats accurate**: The overview section contains counts of total Skills, Agents, and Commands - ensure these numbers stay accurate
 
-4. **Maintain per-plugin sections**: Each of the 5 plugins has its own section listing components - update the relevant section(s) when plugins change
+4. **Maintain per-plugin sections**: Each plugin has its own section listing components - update the relevant section(s) when plugins change
 
 This ensures the external documentation stays synchronized with the actual plugin codebase.
 


### PR DESCRIPTION
## Problem

`.claude/rules/plugin-docs.md` is a project rules file, so it loads into **every** session's context. Its `## The 5 Plugins` section listed only 5 of the repo's 8 plugin directories, omitting `claude-setup`, `skill-management`, and `spec-workflow`. Any agent following that rule would skip those three when doing plugin work.

It also contradicted the root `CLAUDE.md`, which already said 8.

Verified actual inventory (8, and directories match `marketplace.json` exactly):

```
claude-setup                development-productivity
development-codebase-tools  skill-management
development-planning        spec-workflow
development-pr-workflow     uniswap-integrations
```

## Approach

Correcting `5` to `8` would drift again on the next plugin addition, so both files now derive the inventory instead of asserting it:

- **Source of truth named**: `packages/plugins/` directories + the `plugins` array in `.claude-plugin/marketplace.json`.
- **Enumeration command** given inline (uses `find`/`basename` rather than `ls -1`, which emits `.` and `..` under a common `ls` alias).
- **Parity check** as a one-liner: `diff` of the directory list against `marketplace.json` names. Any output means the inventory is inconsistent.
- **Snapshot retained but demoted**: the 8 plugins are still listed for at-a-glance context (a rules file should not force a shell-out), but it is dated and readers are told the enumerated output wins and to repair the snapshot on mismatch.

Same de-hardcoding applied to the `CLAUDE.md` inventory bullet.

## Changes

| File | Change |
| --- | --- |
| `.claude/rules/plugin-docs.md` | `## The 5 Plugins` -> `## The Plugins` with source-of-truth block, enumeration command, parity check, dated snapshot of all 8 |
| `.claude/rules/plugin-docs.md` | "Each of the 5 plugins has its own section" -> "Each plugin" |
| `CLAUDE.md` | Inventory bullet now points at the source of truth; count is dated and marked subordinate to enumeration |
| `CLAUDE.md` | Same "Each of the 5 plugins" phrasing fixed in the Notion sync section |

## Grep sweep

Swept the repo for other hardcoded plugin-count claims. One remaining hit, deliberately left:

- `.plan/DEV-218-implementation.md:17` — "the 27 commands ... are covered by the 5 plugins". This is a point-in-time justification inside a completed migration plan. Rewriting it to 8 would make it wrong about the state it describes.

(`packages/plugins/claude-setup/skills/setup-repository/references/boris-best-practices.md:21` matches "The 5 Pillars" — unrelated false positive.)

## Verification

- `bunx nx format:write --uncommitted` — clean
- `bunx markdownlint-cli2 --fix "**/*.md"` — 196 files, 0 errors
- Pre-commit hooks all green: format, lint, lint-markdown, test, typecheck
- Ran both documented commands verbatim; the parity check reports the directories and `marketplace.json` agree
- Diff touches exactly 2 files, nothing under `packages/plugins/`, so **no plugin version bump applies**