### PR TITLE
fix(claude-setup): migrate docs for Opus 5, stop blind staging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,7 +223,7 @@ All plugins follow semantic versioning (semver). Key versioning rules:
 
 | Plugin                     | Version |
 | -------------------------- | ------- |
-| claude-setup               | 1.0.5   |
+| claude-setup               | 1.1.0   |
 | development-codebase-tools | 2.6.2   |
 | development-planning       | 2.0.7   |
 | development-pr-workflow    | 2.3.0   |

--- a/packages/plugins/claude-setup/.claude-plugin/plugin.json
+++ b/packages/plugins/claude-setup/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-setup",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Interactive setup wizard for configuring any repository with Claude Code best practices, based on Boris Cherny's workflow",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/claude-setup/README.md
+++ b/packages/plugins/claude-setup/README.md
@@ -71,7 +71,7 @@ This plugin implements key practices from Boris Cherny (creator of Claude Code):
 - **Plan mode first** - Start complex tasks with planning
 - **Compounding learning** - Update CLAUDE.md when Claude makes mistakes
 - **Slash commands for inner loops** - Automate repetitive workflows
-- **Opus 4.8** - Use the best model for quality
+- **Opus 5** - Use the best model for quality
 
 See [references/boris-best-practices.md](skills/setup-repository/references/boris-best-practices.md) for full details.
 

--- a/packages/plugins/claude-setup/skills/setup-repository/SKILL.md
+++ b/packages/plugins/claude-setup/skills/setup-repository/SKILL.md
@@ -117,6 +117,8 @@ Before starting, analyze the repository to understand its structure:
 [Empty section - add mistakes/corrections here over time]
 ```
 
+Keep the generated CLAUDE.md under 200 lines. It loads into every session in this repo, so anything that is not acted on is paid for on every turn.
+
 **Ask user:**
 
 - "Should I create/enhance CLAUDE.md? [Yes / Skip]"
@@ -220,7 +222,7 @@ Verify that recent changes work correctly before considering them complete.
 
 ## Output
 
-Report verification results:
+Report verification results in under 20 lines:
 
 - Build: [PASS/FAIL]
 - Tests: [PASS/FAIL] - X passed, Y failed
@@ -259,7 +261,7 @@ Review recently changed code and simplify where possible.
 
 ## Output
 
-List changes made with before/after snippets.
+List changes made with before/after snippets, in under 20 lines.
 ```
 
 **Create directory:**

--- a/packages/plugins/claude-setup/skills/setup-repository/references/agent-templates.md
+++ b/packages/plugins/claude-setup/skills/setup-repository/references/agent-templates.md
@@ -82,6 +82,8 @@ If changes affect external integrations:
 
 ## Output Format
 
+Keep the report under 40 lines. It is read by the agent that dispatched this one, so spend the space on failures rather than restating passing checks.
+
 ```
 ## Verification Results
 
@@ -172,6 +174,8 @@ Review recently changed code and simplify without changing behavior.
 - Run tests after changes
 
 ## Output Format
+
+Keep the report under 40 lines. Show snippets only for changes a reviewer could not infer from the description.
 
 ````
 
@@ -271,18 +275,19 @@ Verify documentation is current:
 
 ## Output Format
 
+Keep the report under 30 lines. Report only fields you actually measured; omit a line rather than guessing a value for it.
+
 ```
 ## Build Validation Report
 
 ### Build Status
 - Clean build: [PASS/FAIL]
-- Build time: [X seconds]
-- Bundle size: [X KB] ([+/- Y KB] from main)
+- Build time: [X seconds, only if you timed the build]
+- Bundle size: [X KB, only if the analyze step ran. Omit the delta unless you also built the base branch to compare against.]
 
 ### Dependency Status
-- Total dependencies: X
-- Peer warnings: [list]
-- Vulnerabilities: [npm audit results]
+- Peer warnings: [list from `npm ls`]
+- Vulnerabilities: [omit this line unless you ran `npm audit`]
 
 ### Pre-PR Checklist
 - [ ] Build passes
@@ -348,6 +353,8 @@ Based on analysis:
 - Mitigations: [how to address risks]
 
 ## Output Format
+
+Keep the analysis under 60 lines. Two or three options is enough; do not pad the list to look thorough.
 
 ````
 
@@ -452,6 +459,8 @@ Assist with diagnosing and resolving production issues.
 - Prevention measures
 
 ## Output Format
+
+Keep the analysis under 40 lines. During an active incident, the summary and the resolution are what get read.
 ```
 
 ## Incident Analysis

--- a/packages/plugins/claude-setup/skills/setup-repository/references/boris-best-practices.md
+++ b/packages/plugins/claude-setup/skills/setup-repository/references/boris-best-practices.md
@@ -62,9 +62,11 @@ The key insight: Claude Code is powerful by default. The goal of configuration i
 - Use inline bash to pre-compute context (git status, etc.)
 - Reduces back-and-forth with the model
 
-### 5. Opus 4.8 (Most Capable)
+### 5. Opus (Most Capable)
 
 > "The model choice is unambiguous: Opus 4.8 for everything."
+
+_(Quoted as written. The current flagship is Opus 5; the point about always reaching for the most capable Opus still stands.)_
 
 **Rationale:**
 
@@ -135,7 +137,7 @@ Boris runs:
 | ------------------------------------ | ------------------------------------- |
 | `git add .`                          | Add files individually                |
 | Skip verification                    | Always verify before marking complete |
-| Use Sonnet for complex tasks         | Use Opus 4.8                          |
+| Use Sonnet for complex tasks         | Use Opus 5                            |
 | Skip plan mode                       | Start in plan mode, iterate on plan   |
 | Ignore mistakes                      | Add to CLAUDE.md immediately          |
 | Use `--dangerously-skip-permissions` | Use `/permissions` for pre-approval   |

--- a/packages/plugins/claude-setup/skills/setup-repository/references/command-templates.md
+++ b/packages/plugins/claude-setup/skills/setup-repository/references/command-templates.md
@@ -299,13 +299,16 @@ git status
 git diff
 ````
 
-### 2. Stage All Changes
+### 2. Stage the Changed Files
 
 ```bash
-git add -A
+git add [file1] [file2] ...
 ```
 
-**Note:** This stages everything. Use /commit-push-pr for more control.
+**Note:** Even in the quick path, stage files individually. `git add -A` sweeps in
+untracked files you never reviewed — build artifacts, local scratch files, and
+`.env` files that a missing `.gitignore` entry left visible. Use `/commit-push-pr`
+when you want the fuller review flow.
 
 ### 3. Generate and Commit
 


### PR DESCRIPTION
Applies the Opus 5 migration audit to `packages/plugins/claude-setup/`. Every `.md` under that directory was read in full; only defects were touched.

## Deltas addressed

### Stale facts (model version)

The plugin recommended **Opus 4.8** in three places. All three now say Opus 5:

- `README.md` — "Boris' Best Practices" bullet.
- `references/boris-best-practices.md` — the pillar-5 heading (`### 5. Opus 4.8 (Most Capable)` → `### 5. Opus (Most Capable)`).
- `references/boris-best-practices.md` — the anti-patterns table row (`Use Opus 4.8` → `Use Opus 5`).

**Carve-out honored:** the Boris quotation on the next line ("The model choice is unambiguous: Opus 4.8 for everything.") is left verbatim. Rewriting the inside of a quotation would falsify the source. An italic editorial note below it records that the current flagship is Opus 5.

> Correction to the audit brief: it stated that the anti-patterns table "already says Opus 5." It did not — it said Opus 4.8, same as the other two sites. There was no self-contradiction in the file; all three were uniformly stale.

### Delta 4 — output length

Reasoning-effort settings do not shorten authored deliverables; only explicit length instructions do. Report sections that lacked one now have one. Highest priority first (agent reports feed another agent's context):

- `references/agent-templates.md` — length bounds added to the `## Output Format` section of `verify-app` (40 lines), `code-simplifier` (40), `build-validator` (30), `code-architect` (60), and `oncall-guide` (40).
- `SKILL.md` — the inline `verify-app` and `code-simplifier` templates now bound their `## Output` at 20 lines.
- `SKILL.md` — the generated CLAUDE.md is bounded at **under 200 lines**, with the reason stated (it loads into every session in the target repo). This is the plugin's primary deliverable and had no length guidance at all.

### Invented numbers

`build-validator`'s report template demanded three numeric fields its own validation steps never produce, so a model filling the required fields would fabricate them and they would read as measured:

- `Build time: [X seconds]` — the steps never time the build.
- `Bundle size: [X KB] ([+/- Y KB] from main)` — the delta requires a base-branch build the template never instructs.
- `Vulnerabilities: [npm audit results]` — `npm audit` is never run; only `npm ls`.

Each is now explicitly conditional on the measurement having actually happened, and the report section instructs omitting a line rather than guessing a value. `Total dependencies: X` was dropped (unmeasured and not actionable). Counts that *are* derived from real tool output (`X passed, Y failed`, `Files modified`, `Lines removed`) were left alone — arithmetic over measured inputs is fine.

## Deltas audited and found absent

Reported rather than invented:

- **Delta 1 (verification ceremony)** — no mandated pre-think phases, no trailing self-review over just-written output, no second-agent verification pass. The `verify-app` template's checks run real build/test/typecheck/lint commands and report their results, which is grounding, not ceremony. Kept as-is.
- **Delta 2 (delegation)** — no agent-count floors, quotas, or "spawn N agents" instructions anywhere in this plugin. Nothing to convert.
- **Delta 3 (recall filters / emphasis)** — no discovery-time filters. `review-changes` is already coverage-first (report every issue found, summarize downstream). The remaining `Do NOT` / `Never` emphasis marks real constraints (`git add .`, not marking ready while a check fails), not decoration.
- **Broken references** — every agent, skill, command, and tool name in this plugin refers to a template the wizard *creates* in the user's repo, not to a dispatch target in this marketplace. No fabricated dispatch names. `allowed-tools` in `SKILL.md` lists only real tools; no `MultiEdit`, no `budget_tokens`, no OpenAI-only sampling params.

## Version bump

`1.0.5` → **`1.1.0`** (minor). The length bounds and the omit-unmeasured-fields rule change what the generated agents and CLAUDE.md do, not just the wording of the docs. Root `CLAUDE.md` version table updated in the same commit.

`CLAUDE.md` and `README.md` component lists were checked and needed no update: no skill, agent, or command was added, removed, or renamed.

## Test plan

- `bunx nx format:write --uncommitted` — clean; normalized `agent-templates.md`, that normalization is in the commit.
- `bunx markdownlint-cli2 --fix "packages/plugins/claude-setup/**/*.md"` — `Linting: 200 file(s)`, `Summary: 0 error(s)`, exit 0.
- Pre-commit (lefthook) — all six gates green: `format`, `lint`, `lint-markdown`, `test`, `typecheck`, `update-lockfile`.
- `grep -rn "Opus 4" packages/plugins/claude-setup/` — one remaining hit, the Boris quotation, intentionally preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Applies the Opus 5 migration audit to `packages/plugins/claude-setup/`, plus one credential-adjacent
fix found in the same read: the quick-commit template told users to `git add -A`. Every `.md` under
the plugin was read in full; only defects were touched. 7 files, +31/-15.
## Stale model version
The plugin recommended **Opus 4.8** in three places. All three now say Opus 5:
- `README.md` — the "Boris' Best Practices" bullet.
- `references/boris-best-practices.md` — the pillar-5 heading (`### 5. Opus 4.8 (Most Capable)` → `### 5. Opus (Most Capable)`).
- `references/boris-best-practices.md` — the anti-patterns table row (`Use Opus 4.8` → `Use Opus 5`).
**Carve-out honored:** the Boris quotation on the next line ("The model choice is unambiguous: Opus
4.8 for everything.") is left verbatim — rewriting the inside of an attributed quotation would
falsify the source. An italic editorial note below it records that the current flagship is Opus 5.
This matches the exemption already taken in #558.
## Output length
Reasoning-effort settings do not shorten authored deliverables; only an explicit length instruction
does. Report sections that lacked one now have one, agent reports first since they feed another
agent's context:
- `references/agent-templates.md` — bounds added to the `## Output Format` of `verify-app` (40 lines), `code-simplifier` (40), `build-validator` (30), `code-architect` (60), and `oncall-guide` (40).
- `SKILL.md` — the inline `verify-app` and `code-simplifier` templates now bound their `## Output` at 20 lines.
- `SKILL.md` — the generated CLAUDE.md is bounded at **under 200 lines**, with the reason stated (it loads into every session in the target repo). This is the plugin's primary deliverable and had no length guidance at all.
## Invented numbers
`build-validator`'s report template required three numeric fields its own validation steps never
produce, so a model filling the required fields would fabricate them — and they would read as
measured:
| Field | Why it could only be guessed |
| --- | --- |
| `Build time: [X seconds]` | the steps never time the build |
| `Bundle size: [X KB] ([+/- Y KB] from main)` | the delta needs a base-branch build the template never instructs |
| `Vulnerabilities: [npm audit results]` | `npm audit` is never run; only `npm ls` |
Each is now explicitly conditional on the measurement having happened, and the section says to omit a
line rather than guess. `Total dependencies: X` was dropped (unmeasured and not actionable). Counts
that *are* derived from real tool output (`X passed, Y failed`, `Files modified`, `Lines removed`)
were left alone — arithmetic over measured inputs is fine.
## Quick-commit staged blind
`references/command-templates.md` is the source for the slash commands the wizard writes into a
user's repo. Its `/quick-commit` template said:
```bash
git add -A
```
`git add -A` sweeps in untracked files the user never reviewed — build artifacts, local scratch
files, and `.env` files that a missing `.gitignore` entry left visible. The template's own mitigation
was a one-line "Note: This stages everything," which does not stop the command it just prescribed.
This contradicted the plugin in three other places, including **line 50 of the same file** (`Never
use git add .`), `SKILL.md:166`, `references/claude-md-examples.md:27`, and the `git add .`
anti-patterns row in `boris-best-practices.md`. So this was an internal inconsistency, not a missing
convention — the correct form was already modeled 250 lines up.
The template now stages named files and states why, so the pattern does not get reintroduced as a
"simplification." `/commit-push-pr` remains the pointer for the fuller review flow.
## Deltas audited and found absent
Reported rather than invented:
- **Verification ceremony** — no mandated pre-think phases, no trailing self-review over just-written output, no second-agent verification pass. `verify-app`'s checks run real build/test/typecheck/lint commands and report their results, which is grounding, not ceremony.
- **Delegation floors** — no agent-count minimums, quotas, or "spawn N agents" instructions anywhere in this plugin.
- **Recall filters / emphasis** — no discovery-time filters. `review-changes` is already coverage-first. The remaining `Do NOT` / `Never` marks real constraints (`git add .`, not marking ready while a check fails), not decoration.
- **Broken references** — every agent, skill, command, and tool name here refers to a template the wizard *creates* in the user's repo, not to a dispatch target in this marketplace, so there are no fabricated dispatch names. `allowed-tools` in `SKILL.md` lists only real tools; no `MultiEdit`, no `budget_tokens`, no OpenAI-only sampling params.
> Correction to the audit brief: it stated the anti-patterns table "already says Opus 5." It did not —
> it said Opus 4.8, same as the other two sites. There was no self-contradiction; all three were
> uniformly stale.
## Version bump
`1.0.5` → **`1.1.0`** (minor). The length bounds, the omit-unmeasured-fields rule, and the staging
change alter what the generated agents and commands *do*, not just the wording of the docs. Root
`CLAUDE.md` version table updated in the same commit.
Plugin `CLAUDE.md` and `README.md` component lists were checked and need no update: no skill, agent,
or command was added, removed, or renamed.
## Test plan
- [x] `grep -rn "Opus 4" packages/plugins/claude-setup/` — exactly one hit, the Boris quotation, intentionally preserved
- [x] `grep -rn "git add -A"` across the plugin — no hits remain
- [x] `bunx nx format:write --uncommitted` — clean; normalized `agent-templates.md`, that normalization is in the commit
- [x] `bunx markdownlint-cli2 --fix "packages/plugins/claude-setup/**/*.md"` — 200 files, 0 errors, exit 0
- [x] Lefthook pre-commit — all six gates green: `format`, `lint`, `lint-markdown`, `test`, `typecheck`, `update-lockfile`

</details>
<!-- claude-pr-description-end -->