### PR TITLE
chore: migrate project config for Claude Opus 5

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,15 +1,5 @@
 {
   "hooks": {
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo '{\"systemMessage\": \"If this request is ambiguous or has multiple valid approaches, ask clarifying questions before proceeding.\"}'"
-          }
-        ]
-      }
-    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",

--- a/.github/REUSABLE_WORKFLOWS.md
+++ b/.github/REUSABLE_WORKFLOWS.md
@@ -511,7 +511,7 @@ Worried about Anthropic API costs
 
 **Solutions**:
 
-- Use `claude-sonnet-5` (default) instead of Opus for most tasks (~80% cheaper)
+- Use `claude-sonnet-5` (default) instead of Opus for most tasks (~40% cheaper: $3/$15 vs $5/$25 per MTok)
 - Reduce `timeout_minutes` to limit execution time (default: 10)
 - The workflow includes concurrency control to prevent duplicate runs
 - Monitor usage at console.anthropic.com

--- a/.github/workflows/examples/07-claude-main-custom.yml
+++ b/.github/workflows/examples/07-claude-main-custom.yml
@@ -417,8 +417,12 @@ jobs:
 #
 # 1. **Choose the right model**:
 #    - Haiku 4.5: Most cost-effective for simple tasks and high-volume usage
-#    - Sonnet 5: Best balance for most tasks (~80% cheaper than Opus)
-#    - Opus: Reserve for complex analysis or critical reviews
+#      ($1/$5 per MTok — still ~5x cheaper than Opus 5)
+#    - Sonnet 5: Best balance for most tasks ($3/$15 per MTok, ~40% cheaper
+#      than Opus 5)
+#    - Opus 5: $5/$25 per MTok. The Opus/Sonnet gap narrowed sharply with the
+#      Claude 5 family, so reserve Opus for complex analysis or critical
+#      reviews on judgment grounds rather than on cost grounds alone.
 #
 # 2. **Set appropriate timeouts**:
 #    - 5 minutes for simple questions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,6 +341,16 @@ review-cli 123 --repo Uniswap/ai-toolkit
 
 ## Documentation Management
 
+### Deliverable Length
+
+Match the length of written deliverables to what the task needs. This covers everything Claude Code authors as a file or a posted artifact: CLAUDE.md and README.md updates, plan and spec documents, changelog entries, Notion pages, PR bodies, and review summaries.
+
+- Cover the substance the reader actually needs to act on.
+- Skip filler sections, redundant summaries that restate the section above, and boilerplate padding.
+- Prefer editing an existing section over appending a parallel one that repeats it.
+
+This is a real constraint rather than a style preference: reasoning-effort settings do not shorten authored files, so length only comes down when it is asked for explicitly. Unbounded docs are also expensive here, since the plugin CLAUDE.md files load into the context of every session that touches those packages.
+
 ### CLAUDE.md File Management
 
 After making any changes to files in this repository, Claude Code MUST:


### PR DESCRIPTION
## Summary

Audit and migration of this repo's Claude Code config (`CLAUDE.md`, `.claude/`, `.github/prompts/`, workflows, plugin frontmatter) against the Claude Opus 5 behavioral changes, run via the `migrate-config-to-opus-5` skill added in #562.

Most of the surface was already clean — the model-ID sweep already landed on `next`, `.claude/review.yml` is already Opus-5-native, there are no `budget_tokens` API params anywhere, and the PR-review prompts carry no confidence floors or severity filters. Three real findings remained.

## Changes

**1. Stale Opus-vs-Sonnet cost ratio** (`.github/REUSABLE_WORKFLOWS.md`, `examples/07-claude-main-custom.yml`)

The "~80% cheaper" guidance was derived from Claude 4.x list prices (Opus 4.8 at \$15/\$75 vs Sonnet 4.6 at \$3/\$15). The Claude 5 family narrowed that gap: Opus 5 is \$5/\$25 and Sonnet 5 is \$3/\$15, so Sonnet is ~40% cheaper. The model IDs in those lines were updated in an earlier sweep, but the ratio derived from the old prices was not — it overstated the savings by 2x. Now quotes per-MTok prices directly so the claim is checkable.

**2. Removed the `UserPromptSubmit` clarify-questions hook** (`.claude/settings.json`)

It injected "If this request is ambiguous or has multiple valid approaches, ask clarifying questions before proceeding" into every prompt. That's a 4.x-era compensation for a generation that under-asked. Opus 5 already interviews on genuine ambiguity and follows standing instructions more literally, so an unconditional directive now over-triggers on routine requests.

The `PostToolUse` lint/typecheck hook and the `SessionStart` `NX_DAEMON=false` hook are untouched — both encode environment facts rather than model behavior.

**3. Added a deliverable-length rule** (`CLAUDE.md` → Documentation Management)

Opus 5 writes longer authored files, and reasoning-effort settings don't shorten them; only an explicit length instruction does. This matters more here than in most repos because the per-package `CLAUDE.md` files load into the context of every session touching those packages, so padding is a recurring cost rather than a one-time read.

## Deliberately left alone

- **`4-review-priorities.md` "Only mention if high value - skip nitpicks"** and **`14-important-notes.md` "Skip nitpicks"** — scoped to the tier-3 nice-to-have bucket and to style comments, not a confidence floor on bugs. Legitimate signal-to-noise policy.
- **`18-fast-review-mode.md`** — a deliberate cost contract for sub-20-line PRs, not model compensation.
- **`.claude/review.yml`'s `claude-opus-4-8` mention** — an accurate historical note about the retired homegrown reviewer.
- **Plugin frontmatter using aliases (`model: opus`/`sonnet`/`haiku`)** — 38 files; aliases are self-updating and correct as-is.

## Test plan

- [x] `markdownlint-cli2` clean (200 files, 0 errors)
- [x] Lefthook pre-commit passed on all three commits (format, lint, lint-markdown, test, typecheck, lockfile)
- [x] `.claude/settings.json` validated as JSON; remaining hooks are `PostToolUse` + `SessionStart`
- [x] Fresh-session probe (`claude -p --model haiku`) from the worktree confirms the new Deliverable Length rule loads AND that no clarify-questions instruction is active any more
- [x] No `packages/plugins/` files changed, so no plugin version bump is required

🤖 Generated with [Claude Code](https://claude.com/claude-code)