### PR TITLE
fix(uniswap-integrations): repair unsafe and always-true PAT checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,7 @@ docs/enterprise/README.md
 # Proposals for LLM implementation
 docs/proposals/
 docs/audits/
+
+# Claude Code session artifacts
+.claude-outputs/
+.playwright-mcp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,7 +230,7 @@ All plugins follow semantic versioning (semver). Key versioning rules:
 | development-productivity   | 2.4.1   |
 | skill-management           | 1.2.0   |
 | spec-workflow              | 2.0.1   |
-| uniswap-integrations       | 2.6.0   |
+| uniswap-integrations       | 2.6.1   |
 
 **Note:** Keep this table updated when versions change.
 

--- a/packages/plugins/uniswap-integrations/.claude-plugin/plugin.json
+++ b/packages/plugins/uniswap-integrations/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uniswap-integrations",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "External service integrations (Linear, Notion, Nx, Chrome DevTools, GitHub, Slack, Amplitude, Datadog) and deployment orchestration",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/uniswap-integrations/skills/github-setup/SKILL.md
+++ b/packages/plugins/uniswap-integrations/skills/github-setup/SKILL.md
@@ -104,13 +104,19 @@ Then run `/mcp` in Claude Code to see the GitHub MCP server listed.
 
 If the GitHub MCP server reports a missing token:
 
-1. Verify the environment variable is set:
+1. Verify the environment variable is set. Check for presence and length only — never echo the
+   token itself, since anything printed here lands in the terminal transcript and in any session
+   log, which means the token has to be rotated:
 
    ```bash
-   echo $GITHUB_PERSONAL_ACCESS_TOKEN
+   if [ -n "$GITHUB_PERSONAL_ACCESS_TOKEN" ]; then
+     echo "GitHub token is set (length: ${#GITHUB_PERSONAL_ACCESS_TOKEN} chars)"
+   else
+     echo "GitHub token is NOT set"
+   fi
    ```
 
-2. If empty, check your shell profile contains the export
+2. If not set, check your shell profile contains the export
 
 3. Source your profile or restart the terminal:
 

--- a/packages/plugins/uniswap-integrations/skills/github-setup/SKILL.md
+++ b/packages/plugins/uniswap-integrations/skills/github-setup/SKILL.md
@@ -92,8 +92,12 @@ set -Ux GITHUB_PERSONAL_ACCESS_TOKEN "ghp_your_token_here"
 After setting the token, restart Claude Code and verify:
 
 ```bash
-# Verify token is set
-echo "Token configured: $([ -n \"$GITHUB_PERSONAL_ACCESS_TOKEN\" ] && echo 'Yes' || echo 'No')"
+# Verify token is set (presence only — never echo the value itself)
+if [ -n "$GITHUB_PERSONAL_ACCESS_TOKEN" ]; then
+  echo "GitHub token is set (length: ${#GITHUB_PERSONAL_ACCESS_TOKEN} chars)"
+else
+  echo "GitHub token is NOT set"
+fi
 ```
 
 Then run `/mcp` in Claude Code to see the GitHub MCP server listed.


### PR DESCRIPTION
## Problem

`packages/plugins/uniswap-integrations/skills/github-setup/SKILL.md` told users, in the **Token Not Found** troubleshooting section, to run:

```bash
echo $GITHUB_PERSONAL_ACCESS_TOKEN
```

That prints the token into the terminal transcript and into any session log that captures it. Once a credential lands in a transcript it has to be rotated — so the diagnostic step burns the token it is checking. Anyone following this skill to debug a *working* token ends up needing a new one.

The same file already models the correct form at Step 1 (line 29), so this was an internal inconsistency, not a missing pattern.

## Fix

Replace the echo with a presence-and-length-only check, and state why the echo form is unsafe so the pattern does not get reintroduced by a future edit:

```bash
if [ -n "$GITHUB_PERSONAL_ACCESS_TOKEN" ]; then
  echo "GitHub token is set (length: ${#GITHUB_PERSONAL_ACCESS_TOKEN} chars)"
else
  echo "GitHub token is NOT set"
fi
```

Length still distinguishes "unset" from "set but truncated," which is what the troubleshooting step actually needs.

Also gitignores `.claude-outputs/` and `.playwright-mcp/` so session artifacts stay out of the repo.

## Scope

Found during the Opus 5 marketplace audit. Split out as its own PR because it is a credential-handling defect, unrelated to the audit's migration findings — those land as one PR per plugin.

## Test plan

- `/usr/bin/grep -rn 'echo \$GITHUB_PERSONAL_ACCESS_TOKEN'` across the repo returns no hits.
- `bunx markdownlint-cli2` — 0 errors across 201 files.
- Lefthook pre-commit (format, lint, lint-markdown, test, typecheck, lockfile) passed.
- `uniswap-integrations` bumped 2.6.0 → 2.6.1 (patch, bug fix) with the root `CLAUDE.md` table updated in the same commit, per the mandatory version-bump rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Problem
`packages/plugins/uniswap-integrations/skills/github-setup/SKILL.md` had two broken token checks — one that leaks the credential, one that lies about it.
**1. The Token Not Found troubleshooting step printed the token.** It told users to run:
```bash
echo $GITHUB_PERSONAL_ACCESS_TOKEN
```
That writes the token into the terminal transcript and into any session log that captures it. Once a credential lands in a transcript it has to be rotated — so the diagnostic step burns the token it is checking. Anyone following this skill to debug a *working* token ends up needing a new one.
**2. The Step 4 verification was unconditionally true.** It used a command substitution whose inner quotes were backslash-escaped:
```bash
echo "Token configured: $([ -n \"$GITHUB_PERSONAL_ACCESS_TOKEN\" ] && echo 'Yes' || echo 'No')"
```
Inside `$( ... )` the body is re-parsed as a fresh command, where `\"` is not a quoting operator, so the backslashes survive into the word. `test` then receives the two-character literal string `""` — non-empty — and the condition can never be false. Verified under `/bin/sh` with the variable unset: the old form prints `Token configured: Yes`.
The consequence is that a user with **no** token set is told it is configured, and never reaches the Token Not Found section that the first fix repairs.
## Fix
Both sites now use the same presence-and-length-only check, matching the form Step 1 of this skill already models:
```bash
if [ -n "$GITHUB_PERSONAL_ACCESS_TOKEN" ]; then
  echo "GitHub token is set (length: ${#GITHUB_PERSONAL_ACCESS_TOKEN} chars)"
else
  echo "GitHub token is NOT set"
fi
```
Length still distinguishes "unset" from "set but truncated," which is what the troubleshooting step actually needs, without printing the value. The troubleshooting section also states *why* the echo form is unsafe, so the pattern does not get reintroduced by a future edit.
Also gitignores `.claude-outputs/` and `.playwright-mcp/` so session artifacts stay out of the repo.
## Scope
Found during the Opus 5 marketplace audit. Split out as its own PR because it is a credential-handling defect, unrelated to the audit's migration findings — those land as one PR per plugin.
## Test plan
- [x] `grep -rn 'echo \$GITHUB_PERSONAL_ACCESS_TOKEN'` across the repo returns no hits
- [x] Old Step 4 form reproduced under `/bin/sh` with the variable unset — prints `Token configured: Yes`, confirming the always-true bug; new form correctly prints `GitHub token is NOT set`
- [x] `bunx markdownlint-cli2` — 0 errors across 201 files
- [x] Lefthook pre-commit (format, lint, lint-markdown, test, typecheck, lockfile) passed
- [x] `uniswap-integrations` bumped 2.6.0 → 2.6.1 (patch, bug fix) with the root `CLAUDE.md` version table updated in the same commit, per the mandatory version-bump rule

</details>
<!-- claude-pr-description-end -->