### PR TITLE
feat(skill-management): add migrate-config-to-opus-5 skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,7 +228,7 @@ All plugins follow semantic versioning (semver). Key versioning rules:
 | development-planning       | 2.0.7   |
 | development-pr-workflow    | 2.3.0   |
 | development-productivity   | 2.4.1   |
-| skill-management           | 1.0.2   |
+| skill-management           | 1.1.0   |
 | spec-workflow              | 2.0.1   |
 | uniswap-integrations       | 2.6.0   |
 

--- a/packages/plugins/skill-management/.claude-plugin/plugin.json
+++ b/packages/plugins/skill-management/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-management",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Audit, map, mine, and improve your Claude Code skills, agents, and slash commands. Inventories your whole customization surface, flags overlaps/gaps/weak triggering descriptions, and mines sessions for workflows worth codifying into new skills or agents.",
   "author": {
     "name": "Uniswap Labs",
@@ -9,6 +9,6 @@
   "homepage": "https://github.com/Uniswap/ai-toolkit",
   "keywords": ["claude-code", "skills", "agents", "commands", "meta", "curation", "ai-toolkit"],
   "license": "MIT",
-  "skills": ["./skills/skill-doctor"],
+  "skills": ["./skills/skill-doctor", "./skills/migrate-config-to-opus-5"],
   "commands": ["./commands/skill-mine.md", "./commands/skill-map.md", "./commands/skill-new.md"]
 }

--- a/packages/plugins/skill-management/.claude-plugin/plugin.json
+++ b/packages/plugins/skill-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "skill-management",
   "version": "1.1.0",
-  "description": "Audit, map, mine, and improve your Claude Code skills, agents, and slash commands. Inventories your whole customization surface, flags overlaps/gaps/weak triggering descriptions, and mines sessions for workflows worth codifying into new skills or agents.",
+  "description": "Audit, map, mine, and improve your Claude Code skills, agents, and slash commands. Inventories your whole customization surface, flags overlaps/gaps/weak triggering descriptions, and mines sessions for workflows worth codifying into new skills or agents. Also migrates full Claude Code configs (CLAUDE.md, rules, settings, hooks, CI scripts) for new model generations like Opus 5.",
   "author": {
     "name": "Uniswap Labs",
     "email": "ai-services@uniswap.org"

--- a/packages/plugins/skill-management/CLAUDE.md
+++ b/packages/plugins/skill-management/CLAUDE.md
@@ -5,7 +5,9 @@
 This plugin is the curation/triage layer over a user's whole Claude Code customization surface —
 their skills, agents, and slash commands. It inventories everything (the user's own dirs plus
 installed marketplaces), flags overlaps, gaps, and weak triggering descriptions, and mines the current
-session for workflows worth codifying into a new or edited skill or agent.
+session for workflows worth codifying into a new or edited skill or agent. It also owns
+model-generation migrations of a full Claude Code config (CLAUDE.md, rules, settings, hooks,
+statusline, CI scripts) via the migrate-config-to-opus-5 skill.
 
 ## Plugin Components
 

--- a/packages/plugins/skill-management/CLAUDE.md
+++ b/packages/plugins/skill-management/CLAUDE.md
@@ -17,6 +17,14 @@ session for workflows worth codifying into a new or edited skill or agent.
   never auto-applies. Bundles `references/analysis-rubric.md` (good-description shape, overlap
   judgment, skill-vs-agent-vs-rule decision) and `scripts/inventory.py` (cheap inventory + quality
   flags, no pip installs).
+- **migrate-config-to-opus-5**: Audits and migrates a Claude Code configuration (CLAUDE.md, rules,
+  skills, commands, agents, settings.json, hooks, statusline, CI scripts) for Claude Opus 5's
+  behavioral changes. Interviews for scope first (global `~/.claude` vs the current project),
+  inventories the surface, classifies findings (fix mechanically / rewrite / user decision / leave
+  alone), and executes with granular commits plus a verification probe. Bundles
+  `references/audit-patterns.md` — the four behavioral deltas (verification, delegation, literal
+  instruction-following, output length) with search patterns and fix shapes, plus mechanical checks
+  (stale model IDs, pricing ratios, API params).
 
 ### Commands (./commands/)
 

--- a/packages/plugins/skill-management/README.md
+++ b/packages/plugins/skill-management/README.md
@@ -5,7 +5,9 @@ Audit, map, mine, and improve your Claude Code skills, agents, and slash command
 This plugin is the curation layer over your whole Claude Code customization surface. It inventories
 every skill / agent / command you have (your own dirs plus installed marketplaces), flags overlaps,
 gaps, and weak triggering descriptions, and mines the current session for workflows worth codifying
-into a new or edited skill or agent.
+into a new or edited skill or agent. It also covers model-generation migrations: auditing a full
+Claude Code config (CLAUDE.md, rules, settings, hooks, CI scripts) for behavioral changes in a new
+model family like Opus 5.
 
 ## Installation
 

--- a/packages/plugins/skill-management/README.md
+++ b/packages/plugins/skill-management/README.md
@@ -19,9 +19,10 @@ claude /plugin install skill-management
 
 ## Skills
 
-| Skill            | Description                                                                                                                                                     |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **skill-doctor** | Orchestrator/triage over your skills, agents, and commands: inventory, analyze, mine, and improve. The commands below are thin entry points into its run modes. |
+| Skill                        | Description                                                                                                                                                                                                                                                                                                                                                                      |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **skill-doctor**             | Orchestrator/triage over your skills, agents, and commands: inventory, analyze, mine, and improve. The commands below are thin entry points into its run modes.                                                                                                                                                                                                                  |
+| **migrate-config-to-opus-5** | Audit and migrate a Claude Code configuration (CLAUDE.md, rules, skills, commands, agents, settings, hooks, CI scripts) for Claude Opus 5's behavioral changes — removes 4.x-era compensations (over-verification ceremony, delegation nudges, confidence filters), fixes stale model IDs/pricing, and interviews you on anything that might be policy rather than compensation. |
 
 ## Commands
 

--- a/packages/plugins/skill-management/skills/migrate-config-to-opus-5/SKILL.md
+++ b/packages/plugins/skill-management/skills/migrate-config-to-opus-5/SKILL.md
@@ -18,7 +18,7 @@ Ask the user which surface to migrate, via AskUserQuestion:
 
 If the user picked global and `~/.claude` is a git repo shared across machines, every path fix must be machine-agnostic (`$HOME`, `~/`, resolver scripts) — a literal home-dir path that is correct on this machine is silently wrong on the others.
 
-In the same interview, ask one execution question: apply edits directly with granular commits (the default), or propose the full diff for review first. For project scope on a shared repo, apply the edits on a new branch and deliver them as a PR rather than committing to the checked-out branch — matching this plugin's skill-doctor delivery rule.
+In the same interview, ask one execution question: apply edits directly with granular commits (the default), or propose the full diff for review first. For project scope on a shared repo, apply the edits on a new branch off the repo's default branch (`origin/main` or equivalent, not the current checkout) and deliver them as a PR — matching this plugin's skill-doctor delivery rule.
 
 ## Step 1 — Inventory
 

--- a/packages/plugins/skill-management/skills/migrate-config-to-opus-5/SKILL.md
+++ b/packages/plugins/skill-management/skills/migrate-config-to-opus-5/SKILL.md
@@ -18,7 +18,7 @@ Ask the user which surface to migrate, via AskUserQuestion:
 
 If the user picked global and `~/.claude` is a git repo shared across machines, every path fix must be machine-agnostic (`$HOME`, `~/`, resolver scripts) — a literal home-dir path that is correct on this machine is silently wrong on the others.
 
-In the same interview, ask one execution question: apply edits directly with granular commits (the default), or propose the full diff for review first.
+In the same interview, ask one execution question: apply edits directly with granular commits (the default), or propose the full diff for review first. For project scope on a shared repo, apply the edits on a new branch and deliver them as a PR rather than committing to the checked-out branch — matching this plugin's skill-doctor delivery rule.
 
 ## Step 1 — Inventory
 
@@ -51,7 +51,7 @@ Present the "user decision" findings via AskUserQuestion (batch related ones; re
 - One granular commit per logical change (if the surface is a git repo). Never one big migration commit — the user needs to be able to revert a single decision.
 - For shared/synced files, apply the machine-agnostic path rule from Step 0.
 - When editing `settings.json`, validate with `python3 -c "import json; json.load(open('...'))"` after every edit, and check `git diff` first so pre-existing drift from other sessions is named in the commit message rather than silently swept in.
-- Delete dead things outright (superseded commands, archives, backup files) — git history is the recovery path; "kept for recovery" copies keep loading into context.
+- Delete dead things outright (superseded commands, archives, backup files) when the surface is a git repo — git history is the recovery path, and "kept for recovery" copies keep loading into context. On a non-git surface, deletion is unrecoverable: confirm the user has a backup (Time Machine, sync) or ask before deleting.
 
 ## Step 5 — Verify and set a checkpoint
 

--- a/packages/plugins/skill-management/skills/migrate-config-to-opus-5/SKILL.md
+++ b/packages/plugins/skill-management/skills/migrate-config-to-opus-5/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: migrate-config-to-opus-5
+description: Audit and migrate a Claude Code configuration (CLAUDE.md, rules, skills, commands, agents, settings.json, hooks, statusline, CI scripts) for Claude Opus 5's behavioral changes. Use when the user asks to migrate or audit their config for Opus 5 / the Claude 5 family, says their setup was written for Opus 4.x or an older Claude model, or reports post-upgrade symptoms like over-verification, over-delegation to subagents, code reviewers missing real findings, or noticeably longer output. Always interview for scope first — the global setup (~/.claude) or an individual project (the cwd).
+---
+
+# Migrate a Claude Code Config to Opus 5
+
+Opus 5 changed what good config looks like. Config written for Opus 4.x often _compensated_ for that era's failure modes (under-verification, under-delegation, under-triggering on instructions). Opus 5 inverts those defaults, so the old compensations now actively fight the model.
+
+Ground rule: the harness (Claude Code's own system prompt) is re-tuned by Anthropic per model. Config should carry only what the harness can't know — the user's policies, environment facts, and preferences. Anything duplicating harness behavior is dead weight; anything compensating for a pre-Opus-5 failure mode is now harmful.
+
+## Step 0 — Scope interview (required, before touching anything)
+
+Ask the user which surface to migrate, via AskUserQuestion:
+
+- **Global setup** — `~/.claude`: CLAUDE.md, `rules/**`, `skills/**`, `commands/`, `agents/`, `settings.json` (+ hooks), statusline script, plugin registrations. Affects every session on the machine (and, if the directory syncs via git, every machine).
+- **This project** — the cwd: `./CLAUDE.md`, `.claude/` (settings, skills, agents, commands, rules), plus project scripts/CI workflows that embed Claude model IDs or API params.
+
+If the user picked global and `~/.claude` is a git repo shared across machines, every path fix must be machine-agnostic (`$HOME`, `~/`, resolver scripts) — a literal home-dir path that is correct on this machine is silently wrong on the others.
+
+In the same interview, ask one execution question: apply edits directly with granular commits (the default), or propose the full diff for review first.
+
+## Step 1 — Inventory
+
+Enumerate the chosen surface before judging any of it. For a large surface, dispatch a read-only Explore agent; for a small project config, do it inline. Collect:
+
+- Every file that loads into context (always-on rules vs path-scoped vs on-demand).
+- Prompt text embedded in skills/commands/agents — reviewer prompts especially.
+- Scripts and CI that mention `claude-*` model IDs, pricing, context-window sizes, or API params.
+- Hooks and their target paths.
+
+Environment note: in Claude Code's Bash, bare `grep` is an embedded ugrep that silently skips gitignored files and any file with invalid UTF-8. Use `/usr/bin/grep` for every search whose result drives a decision.
+
+## Step 2 — Audit against the Opus 5 deltas
+
+Read `references/audit-patterns.md` and scan the inventory against it. It covers the four behavioral deltas (verification, delegation, literal instruction-following, output length), the mechanical checks (stale model IDs and pricing, API params, dead weight), and the settings that need a user decision (effortLevel), with search patterns and fix shapes.
+
+Classify every finding as one of:
+
+- **Fix mechanically** — stale facts with one correct answer (model IDs, pricing, dead entries). No interview needed.
+- **Rewrite** — model-compensation text with a clear Opus 5 replacement (verification ceremony → grounding language; delegation nudges → caps; confidence filters → coverage-first).
+- **User decision** — anything that might be _policy_ rather than compensation. The test: would the user still want this behavior from a perfectly-calibrated model? A review-before-merge gate, a cost-routing table, a secrets rule — those are policy; keep them and say so. When unsure, ask rather than assume.
+- **Leave alone, note why** — pressure language (CRITICAL/MUST) that guards a genuinely fragile workflow or a hard policy line (secrets, destructive git). Deleting emphasis there trades a model-fit win for a real safety loss.
+
+## Step 3 — Decision interview
+
+Present the "user decision" findings via AskUserQuestion (batch related ones; recommendation first). Do not fold policy questions into the mechanical edits — a silently removed gate is the worst outcome of this migration.
+
+## Step 4 — Execute
+
+- One granular commit per logical change (if the surface is a git repo). Never one big migration commit — the user needs to be able to revert a single decision.
+- For shared/synced files, apply the machine-agnostic path rule from Step 0.
+- When editing `settings.json`, validate with `python3 -c "import json; json.load(open('...'))"` after every edit, and check `git diff` first so pre-existing drift from other sessions is named in the commit message rather than silently swept in.
+- Delete dead things outright (superseded commands, archives, backup files) — git history is the recovery path; "kept for recovery" copies keep loading into context.
+
+## Step 5 — Verify and set a checkpoint
+
+- Run a fresh probe: `claude -p --model haiku '<ask it to quote a changed line and confirm a removed one is gone>'` from the relevant directory. This proves the edited config actually loads, hooks don't error, and removals took.
+- If a statusline or script was changed, test it directly with synthetic payloads.
+- Log a one-week checkpoint list of what to watch (response depth at the new effort level, delegation volume, reviewer recall, deliverable length) wherever the user keeps such notes, and say where you put it.
+
+## Output
+
+End with: scope migrated, a per-commit list of what changed and why, findings deliberately left alone (with the policy reason), anything out of reach (other machines, external repos), and the checkpoint date.

--- a/packages/plugins/skill-management/skills/migrate-config-to-opus-5/references/audit-patterns.md
+++ b/packages/plugins/skill-management/skills/migrate-config-to-opus-5/references/audit-patterns.md
@@ -27,7 +27,7 @@ Config written to push delegation harder ("use subagents proactively", "delegate
 
 **Keep (policy):** cost-routing tables (cheap models for mechanical steps — that's economics), and adversarial-review/verification dispatches the user explicitly wants in fresh contexts. If the user has such a policy, write the cap language _with an explicit carve-out_ naming it, or the cap will silently eat the gate.
 
-**Related stale fact:** pre-2026 configs often justify model routing with "Opus costs ~5x Sonnet". Claude 5 pricing: Opus 5 $5/$25 per MTok vs Sonnet 5 $3/$15 → ~1.7x. Haiku ($1/$5) is still ~5x under Opus. Update any cost-ratio claims and thresholds derived from them.
+**Related stale fact:** pre-2026 configs often justify model routing with "Opus costs ~5x Sonnet". Claude 5 pricing (as of 2026-08): Opus 5 $5/$25 per MTok vs Sonnet 5 $3/$15 → ~1.7x. Haiku ($1/$5) is still ~5x under Opus. Update any cost-ratio claims and thresholds derived from them — and verify current pricing at docs.claude.com before writing new ones.
 
 ## Delta 3 — Literal instruction-following: emphasis and filters over-apply
 
@@ -55,7 +55,7 @@ Effort settings do not shorten visible text; only explicit length instructions d
 
 ## Mechanical checks (no judgment, just fix)
 
-- **Model IDs:** `/usr/bin/grep -rE 'claude-(opus|sonnet|haiku)-[0-9]' <scope>` across scripts, CI, statuslines, agent frontmatter, scheduled-task registrations. Current IDs: `claude-opus-5`, `claude-sonnet-5`, `claude-haiku-4-5`. Aliases (`opus`, `sonnet`, `haiku`) are self-updating — prefer them where a pin isn't required.
+- **Model IDs:** `/usr/bin/grep -rE 'claude-(opus|sonnet|haiku)-[0-9]' <scope>` across scripts, CI, statuslines, agent frontmatter, scheduled-task registrations. Current IDs (as of 2026-08): `claude-opus-5`, `claude-sonnet-5`, `claude-haiku-4-5`. Aliases (`opus`, `sonnet`, `haiku`) are self-updating — prefer them where a pin isn't required.
 - **Context-window logic:** scripts branching on model ID for window size. All current non-Haiku models are 1M; Haiku 4.5 is 200K. Keying "haiku → 200K, else 1M" beats enumerating model names. Test with synthetic payloads for both branches.
 - **API params:** `budget_tokens` is rejected with a 400 on the Claude 5 family — replace `thinking: {type: "enabled", budget_tokens: N}` with `thinking: {type: "adaptive"}`. Also flag hardcoded `temperature` alongside thinking, and Priority Tier assumptions (not supported on Opus 5).
 - **Dead weight:** vendored commands referencing nonexistent agents, archive directories, `.backup`/`.bak` settings snapshots (these often pin old models), marketplace entries pointing at dead repos. Delete; git holds history.

--- a/packages/plugins/skill-management/skills/migrate-config-to-opus-5/references/audit-patterns.md
+++ b/packages/plugins/skill-management/skills/migrate-config-to-opus-5/references/audit-patterns.md
@@ -27,7 +27,7 @@ Config written to push delegation harder ("use subagents proactively", "delegate
 
 **Keep (policy):** cost-routing tables (cheap models for mechanical steps — that's economics), and adversarial-review/verification dispatches the user explicitly wants in fresh contexts. If the user has such a policy, write the cap language _with an explicit carve-out_ naming it, or the cap will silently eat the gate.
 
-**Related stale fact:** pre-2026 configs often justify model routing with "Opus costs ~5x Sonnet". Claude 5 pricing (as of 2026-08): Opus 5 $5/$25 per MTok vs Sonnet 5 $3/$15 → ~1.7x. Haiku ($1/$5) is still ~5x under Opus. Update any cost-ratio claims and thresholds derived from them — and verify current pricing at docs.claude.com before writing new ones.
+**Related stale fact:** pre-2026 configs often justify model routing with "Opus costs ~5x Sonnet". Claude 5 pricing (as of 2026-08): Opus 5 $5/$25 per MTok vs Sonnet 5 $3/$15 → ~1.7x — but Sonnet 5 has introductory pricing of $2/$10 through 2026-08-31, so the ratio is ~2.5x until then. Haiku ($1/$5) is still ~5x under Opus. Don't rewrite a cost-ratio claim to a number that goes stale in weeks: verify current pricing at docs.claude.com before writing the replacement.
 
 ## Delta 3 — Literal instruction-following: emphasis and filters over-apply
 
@@ -55,12 +55,12 @@ Effort settings do not shorten visible text; only explicit length instructions d
 
 ## Mechanical checks (no judgment, just fix)
 
-- **Model IDs:** `/usr/bin/grep -rE 'claude-(opus|sonnet|haiku)-[0-9]' <scope>` across scripts, CI, statuslines, agent frontmatter, scheduled-task registrations. Current IDs (as of 2026-08): `claude-opus-5`, `claude-sonnet-5`, `claude-haiku-4-5`. Aliases (`opus`, `sonnet`, `haiku`) are self-updating — prefer them where a pin isn't required.
+- **Model IDs:** `/usr/bin/grep -rE 'claude-(opus|sonnet|haiku)-[0-9]|claude-[0-9]' <scope>` across scripts, CI, statuslines, agent frontmatter, scheduled-task registrations. The second alternative catches Claude 3.x-era IDs (`claude-3-opus-20240229`, `claude-3-5-sonnet-20241022`), where the version precedes the tier — those retired, now-404 pins are exactly what a pre-Opus-5 config is most likely to carry. Current IDs (as of 2026-08): `claude-opus-5`, `claude-sonnet-5`, `claude-haiku-4-5`. Aliases (`opus`, `sonnet`, `haiku`) are self-updating — prefer them where a pin isn't required.
 - **Context-window logic:** scripts branching on model ID for window size. All current non-Haiku models are 1M; Haiku 4.5 is 200K. Keying "haiku → 200K, else 1M" beats enumerating model names. Test with synthetic payloads for both branches.
 - **API params:** `budget_tokens` is rejected with a 400 on the Claude 5 family — replace `thinking: {type: "enabled", budget_tokens: N}` with `thinking: {type: "adaptive"}`. Also flag hardcoded `temperature` alongside thinking, and Priority Tier assumptions (not supported on Opus 5).
-- **Dead weight:** vendored commands referencing nonexistent agents, archive directories, `.backup`/`.bak` settings snapshots (these often pin old models), marketplace entries pointing at dead repos. Delete; git holds history.
+- **Dead weight:** vendored commands referencing nonexistent agents, archive directories, `.backup`/`.bak` settings snapshots (these often pin old models), marketplace entries pointing at dead repos. Delete outright only when the surface is a git repo — git holds history there. On a non-git surface (a plain `~/.claude` is the common case) deletion is unrecoverable, so treat dead-weight removal as a user decision, or confirm an external backup (Time Machine, sync) before deleting.
 - **Third-party plugins:** their prompts carry the same 4.x-era patterns but are not yours to edit. Check each plugin's upstream for explicit Opus 5 retuning evidence; disable or flag the ones without it, and flag (don't disable) the ones the user authors — those are theirs to retune.
 
 ## Settings that need a user decision
 
-- **effortLevel** (Claude Code setting): Opus 5's default is xhigh; low/medium are unusually strong on this model, so a pinned `high` from the 4.x era is worth revisiting. Never change this one mechanically — present the trade (cost/latency vs depth) in the Step 3 interview and let the user pick; log a checkpoint to revisit after a week of use.
+- **effortLevel** (Claude Code setting): Claude Code defaults Opus 5 to xhigh (the raw API default is high — don't conflate the two); low/medium are unusually strong on this model, so a pinned `high` from the 4.x era is worth revisiting. Never change this one mechanically — present the trade (cost/latency vs depth) in the Step 3 interview and let the user pick; log a checkpoint to revisit after a week of use.

--- a/packages/plugins/skill-management/skills/migrate-config-to-opus-5/references/audit-patterns.md
+++ b/packages/plugins/skill-management/skills/migrate-config-to-opus-5/references/audit-patterns.md
@@ -1,0 +1,66 @@
+# Opus 5 Audit Patterns
+
+What to search for, why it's now wrong, and the fix shape. Patterns come from Anthropic's Opus 5 prompting guide, the 4.8→5 migration guide, and a full migration of a large real-world config (2026-08-04).
+
+## Delta 1 — Verification: the model self-verifies unprompted
+
+Opus 4.x under-verified, so configs accumulated verification pressure. Opus 5 verifies on its own; standing re-verify instructions now cause over-verification — wasted tokens, no quality gain. Anthropic's guidance is to delete them.
+
+**Search for:** `triple-check`, `double-check`, `re-verify`, `verify before`, `verify after every`, `check your work`, per-action expect/result ceremony (structured "state expectation → act → compare" protocols).
+
+**Fix shape:** delete the re-verification loop; keep the _grounding_ half if the user values it. Worked rewrite:
+
+- Before: `**Triple-check by default** - Verify before reporting success.`
+- After: `**Report only observed outcomes** - Never claim success you haven't seen happen; if a step wasn't verified, say so plainly. (Do not add extra re-verification passes beyond this — current models self-verify.)`
+
+**Keep (policy, not compensation):** independent review gates (a fresh-context reviewer before merge), "reproduce the bug before fixing it" workflows. Those are process decisions with history behind them, not model babysitting. Confirm with the user rather than deleting.
+
+## Delta 2 — Delegation: the model over-delegates where 4.8 under-delegated
+
+Config written to push delegation harder ("use subagents proactively", "delegate aggressively") now over-triggers: agents spawned for work that fits in a handful of tool calls.
+
+**Search for:** `use subagents` / `delegate` phrased as encouragement without limits; "PROACTIVELY" in agent descriptions; anything nudging fan-outs.
+
+**Fix shape:** convert nudges to caps and "when not to delegate" rules:
+
+> Cap delegation: don't spawn an agent for work that finishes in a handful of tool calls, prefer one agent over several when one suffices, and keep fleet counts low by default.
+
+**Keep (policy):** cost-routing tables (cheap models for mechanical steps — that's economics), and adversarial-review/verification dispatches the user explicitly wants in fresh contexts. If the user has such a policy, write the cap language _with an explicit carve-out_ naming it, or the cap will silently eat the gate.
+
+**Related stale fact:** pre-2026 configs often justify model routing with "Opus costs ~5x Sonnet". Claude 5 pricing: Opus 5 $5/$25 per MTok vs Sonnet 5 $3/$15 → ~1.7x. Haiku ($1/$5) is still ~5x under Opus. Update any cost-ratio claims and thresholds derived from them.
+
+## Delta 3 — Literal instruction-following: emphasis and filters over-apply
+
+CRITICAL/MUST written to overcome 4.x under-triggering now over-applies. The highest-impact instance: **review-prompt recall filters**. "Only report findings with confidence ≥ 75" or a severity floor makes Opus 5 silently drop real findings.
+
+**Search for:** `confidence >=` / `confidence ≥` / `only report` / `high-severity only` / `be conservative` / `skip things that look correct` in reviewer prompts; count `CRITICAL|MUST|NEVER|ALWAYS` per file and investigate the outliers.
+
+**Fix shape for review prompts** — coverage-first, filter downstream:
+
+> Report every genuine issue you find, including ones you are uncertain about or consider low-severity. Do not filter for confidence at this stage — set the confidence field honestly and let the downstream verification pass rank and filter. It is better to surface a finding that later gets filtered out than to silently drop a real bug.
+
+If a severity floor must stay (a pipeline contract), soften its edge: "when uncertain whether an issue clears the floor, err on the side of reporting it — never silently drop a borderline finding you actually investigated."
+
+**Fix shape for pressure language:** rewrite emphasis into a one-line _why_ ("X breaks when Y, so do Z") — explained constraints steer better than shouted ones.
+
+**Leave alone:** full-volume emphasis guarding genuinely fragile operations (exact scripts for brittle tooling) and hard policy lines (secrets handling, destructive git). Note each one you kept and why.
+
+## Delta 4 — Output length: longer responses and file deliverables
+
+Effort settings do not shorten visible text; only explicit length instructions do. Most configs already constrain chat replies but say nothing about files the model authors.
+
+**Check:** does the config have a deliverable-length rule? If not, add one line where writing style lives:
+
+> Match the length of written deliverables (reports, docs, Markdown files Claude authors) to what the task needs: cover the substance, skip filler sections, redundant summaries, and boilerplate padding.
+
+## Mechanical checks (no judgment, just fix)
+
+- **Model IDs:** `/usr/bin/grep -rE 'claude-(opus|sonnet|haiku)-[0-9]' <scope>` across scripts, CI, statuslines, agent frontmatter, scheduled-task registrations. Current IDs: `claude-opus-5`, `claude-sonnet-5`, `claude-haiku-4-5`. Aliases (`opus`, `sonnet`, `haiku`) are self-updating — prefer them where a pin isn't required.
+- **Context-window logic:** scripts branching on model ID for window size. All current non-Haiku models are 1M; Haiku 4.5 is 200K. Keying "haiku → 200K, else 1M" beats enumerating model names. Test with synthetic payloads for both branches.
+- **API params:** `budget_tokens` is rejected with a 400 on the Claude 5 family — replace `thinking: {type: "enabled", budget_tokens: N}` with `thinking: {type: "adaptive"}`. Also flag hardcoded `temperature` alongside thinking, and Priority Tier assumptions (not supported on Opus 5).
+- **Dead weight:** vendored commands referencing nonexistent agents, archive directories, `.backup`/`.bak` settings snapshots (these often pin old models), marketplace entries pointing at dead repos. Delete; git holds history.
+- **Third-party plugins:** their prompts carry the same 4.x-era patterns but are not yours to edit. Check each plugin's upstream for explicit Opus 5 retuning evidence; disable or flag the ones without it, and flag (don't disable) the ones the user authors — those are theirs to retune.
+
+## Settings that need a user decision
+
+- **effortLevel** (Claude Code setting): Opus 5's default is xhigh; low/medium are unusually strong on this model, so a pinned `high` from the 4.x era is worth revisiting. Never change this one mechanically — present the trade (cost/latency vs depth) in the Step 3 interview and let the user pick; log a checkpoint to revisit after a week of use.


### PR DESCRIPTION
## Summary

Ports the `migrate-config-to-opus-5` skill into the `skill-management` plugin for team-wide use. The skill audits and migrates a Claude Code configuration (CLAUDE.md, rules, skills, commands, agents, settings.json, hooks, statusline, CI scripts) for Claude Opus 5's behavioral changes.

**What the skill does:**

- Interviews for scope first: global `~/.claude` vs the current project
- Inventories every file that loads into context, plus scripts/CI embedding model IDs or API params
- Audits against `references/audit-patterns.md` — the four Opus 5 behavioral deltas (self-verification, delegation, literal instruction-following, output length) with concrete search patterns and fix shapes
- Classifies every finding: fix mechanically / rewrite / **user decision** (policy vs compensation — never silently removes a gate) / leave alone with rationale
- Executes with one granular commit per logical change, then verifies with a fresh `claude -p` probe

**Plugin changes:**

- New skill at `packages/plugins/skill-management/skills/migrate-config-to-opus-5/` (SKILL.md + references/audit-patterns.md)
- `plugin.json`: skill registered, version bumped 1.0.2 → 1.1.0 (minor: new backward-compatible skill)
- Plugin CLAUDE.md + README updated; root CLAUDE.md version table updated

**Why `skill-management`:** this plugin is the curation layer over the Claude Code customization surface (inventory, audit, improve). A model-migration audit of that same surface fits its charter; `claude-setup` is about bootstrapping new repos, not migrating existing config.

## Test plan

- [x] `node scripts/validate-plugin.cjs packages/plugins/skill-management` passes
- [x] `bunx markdownlint-cli2` clean on all touched files
- [x] `bunx nx format:write --uncommitted` applied
- [x] Pre-commit hooks (format, lint, lint-markdown, test, typecheck, lockfile) all green
- [x] Skill content exercised in a real end-to-end migration of a large personal config (2026-08-04) before porting

🤖 Generated with [Claude Code](https://claude.com/claude-code)