### PR TITLE
fix(spec-workflow): migrate skills for Opus 5 behavior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,7 +229,7 @@ All plugins follow semantic versioning (semver). Key versioning rules:
 | development-pr-workflow    | 2.3.0   |
 | development-productivity   | 2.4.1   |
 | skill-management           | 1.2.0   |
-| spec-workflow              | 2.0.1   |
+| spec-workflow              | 2.1.0   |
 | uniswap-integrations       | 2.6.1   |
 
 **Note:** Keep this table updated when versions change.

--- a/packages/plugins/spec-workflow/.claude-plugin/plugin.json
+++ b/packages/plugins/spec-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-workflow",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Autonomous spec-driven development workflow with multi-agent collaboration, specification management, and task orchestration",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/spec-workflow/CLAUDE.md
+++ b/packages/plugins/spec-workflow/CLAUDE.md
@@ -67,6 +67,14 @@ The skills in this plugin primarily use these MCP tools:
 - `mcp__spec-workflow__get-steering-context` - Load steering documents
 - `mcp__spec-workflow__get-template-context` - Get document templates
 
+## Agent Staffing Conventions
+
+Both skills name rosters of specialized agents per phase. Those rosters are menus, not teams to staff in full:
+
+- At most 4 concurrent agents at any moment. That is a ceiling, not a quota.
+- Staff only the dimensions the work raises; do the work directly when it would finish in a handful of tool calls.
+- Loop exit conditions must be observable (test/lint/typecheck run and passed, reviewer findings applied or explicitly rejected), never a numeric quality score the model would have to invent.
+
 ## Development Guidelines
 
 ### Adding New Skills

--- a/packages/plugins/spec-workflow/skills/auto-spec/SKILL.md
+++ b/packages/plugins/spec-workflow/skills/auto-spec/SKILL.md
@@ -1,29 +1,20 @@
 ---
-description: Autonomously create and implement a complete spec workflow with multi-agent collaboration, bypassing manual review steps through intelligent consensus-building
+description: Autonomously create and implement a complete spec workflow with multi-agent collaboration, replacing manual review steps with agent review
 argument-hint: <feature/task description> [--skip-final-review]
-allowed-tools: Read(*), Write(*), MultiEdit(*), Edit(*), Glob(*), Grep(*), LS(*), Bash(*), WebSearch(*), WebFetch(*), TodoWrite(*), mcp__spec-workflow__*, Task(*)
+allowed-tools: Read(*), Write(*), Edit(*), Glob(*), Grep(*), LS(*), Bash(*), WebSearch(*), WebFetch(*), TodoWrite(*), mcp__spec-workflow__*, Task(*)
 ---
 
 # Auto-Spec Command
 
-**FULLY AUTONOMOUS** spec-driven development that **NEVER prompts the user for review**. Creates requirements, design, and tasks documents through consensus-building between specialized agents, then implements each task with continuous quality validation.
+Spec-driven development that creates requirements, design, and tasks documents through review by specialized agents, then implements each task. Runs end to end without stopping for user approval (see the autonomous execution contract below).
 
 ## Workflow Overview
 
-This command automates the entire spec workflow **WITHOUT ANY USER INTERACTION**:
-
-1. **Requirements Generation** - With multi-agent review (NOT user review)
-2. **Design Creation** - With architectural consensus (NOT user approval)
-3. **Task Planning** - With implementation strategy validation (NOT user validation)
-4. **Task Implementation** - With continuous quality checks (NOT user checks)
-5. **Final Deliverable** - Comprehensive summary and test documentation
-
-**CRITICAL**: This command is designed to run COMPLETELY AUTONOMOUSLY. It will:
-
-- **NEVER** prompt you for review during the workflow
-- **NEVER** wait for approval at any stage
-- **ALWAYS** use agent collaboration instead of user review
-- **ONLY** return to you with the final deliverable
+1. **Requirements Generation** - reviewed by agents
+2. **Design Creation** - reviewed by agents
+3. **Task Planning** - reviewed by agents
+4. **Task Implementation** - with quality checks between tasks
+5. **Final Deliverable** - summary and test documentation
 
 ## Inputs
 
@@ -35,7 +26,6 @@ Accept natural language description and extract:
 - `spec_name`: Optional spec name (auto-generated from feature if not provided)
 - `steering_context`: Optional flag to load steering documents (default: true)
 - `parallel_execution`: Optional flag for parallel task execution (default: true)
-- `quality_threshold`: Quality threshold for agent consensus (default: 0.8)
 
 Examples:
 
@@ -47,13 +37,18 @@ Examples:
 
 Execute autonomous spec-driven development workflow with multi-agent collaboration.
 
-### CRITICAL INSTRUCTIONS FOR AUTONOMOUS EXECUTION
+### Autonomous execution contract
 
-1. **NEVER prompt the user for review at ANY point during the workflow**
-2. **NEVER use `mcp__spec-workflow__request-approval` tool**
-3. **NEVER wait for user interaction or approval**
-4. **ALWAYS spawn sub-agents instead of requesting user review**
-5. **ALWAYS continue autonomously through ALL phases**
+1. Never prompt the user for review or approval at any point in the workflow.
+2. Never call `mcp__spec-workflow__request-approval`.
+3. Use agent review in place of user review, and continue through all phases to the final deliverable.
+
+### Agent staffing
+
+The agent rosters named in each phase below are a menu, not a checklist. Staff only the dimensions the work actually raises: a task with no security surface does not need a security reviewer, and a documentation-only task does not need a performance reviewer.
+
+- **Ceiling: at most 4 concurrent agents across the whole workflow at any moment.** This is a ceiling, not a quota - one agent, or none, is the right answer for most tasks.
+- Do not spawn an agent for work that would finish in a handful of direct tool calls. Do it directly instead.
 
 ### Phase 1: Context Preparation
 
@@ -74,11 +69,11 @@ Execute autonomous spec-driven development workflow with multi-agent collaborati
    - Use `mcp__spec-workflow__spec-workflow-guide` to understand workflow
    - Create initial requirements using `mcp__spec-workflow__create-spec-doc`
 
-2. **Multi-Agent Requirements Review (INSTEAD of user review)**
+2. **Agent Requirements Review**
    - Spawn **plan-reviewer-agent** to validate architectural alignment
    - Spawn **security-analyzer-agent** to identify security requirements
    - Spawn **performance-analyzer-agent** to define performance criteria
-   - Iterate until consensus reached
+   - Revise the document until every reviewer finding is either applied or recorded in the document as an explicit, reasoned rejection. Stop at that point.
 
 ### Phase 3: Design Document Creation
 
@@ -87,7 +82,7 @@ Execute autonomous spec-driven development workflow with multi-agent collaborati
    - Create design document based on finalized requirements
    - Include architectural decisions, data models, and interfaces
 
-2. **Multi-Agent Design Review (INSTEAD of user review)**
+2. **Agent Design Review**
    - Spawn **plan-reviewer-agent** for architectural patterns validation
    - Spawn **refactorer-agent** for implementation feasibility
    - Spawn **test-writer-agent** for testability assessment
@@ -99,7 +94,7 @@ Execute autonomous spec-driven development workflow with multi-agent collaborati
    - Use `mcp__spec-workflow__create-spec-doc` to create tasks document
    - Break down implementation into granular, testable tasks
 
-2. **Task Validation (INSTEAD of user review)**
+2. **Task Validation**
    - Spawn **planner-agent** to validate task completeness
    - Spawn **code-explainer-agent** to assess task dependencies
 
@@ -112,15 +107,19 @@ For each task in the implementation plan:
    - Mark task as in-progress using `mcp__spec-workflow__manage-tasks`
    - Spawn appropriate specialized agent(s) for implementation
 
-2. **Quality Validation Loop (INSTEAD of user review)**
+2. **Quality Validation Loop**
 
    - Spawn **refactorer-agent** to review implementation
    - Spawn **test-writer-agent** to verify test coverage
-   - Iterate until quality threshold met
+   - Exit the loop when all of these are observed to be true, not estimated:
+     - The project's test command has been run and passes.
+     - The project's lint and typecheck commands have been run and pass.
+     - Every reviewer finding has been applied, or recorded in the task notes as an explicit, reasoned rejection.
+   - If a criterion still fails after 3 passes, stop the loop, mark the task blocked, and record what failed. Do not keep iterating.
 
 3. **Task Completion**
    - Mark task as completed
-   - Move to next task (parallel execution if enabled)
+   - Move to next task. When `parallel_execution` is enabled, run independent tasks concurrently within the 4-agent ceiling above - the ceiling covers implementation and review agents together.
 
 ### Phase 6: Final Quality Assurance
 
@@ -130,16 +129,22 @@ For each task in the implementation plan:
 
 ### Phase 7: Deliverable Generation
 
-Create comprehensive summary including:
+Create a summary including:
 
 - Key architectural decisions and rationale
 - Trade-offs made during implementation
 - Technical debt incurred (if any)
 - Test documentation and coverage report
 
+## Document Length
+
+The requirements, design, and tasks documents are written to be read by a later agent and by a human reviewer, so length is a real cost. Keep each under roughly 600 words unless the feature genuinely needs more; cover the substance and skip restatement, filler sections, and summaries that repeat the section above.
+
 ## Output
 
 ### Structured Response Format
+
+Keep the final summary under roughly 400 words.
 
 ```markdown
 # Autonomous Spec Implementation: [Feature Name]
@@ -148,8 +153,7 @@ Create comprehensive summary including:
 
 - Spec Name: [spec-name]
 - Total Tasks: [X completed / Y total]
-- Execution Time: [duration]
-- Quality Score: [X/10]
+- Blocked Tasks: [list, with what failed - omit if none]
 
 ## Key Decisions and Rationale
 
@@ -157,8 +161,9 @@ Create comprehensive summary including:
 
 ## Testing Guide
 
-- Unit Tests: [X% coverage]
-- Integration Tests: [Y scenarios]
+- Test suite result: [pass/fail, quoted from the actual test run]
+- Coverage: [only if a coverage tool was run; quote its output. Omit this line otherwise - do not estimate a percentage.]
+- Integration Tests: [scenarios added]
 
 ## Next Steps
 
@@ -170,5 +175,5 @@ Create comprehensive summary including:
 ```
 /auto-spec add user profile picture upload with image resizing
 /auto-spec implement event-driven microservices architecture for order processing
-/auto-spec refactor authentication system --quality-threshold=0.9
+/auto-spec refactor authentication system --skip-final-review
 ```

--- a/packages/plugins/spec-workflow/skills/implement-spec/SKILL.md
+++ b/packages/plugins/spec-workflow/skills/implement-spec/SKILL.md
@@ -60,7 +60,7 @@ Invoke it with comprehensive context including:
 The orchestrator will:
 
 - Discover all available agents
-- Use **agent-capability-analyst** for optimal matching
+- Match tasks to agents by capability
 - Coordinate specialized agents for each task
 - Handle parallel execution groups
 
@@ -75,6 +75,8 @@ Execute tasks sequentially without orchestration:
 
 ### Phase 3: Task Execution
 
+Each list below is a menu of agents that fit that task type, not a team to staff in full. Pick only the ones the task actually needs, and do the work directly rather than spawning an agent when it would finish in a handful of tool calls. **Ceiling: at most 4 concurrent agents at any moment** - a ceiling, not a quota.
+
 For each task, coordinate:
 
 1. **Code Implementation Tasks**: code-generator-agent, test-writer-agent, documentation-agent
@@ -84,19 +86,21 @@ For each task, coordinate:
 
 ### Phase 4: Quality Gates
 
-Between task groups, apply quality checks:
+Between task groups, apply the quality checks the changes actually call for:
 
 - **Code Quality**: style-enforcer-agent, security-analyzer-agent, performance-analyzer-agent
 - **Test Coverage**: agent-tester-agent, test-writer-agent
-- **Documentation**: documentation-agent, review-plan
+- **Documentation**: documentation-agent
+
+Prefer running the project's own test, lint, and typecheck commands over spawning an agent to judge quality - a tool result is evidence, an agent's opinion of code it just read is not.
 
 ## Output Format
 
-Return structured results:
+Return structured results, under roughly 400 words:
 
-- **Summary**: spec name, tasks completed/remaining, execution time
+- **Summary**: spec name, tasks completed/remaining
 - **Execution Plan**: phases, tasks, agents, execution type
-- **Results**: per-task status, agent used, duration, quality metrics
+- **Results**: per-task status, agent used, and the observed result of any test/lint/typecheck run (quote the command output; do not report a score or metric you did not measure)
 - **Next Steps**: remaining tasks, blockers, recommendations
 
 ## Examples


### PR DESCRIPTION
Applies the Opus 5 migration deltas to `packages/plugins/spec-workflow`. Both `.md` skill files were read in full; no other plugin is touched.

## Headline fix: the invented `quality_threshold` loop gate

`auto-spec` declared an input `quality_threshold: 0.8` with **no rubric defined anywhere in the plugin**, and Phase 5 then said `Iterate until quality threshold met`. The model has no data from which to compute a quality score, so it fabricates one — and that fabricated number was the loop's termination condition. A made-up number decided when implementation stopped.

Replaced with exit criteria that are observable from tool output:

- The project's test command has been run and passes.
- The project's lint and typecheck commands have been run and pass.
- Every reviewer finding has been applied, or recorded as an explicit reasoned rejection.
- Hard stop after 3 passes: mark the task blocked and record what failed, rather than looping.

The `quality_threshold` input and the `--quality-threshold=0.9` usage example are gone.

## Changes by delta

**Invented numbers**
- Removed the `quality_threshold` input, the loop gate, and the usage example (above).
- Removed `Quality Score: [X/10]` from the output template — nothing measures it.
- `Unit Tests: [X% coverage]` → coverage is reported only if a coverage tool actually ran, quoting its output; the line is omitted otherwise. Test result must be quoted from the real run.
- `implement-spec` output: replaced undefined `quality metrics` and `duration` with the observed result of the test/lint/typecheck run, plus an explicit "do not report a score you did not measure".
- Phase 2's `Iterate until consensus reached` (unbounded, undefined "consensus") → revise until each finding is applied or explicitly rejected, then stop.

**Delta 2 — delegation ceilings**
- New "Agent staffing" section in `auto-spec`: rosters are a menu, not a checklist; **ceiling of 4 concurrent agents**, stated as a ceiling not a quota; and a "when NOT to delegate" rule (don't spawn an agent for work that finishes in a handful of direct tool calls).
- Same ceiling + menu framing added to `implement-spec` Phase 3, which previously read as a prescribed team per task type over an unbounded task list with `parallel_execution: true`.
- Phase 5 parallel execution now explicitly says the ceiling covers implementation and review agents together.

**Delta 1 — verification ceremony**
- `implement-spec` Phase 4 now prefers running the project's own test/lint/typecheck commands over spawning an agent to judge quality: "a tool result is evidence, an agent's opinion of code it just read is not." Grounding instructions were kept, not removed.

**Delta 3 — literal instruction-following / decorative emphasis**
- `auto-spec` stated its autonomy contract three times (header block, a `**CRITICAL**` bullet list, and a numbered `CRITICAL INSTRUCTIONS` section). Kept one operative statement — the numbered contract, which is the only one naming the specific tool never to call. Removed the duplicate `**CRITICAL**` block and the `(NOT user review)` / `(INSTEAD of user review)` parentheticals that restated it on six more lines.
- Softened the shouty `CRITICAL` / `NEVER` / `ALWAYS` / `ANY` decoration in that block while keeping the constraints themselves intact.

**Delta 4 — output length**
- New "Document Length" section in `auto-spec`: the four generated documents feed a later agent's context, so ~600 words each unless the feature needs more. The skill previously said "comprehensive" with no length guidance at all.
- Final summary capped at ~400 words in both skills.

**Broken references**
- `implement-spec` referenced **`agent-capability-analyst`**, which does not exist as an agent anywhere in the repo (verified against every `agents/*.md` `name:` frontmatter value). Replaced with a plain description of the behavior.
- `implement-spec` Phase 4 listed `review-plan` among agents; it is a *skill* in `development-planning`, and `Task(subagent_type:)` takes agent names. Removed.
- Every other agent name in both skills was verified to exist: `planner-agent`, `plan-reviewer-agent`, `security-analyzer-agent`, `performance-analyzer-agent`, `refactorer-agent`, `test-writer-agent`, `code-explainer-agent`, `agent-orchestrator-agent`, `code-generator-agent`, `documentation-agent`, `style-enforcer-agent`, `agent-tester-agent`, `infrastructure-agent`, `cicd-agent`, `migration-assistant-agent`.

**Stale facts**
- Removed `MultiEdit(*)` from `auto-spec`'s `allowed-tools`; the tool no longer exists and `Edit` covers its cases.
- No model IDs, pricing claims, `budget_tokens`, or OpenAI-only params appear anywhere in this plugin.

## Repo conventions

- Version bumped 2.0.1 → **2.1.0** (minor: `allowed-tools` change and a changed loop-exit condition are behavior changes), in this commit.
- Root `CLAUDE.md` version table row updated in the same commit.
- Plugin `CLAUDE.md` gained a short "Agent Staffing Conventions" section documenting the ceiling and the observable-exit-criteria rule.
- `README.md` needed no change: no component was added, removed, or renamed.

## Test plan

- `bunx nx format:write --uncommitted` — clean, no diff produced.
- `bunx markdownlint-cli2 --fix "packages/plugins/spec-workflow/**/*.md"` — `Summary: 0 error(s)`, exit 0.
- `node scripts/validate-plugin.cjs packages/plugins/spec-workflow` — `Validation PASSED` (`plugin.json: spec-workflow v2.1.0`, 2 skills, 1 MCP server).
- Pre-commit lefthook run green across format / lint / lint-markdown / test / typecheck / update-lockfile.
- Agent-name verification: extracted the `name:` frontmatter from every `packages/plugins/**/agents/*.md` and diffed it against every agent named in both skills. `agent-capability-analyst` was the only miss (also referenced in prose by two files outside this plugin, left untouched as out of scope).
- Residual-reference sweep: `grep -rn -i 'quality_threshold|quality threshold|consensus|MultiEdit' packages/plugins/spec-workflow/` returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)