### PR TITLE
chore(workflows): update model references to claude-opus-5

### DIFF
--- a/.github/REUSABLE_WORKFLOWS.md
+++ b/.github/REUSABLE_WORKFLOWS.md
@@ -218,7 +218,7 @@ Notify Release (_notify-release.yml)
 
 | Input                           | Required | Default                          | Description                                                                        |
 | ------------------------------- | -------- | -------------------------------- | ---------------------------------------------------------------------------------- |
-| `model`                         | No       | `'claude-sonnet-5'`              | Claude model to use (Sonnet 5, Opus 4.8, or Haiku 4.5)                             |
+| `model`                         | No       | `'claude-sonnet-5'`              | Claude model to use (Sonnet 5, Opus 5, or Haiku 4.5)                               |
 | `allowed_tools`                 | No       | (permissive defaults, see below) | YAML string specifying which tools Claude can use (file operations, bash commands) |
 | `custom_instructions`           | No       | `'Be sure to follow rules...'`   | Additional instructions for Claude beyond CLAUDE.md files                          |
 | `timeout_minutes`               | No       | `'10'`                           | Maximum execution time in minutes (prevents runaway costs)                         |
@@ -282,7 +282,7 @@ The following settings are intentionally fixed to ensure consistent security and
 
 - **Interactive AI Assistance**: Respond to `@claude` mentions anywhere in GitHub
 - **Multiple Trigger Points**: Works in issue comments, PR comments, review comments, and reviews
-- **Configurable Model**: Choose between Sonnet 5 (balanced), Opus 4.8 (thorough), or Haiku 4.5 (fast)
+- **Configurable Model**: Choose between Sonnet 5 (balanced), Opus 5 (thorough), or Haiku 4.5 (fast)
 - **Flexible Tool Permissions**: Control what Claude can do (read-only, read-write, or custom)
 - **Custom Instructions**: Add repository-specific guidelines and standards
 - **Bot Filtering**: Automatically excludes bot comments to prevent loops
@@ -334,7 +334,7 @@ jobs:
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     with:
-      model: 'claude-opus-4-8'
+      model: 'claude-opus-5'
       timeout_minutes: '15' # Opus may need more time
 ```
 
@@ -423,7 +423,7 @@ jobs:
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     with:
-      model: 'claude-opus-4-8'
+      model: 'claude-opus-5'
       timeout_minutes: '15'
 ```
 
@@ -546,7 +546,7 @@ Claude says it doesn't have permission to perform action
 2. **Choose the Right Model**:
 
    - **Sonnet 5** (default): Best balance of speed, capability, and cost for 90% of use cases
-   - **Opus 4.8**: Reserve for complex architectural reviews or critical security analysis
+   - **Opus 5**: Reserve for complex architectural reviews or critical security analysis
    - **Haiku 4.5**: Fast and cost-effective for simple questions, quick lookups, or high-volume usage
 
 3. **Set Appropriate Timeouts**:
@@ -619,7 +619,7 @@ jobs:
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     with:
-      model: 'claude-opus-4-8'
+      model: 'claude-opus-5'
       timeout_minutes: '15'
 ```
 
@@ -640,7 +640,7 @@ claude-deep:
     contains(github.event.pull_request.labels.*.name, 'deep-analysis') &&
     # ... (rest of if condition)
   with:
-    model: 'claude-opus-4-8'
+    model: 'claude-opus-5'
 ```
 
 #### Integration with Other Workflows
@@ -691,7 +691,7 @@ Tips for managing Claude API costs effectively:
 
    - Haiku 4.5: Most cost-effective for simple tasks
    - Sonnet 5: ~$2 per 1M input tokens, ~$10 per 1M output tokens (introductory pricing through Aug 31, 2026; default, recommended)
-   - Opus 4.8: ~$5 per 1M input tokens, ~$25 per 1M output tokens (reserve for complex tasks)
+   - Opus 5: ~$5 per 1M input tokens, ~$25 per 1M output tokens (reserve for complex tasks)
    - Typical interaction: 5K-50K tokens (mostly input)
 
 2. **Timeout Strategy**:
@@ -1117,7 +1117,7 @@ jobs:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
       # Use Opus for PRs with 'claude-opus' label, otherwise Sonnet
-      model: ${{ contains(github.event.pull_request.labels.*.name, 'claude-opus') && 'claude-opus-4-8' || 'claude-sonnet-5' }}
+      model: ${{ contains(github.event.pull_request.labels.*.name, 'claude-opus') && 'claude-opus-5' || 'claude-sonnet-5' }}
       max_turns: 20 # Allow more turns for thorough Opus reviews
       timeout_minutes: 45 # Longer timeout for complex reviews
     secrets:
@@ -1501,7 +1501,7 @@ Claude submitted multiple reviews instead of updating one
 2. **Model Selection**:
 
    - **Sonnet 5** (default): Best balance for most PRs (~80% of use cases)
-   - **Opus 4.8**: Reserve for critical code, security-sensitive changes, or complex architectures
+   - **Opus 5**: Reserve for critical code, security-sensitive changes, or complex architectures
    - Use labels to let developers request deeper reviews when needed
 
 3. **Custom Prompts**:
@@ -1596,7 +1596,7 @@ jobs:
     with:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
-      model: 'claude-opus-4-8'
+      model: 'claude-opus-5'
       custom_prompt_path: '.github/prompts/security-review.md'
       timeout_minutes: 60
     secrets:

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -435,7 +435,7 @@ with:
   pr_number: ${{ github.event.pull_request.number }}
   base_ref: ${{ github.base_ref }}
   auto_fix: true # Enable automatic fixing of issues
-  auto_fix_model: 'claude-opus-4-8' # Use Opus for better fixes (optional)
+  auto_fix_model: 'claude-opus-5' # Use Opus for better fixes (optional)
 secrets:
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }} # Required for pushing fixes
@@ -745,7 +745,7 @@ uses: Uniswap/ai-toolkit/.github/workflows/_claude-docs-check.yml@main
 with:
   pr_number: ${{ github.event.pull_request.number }}
   auto_fix: true # Enable automatic fixing of documentation issues
-  auto_fix_model: 'claude-opus-4-8' # Use Opus for better fixes (optional)
+  auto_fix_model: 'claude-opus-5' # Use Opus for better fixes (optional)
 secrets:
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }} # Required for pushing fixes
@@ -1055,14 +1055,14 @@ If both are provided, OAuth token takes precedence. At least one authentication 
 
 **Configuration:**
 
-| Input                     | Default           | Description                                     |
-| ------------------------- | ----------------- | ----------------------------------------------- |
-| `model`                   | `claude-opus-4-8` | Claude model to use                             |
-| `max_turns`               | `150`             | Maximum conversation turns                      |
-| `debug_mode`              | `true`            | Show full Claude output                         |
-| `timeout_minutes`         | `60`              | Job timeout                                     |
-| `pr_type`                 | `draft`           | Type of PR to create: "draft" or "published"    |
-| `install_uniswap_plugins` | `true`            | Auto-install uniswap plugins (false to opt out) |
+| Input                     | Default         | Description                                     |
+| ------------------------- | --------------- | ----------------------------------------------- |
+| `model`                   | `claude-opus-5` | Claude model to use                             |
+| `max_turns`               | `150`           | Maximum conversation turns                      |
+| `debug_mode`              | `true`          | Show full Claude output                         |
+| `timeout_minutes`         | `60`            | Job timeout                                     |
+| `pr_type`                 | `draft`         | Type of PR to create: "draft" or "published"    |
+| `install_uniswap_plugins` | `true`          | Auto-install uniswap plugins (false to opt out) |
 
 **Validation Behavior:**
 
@@ -1096,7 +1096,7 @@ with:
   issue_url: ${{ matrix.issue_url }}
   branch_name: ${{ matrix.branch_name }}
   target_branch: 'next'
-  model: 'claude-opus-4-8'
+  model: 'claude-opus-5'
   debug_mode: true
   pr_type: 'draft' # or 'published' for non-draft PRs
 secrets:
@@ -1116,7 +1116,7 @@ with:
   issue_url: ${{ matrix.issue_url }}
   branch_name: ${{ matrix.branch_name }}
   target_branch: 'next'
-  model: 'claude-opus-4-8'
+  model: 'claude-opus-5'
   debug_mode: true
   pr_type: 'draft'
 secrets:
@@ -1208,7 +1208,7 @@ gh workflow run update-action-versions.yml
 gh workflow run update-action-versions.yml -f dry_run=true
 
 # Use Opus model
-gh workflow run update-action-versions.yml -f model=claude-opus-4-8
+gh workflow run update-action-versions.yml -f model=claude-opus-5
 ```
 
 **Usage example (API Key):**
@@ -1344,7 +1344,7 @@ gh workflow run dev-ai-newsletter.yml -f dry_run=true
 gh workflow run dev-ai-newsletter.yml -f days_back=14
 
 # Use Opus model for better quality
-gh workflow run dev-ai-newsletter.yml -f model=claude-opus-4-8
+gh workflow run dev-ai-newsletter.yml -f model=claude-opus-5
 
 # Post to specific Slack channels
 gh workflow run dev-ai-newsletter.yml -f slack_post_channel_ids="C091XE1DNP2,C094URH6C13"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -75,7 +75,7 @@ Workflows designed to be called by other workflows using `workflow_call`. These 
 
   - Interactive AI assistance via @claude mentions
   - Works in issue comments, PR comments, review comments, and reviews
-  - Configurable models (Sonnet 5, Opus 4.8, Haiku 4.5)
+  - Configurable models (Sonnet 5, Opus 5, Haiku 4.5)
   - Flexible tool permissions (read-only, read-write, or custom)
   - Custom instructions for repository-specific standards
   - Fixed security settings (Bullfrog scanning, immutable permissions)

--- a/.github/workflows/_claude-main.yml
+++ b/.github/workflows/_claude-main.yml
@@ -79,7 +79,7 @@ on:
 
           Available models:
           - claude-sonnet-5 (default, recommended) - Latest Sonnet model with best balance of speed and capability
-          - claude-opus-4-8 - Most capable model for complex tasks
+          - claude-opus-5 - Most capable model for complex tasks
           - claude-haiku-4-5-20251001 - Fast, cost-effective model for simpler tasks
 
           Default: claude-sonnet-5

--- a/.github/workflows/_claude-task-worker.yml
+++ b/.github/workflows/_claude-task-worker.yml
@@ -89,10 +89,10 @@ on:
       model:
         description: |
           Claude model to use.
-          Options: claude-sonnet-5, claude-opus-4-8, claude-haiku-4-5-20251001
+          Options: claude-sonnet-5, claude-opus-5, claude-haiku-4-5-20251001
         required: false
         type: string
-        default: "claude-opus-4-8"
+        default: "claude-opus-5"
 
       timeout_minutes:
         description: "Maximum execution time in minutes"

--- a/.github/workflows/_generate-pr-metadata.yml
+++ b/.github/workflows/_generate-pr-metadata.yml
@@ -47,7 +47,7 @@ on:
         description: "Claude model to use for generation"
         required: false
         type: string
-        default: "claude-opus-4-8"
+        default: "claude-opus-5"
 
       max_turns:
         description: "Maximum conversation turns for Claude. Omit to use unlimited turns."

--- a/.github/workflows/claude-auto-tasks.yml
+++ b/.github/workflows/claude-auto-tasks.yml
@@ -53,9 +53,9 @@ on:
         type: choice
         options:
           - "claude-sonnet-5"
-          - "claude-opus-4-8"
+          - "claude-opus-5"
           - "claude-haiku-4-5"
-        default: "claude-opus-4-8"
+        default: "claude-opus-5"
 
       target_branch:
         description: "Branch to create PRs against"
@@ -124,7 +124,7 @@ jobs:
       issue_url: ${{ matrix.issue_url }}
       branch_name: ${{ matrix.branch_name }}
       target_branch: ${{ inputs.target_branch || 'next' }}
-      model: ${{ inputs.model || 'claude-opus-4-8' }}
+      model: ${{ inputs.model || 'claude-opus-5' }}
       timeout_minutes: 60
       linear_task_utils_tag: ${{ needs.prepare.outputs.linear_task_utils_tag }}
       debug_mode: ${{ inputs.debug_mode != '' && inputs.debug_mode || true }}

--- a/.github/workflows/dev-ai-newsletter.yml
+++ b/.github/workflows/dev-ai-newsletter.yml
@@ -97,7 +97,7 @@ on:
         type: choice
         options:
           - "claude-sonnet-5"
-          - "claude-opus-4-8"
+          - "claude-opus-5"
         default: "claude-sonnet-5"
 
       dry_run:

--- a/.github/workflows/examples/06-claude-main-basic.yml
+++ b/.github/workflows/examples/06-claude-main-basic.yml
@@ -92,7 +92,7 @@ jobs:
 #     secrets:
 #       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 #     with:
-#       model: 'claude-opus-4-8'  # More capable, slower, higher cost
+#       model: 'claude-opus-5'  # More capable, slower, higher cost
 #       timeout_minutes: '15'  # Opus may need more time
 #
 # -------------------
@@ -204,7 +204,7 @@ jobs:
 #     secrets:
 #       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 #     with:
-#       model: 'claude-opus-4-8'
+#       model: 'claude-opus-5'
 #       timeout_minutes: '15'
 #
 

--- a/.github/workflows/examples/07-claude-main-custom.yml
+++ b/.github/workflows/examples/07-claude-main-custom.yml
@@ -48,9 +48,9 @@ jobs:
       # MODEL SELECTION
       # Choose the Claude model based on your needs:
       # - claude-sonnet-5: Latest, best balance (RECOMMENDED)
-      # - claude-opus-4-8: Most capable, slower, higher cost
+      # - claude-opus-5: Most capable, slower, higher cost
       # - claude-haiku-4-5: Fast, cost-effective for simpler tasks
-      model: "claude-opus-4-8"
+      model: "claude-opus-5"
 
       # TIMEOUT CONFIGURATION
       # Set maximum execution time in minutes
@@ -256,7 +256,7 @@ jobs:
 #     secrets:
 #       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 #     with:
-#       model: 'claude-opus-4-8'  # Thorough for code review
+#       model: 'claude-opus-5'  # Thorough for code review
 #       timeout_minutes: '15'
 #
 # -------------------
@@ -289,7 +289,7 @@ jobs:
 #     secrets:
 #       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 #     with:
-#       model: 'claude-opus-4-8'
+#       model: 'claude-opus-5'
 #       timeout_minutes: '30'
 #       custom_instructions: |
 #         Perform a comprehensive codebase audit focusing on:
@@ -368,7 +368,7 @@ jobs:
 # Solution:
 #   1. Verify model name exactly matches available models:
 #      - claude-sonnet-5
-#      - claude-opus-4-8
+#      - claude-opus-5
 #      - claude-haiku-4-5
 #   2. Check Anthropic API key has access to requested model
 #   3. Review Anthropic console for API limits or restrictions

--- a/.github/workflows/examples/10-claude-code-review-advanced.yml
+++ b/.github/workflows/examples/10-claude-code-review-advanced.yml
@@ -13,7 +13,7 @@ name: 'Example: Claude Code Review - Advanced'
 #
 # Model Selection:
 # - Default: Claude Sonnet 5 (fast, cost-effective)
-# - With 'claude-opus' label: Claude Opus 4.8 (more thorough, slower)
+# - With 'claude-opus' label: Claude Opus 5 (more thorough, slower)
 #
 # Use Cases:
 # - Large PRs that need more time
@@ -55,7 +55,7 @@ jobs:
 
       # Model selection based on PR labels
       # Add 'claude-opus' label to PRs that need more thorough review
-      model: ${{ contains(github.event.pull_request.labels.*.name, 'claude-opus') && 'claude-opus-4-8' || 'claude-sonnet-5' }}
+      model: ${{ contains(github.event.pull_request.labels.*.name, 'claude-opus') && 'claude-opus-5' || 'claude-sonnet-5' }}
 
       # Allow more turns for complex reviews
       # Default is 15, increase for PRs that need deeper analysis
@@ -95,7 +95,7 @@ jobs:
 #     with:
 #       pr_number: ${{ github.event.pull_request.number }}
 #       base_ref: ${{ github.base_ref }}
-#       model: 'claude-opus-4-8'  # Always use Opus for security
+#       model: 'claude-opus-5'  # Always use Opus for security
 #       custom_prompt_path: '.github/prompts/security-only-review.md'
 #     secrets:
 #       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/examples/11-autonomous-linear-tasks.yml
+++ b/.github/workflows/examples/11-autonomous-linear-tasks.yml
@@ -63,9 +63,9 @@ on:
         type: choice
         options:
           - "claude-sonnet-5" # Balanced (recommended)
-          - "claude-opus-4-8" # Most capable
+          - "claude-opus-5" # Most capable
           - "claude-haiku-4-5" # Fast & economical
-        default: "claude-opus-4-8"
+        default: "claude-opus-5"
 
       target_branch:
         description: "Branch to create PRs against"

--- a/.github/workflows/update-action-versions.yml
+++ b/.github/workflows/update-action-versions.yml
@@ -46,7 +46,7 @@ on:
         type: choice
         options:
           - 'claude-sonnet-5'
-          - 'claude-opus-4-8'
+          - 'claude-opus-5'
       target_branch:
         description: 'Base branch for the PR'
         required: false

--- a/docs/guides/autonomous-claude-tasks.md
+++ b/docs/guides/autonomous-claude-tasks.md
@@ -60,7 +60,7 @@ on:
         type: choice
         options:
           - 'claude-sonnet-5'
-          - 'claude-opus-4-8'
+          - 'claude-opus-5'
         default: 'claude-sonnet-5'
       target_branch:
         description: 'Branch to create PRs against'
@@ -143,7 +143,7 @@ See the full example at `.github/workflows/examples/11-autonomous-linear-tasks.y
 | Model              | Best For                                  |
 | ------------------ | ----------------------------------------- |
 | `claude-sonnet-5`  | Balance of speed and capability (default) |
-| `claude-opus-4-8`  | Complex tasks requiring deep reasoning    |
+| `claude-opus-5`    | Complex tasks requiring deep reasoning    |
 | `claude-haiku-4-5` | Simple tasks, cost optimization           |
 
 ## Creating Good Task Descriptions
@@ -213,7 +213,7 @@ Trigger manually from the GitHub Actions UI or CLI:
 gh workflow run claude-auto-tasks.yml \
   -f linear_team="Your Team" \
   -f max_issues="5" \
-  -f model="claude-opus-4-8"
+  -f model="claude-opus-5"
 ```
 
 ## Monitoring

--- a/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
+++ b/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-codebase-tools",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "Codebase exploration, refactoring, and quality analysis",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/development-codebase-tools/agents/agent-orchestrator.md
+++ b/packages/plugins/development-codebase-tools/agents/agent-orchestrator.md
@@ -1,7 +1,7 @@
 ---
 name: agent-orchestrator-agent
 description: Use this agent when you need to coordinate multiple AI agents on a complex multi-step software development task. Trigger phrases include "implement this plan", "coordinate agents to", "orchestrate", "break this task into subtasks", "run agents in parallel". Decomposes tasks into atomic units, matches each to the right specialist agent, executes in parallel where possible, and aggregates results.
-model: claude-opus-4-8
+model: claude-opus-5
 tools: *
 ---
 

--- a/packages/plugins/development-codebase-tools/agents/refactorer.md
+++ b/packages/plugins/development-codebase-tools/agents/refactorer.md
@@ -1,7 +1,7 @@
 ---
 name: refactorer-agent
 description: Performs safe, incremental code refactoring with architectural analysis, SOLID principle enforcement, design pattern application, and performance optimization. Use when asked to refactor, improve code quality, reduce technical debt, apply design patterns, or modernize a codebase without changing behavior.
-model: claude-opus-4-8
+model: claude-opus-5
 tools:
   - Read
   - Edit

--- a/packages/plugins/development-codebase-tools/skills/refactor-code/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/refactor-code/SKILL.md
@@ -1,7 +1,7 @@
 ---
 description: Refactor code with safety checks and pattern application. Use when user says "refactor this code", "clean up this function", "simplify this logic", "extract this into a separate function", "apply the strategy pattern here", "reduce the complexity of this module", or "reorganize this file structure".
 allowed-tools: Read, Edit, Write, Grep, TodoWrite, Bash(git diff:*), Bash(git show:*), Task(subagent_type:refactorer-agent), Task(subagent_type:style-enforcer-agent), Task(subagent_type:code-explainer-agent), Task(subagent_type:test-writer-agent), Task(subagent_type:agent-orchestrator-agent)
-model: claude-opus-4-8
+model: claude-opus-5
 ---
 
 # Code Refactorer

--- a/packages/plugins/development-planning/.claude-plugin/plugin.json
+++ b/packages/plugins/development-planning/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-planning",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Implementation planning, execution, and PR creation workflows with multi-agent collaboration",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/development-planning/agents/execute-plan.md
+++ b/packages/plugins/development-planning/agents/execute-plan.md
@@ -2,7 +2,7 @@
 name: execute-plan-agent
 description: Execute implementation plans step-by-step. Use when user says "execute the plan", "implement the plan we created", "start building based on the plan", "go ahead and implement it", "proceed with the implementation", "execute as a stack", "create a PR stack while implementing", "implement with one PR per step", or references a plan file and wants to begin coding.
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git:*), Bash(gt:*), Bash(npx:*), Task(subagent_type:test-writer-agent), Task(subagent_type:documentation-agent), Task(subagent_type:pr-creator-agent), Task(subagent_type:commit-message-generator-agent)
-model: claude-opus-4-8
+model: claude-opus-5
 ---
 
 # Execute Plan Agent

--- a/packages/plugins/development-planning/agents/planner.md
+++ b/packages/plugins/development-planning/agents/planner.md
@@ -2,7 +2,7 @@
 name: planner-agent
 description: Create clear, actionable implementation plans without writing code. Use when asked to plan a feature, design an implementation approach, create a task breakdown, or decide how to implement a change before writing any code.
 allowed-tools: Read, Write, Glob, Grep
-model: claude-opus-4-8
+model: claude-opus-5
 ---
 
 # Planner Agent

--- a/packages/plugins/development-planning/skills/execute-plan/SKILL.md
+++ b/packages/plugins/development-planning/skills/execute-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 description: Execute implementation plans step-by-step. Use when user says "execute the plan", "implement the plan we created", "start building based on the plan", "go ahead and implement it", "proceed with the implementation", "execute as a stack", "create a PR stack while implementing", "implement with one PR per step", or references a plan file and wants to begin coding.
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git:*), Bash(gt:*), Bash(npx:*), Task(subagent_type:test-writer-agent), Task(subagent_type:documentation-agent), Task(subagent_type:pr-creator-agent), Task(subagent_type:commit-message-generator-agent)
-model: claude-opus-4-8
+model: claude-opus-5
 ---
 
 # Plan Executor


### PR DESCRIPTION
## Summary

Anthropic released **Claude Opus 5** (`claude-opus-5`), which supersedes `claude-opus-4-8` as the latest Opus model. Per [platform.claude.com/docs/about-claude/models](https://platform.claude.com/docs/en/docs/about-claude/models), `claude-opus-4-8` has moved to the legacy models table.

This PR updates all git-tracked references from `claude-opus-4-8` to `claude-opus-5` across GitHub Actions workflows, docs, and agent frontmatter (19 files). Prose mentions of "Opus 4.8" in `.github/REUSABLE_WORKFLOWS.md` and `.github/workflows/README.md` were also updated to "Opus 5".

This is a like-for-like ID/prose swap — no new capabilities adopted. Pricing is unchanged (Opus 5 and Opus 4.8 are both $5/input MTok, $25/output MTok), so no pricing-table corrections were needed (unlike the prior Sonnet 5 migration in #548, which needed one). `claude-sonnet-5` and `claude-haiku-4-5` references are untouched — already current.

**Intentionally not touched:** `.claude/review.yml`'s historical comment ("the retired homegrown reviewer, which ran claude-opus-4-8") describes a past state accurately and shouldn't be rewritten. `packages/plugins/claude-setup/README.md` and `.../boris-best-practices.md` quote Boris Cherny by name stating his personal model preference ("The model choice is unambiguous: Opus 4.8 for everything") — rewriting an attributed quote to a model he never mentioned would misrepresent the source, so these are left as-is.

**Not adopted here (out of scope for this maintenance job):** Claude Fable 5 (`claude-fable-5`) and invitation-only Claude Mythos 5 — noting for future capability evaluation, not implementing feature changes in this PR.

## Components updated
- `.github/workflows/*.yml` (main, task-worker, auto-tasks, update-action-versions, newsletter, generate-pr-metadata, examples)
- `.github/REUSABLE_WORKFLOWS.md`, `.github/workflows/README.md`, `.github/workflows/CLAUDE.md`
- `docs/guides/autonomous-claude-tasks.md`
- `packages/plugins/development-codebase-tools/agents/{agent-orchestrator,refactorer}.md`, `skills/refactor-code/SKILL.md` (+ plugin.json 2.6.2 → 2.6.3)
- `packages/plugins/development-planning/agents/{execute-plan,planner}.md`, `skills/execute-plan/SKILL.md` (+ plugin.json 2.0.7 → 2.0.8)

## Test plan
- [x] `npx nx run-many --target=validate --all` — 7 plugins passed
- [x] `npm exec markdownlint-cli2 -- --fix` — 0 errors across 197 files
- [x] `npx nx format:write --uncommitted` — fixed table column alignment after ID-length change
- [x] Pre-commit hooks (format, lint, lint-markdown, test, typecheck, update-lockfile) all passed
- [x] Exhaustive `git grep` confirms zero remaining `claude-opus-4-8` references outside the one intentional historical comment

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Anthropic released **Claude Opus 5** (`claude-opus-5`), which supersedes `claude-opus-4-8` as the latest Opus model. Per [platform.claude.com/docs/about-claude/models](https://platform.claude.com/docs/en/docs/about-claude/models), `claude-opus-4-8` has moved to the legacy models table.
This is a like-for-like ID and prose swap across GitHub Actions workflows, docs, and plugin agent/skill frontmatter — **no new capabilities are adopted**. 22 files, +58/-58.
`claude-sonnet-5` and `claude-haiku-4-5` references are untouched; both are already current.
Directly follows the pattern of #548 (`claude-sonnet-4-6` → `claude-sonnet-5`).
## Changes
| Area | Files | What changed |
| ---- | ----- | ------------ |
| Workflows | 10 `.yml` | `_claude-main`, `_claude-task-worker`, `_generate-pr-metadata`, `claude-auto-tasks`, `dev-ai-newsletter`, `update-action-versions`, and `examples/{06,07,10,11}` — model IDs in `choice` options, defaults, and `${{ }}` fallbacks |
| Docs | 4 `.md` | `.github/REUSABLE_WORKFLOWS.md`, `.github/workflows/CLAUDE.md`, `.github/workflows/README.md`, `docs/guides/autonomous-claude-tasks.md` — model IDs plus prose mentions of "Opus 4.8" → "Opus 5" |
| `development-codebase-tools` | 3 `.md` + `plugin.json` | `agents/{agent-orchestrator,refactorer}.md`, `skills/refactor-code/SKILL.md` frontmatter; version `2.6.2` → `2.6.3` |
| `development-planning` | 3 `.md` + `plugin.json` | `agents/{execute-plan,planner}.md`, `skills/execute-plan/SKILL.md` frontmatter; version `2.0.7` → `2.0.8` |
Patch bumps on both plugins: frontmatter-only model swap, no component added, removed, or renamed.
### Pricing note
Unlike the Sonnet 5 migration in #548 — which needed an actual pricing correction — the cost table in `REUSABLE_WORKFLOWS.md` was **relabeled, not renumbered**. The `~$5 / 1M input, ~$25 / 1M output` figures are unchanged; only the model name on that line moved from "Opus 4.8" to "Opus 5".
A few markdown tables in `.github/workflows/CLAUDE.md` were realigned by `nx format:write` because `claude-opus-5` is shorter than `claude-opus-4-8`. Those column-padding lines account for part of the diff and carry no semantic change.
## Intentionally not changed
`git grep` finds four remaining `claude-opus-4-8` / "Opus 4.8" hits. All are deliberate:
- `.claude/review.yml:16` — a historical comment ("the retired homegrown reviewer, which ran `claude-opus-4-8`"). It describes a past state accurately; rewriting it would make it false.
- `packages/plugins/claude-setup/README.md:74` and `.../references/boris-best-practices.md:{65,67,138}` — content attributed to Boris Cherny by name, including the direct quote *"The model choice is unambiguous: Opus 4.8 for everything."* Substituting a model he never named would misrepresent the source.
Also out of scope for this maintenance job: Claude Fable 5 (`claude-fable-5`) and invitation-only Claude Mythos 5. Noted for a future capability evaluation, not a model-ID swap.
## Note for the reviewer
The root `CLAUDE.md` **Current plugins** table (lines 227–228) still reads `development-codebase-tools 2.6.2` and `development-planning 2.0.7`, while the two `plugin.json` files in this diff now say `2.6.3` and `2.0.8`. `CLAUDE.md` says to keep that table in sync with version changes, so this needs a follow-up edit (or a push to this branch) before merge.
## Test plan
- [x] `npx nx run-many --target=validate --all` — 7 plugins passed
- [x] `npm exec markdownlint-cli2 -- --fix` — 0 errors across 197 files
- [x] `npx nx format:write --uncommitted` — realigned tables after the ID-length change
- [x] Pre-commit hooks (format, lint, lint-markdown, test, typecheck, update-lockfile) passed
- [x] `git grep 'claude-opus-4-8\|Opus 4\.8'` returns only the four intentional hits listed above
- [ ] Root `CLAUDE.md` plugin version table updated to `2.6.3` / `2.0.8`

</details>
<!-- claude-pr-description-end -->