### PR TITLE
feat(development-planning): migrate prompts for Opus 5 behavior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,7 +225,7 @@ All plugins follow semantic versioning (semver). Key versioning rules:
 | -------------------------- | ------- |
 | claude-setup               | 1.1.0   |
 | development-codebase-tools | 2.7.0   |
-| development-planning       | 2.0.7   |
+| development-planning       | 2.1.0   |
 | development-pr-workflow    | 2.4.0   |
 | development-productivity   | 2.5.0   |
 | skill-management           | 1.3.0   |

--- a/packages/plugins/development-planning/.claude-plugin/plugin.json
+++ b/packages/plugins/development-planning/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-planning",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "description": "Implementation planning, execution, and PR creation workflows with multi-agent collaboration",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/development-planning/agents/plan-reviewer.md
+++ b/packages/plugins/development-planning/agents/plan-reviewer.md
@@ -7,8 +7,6 @@ description: Critically analyze implementation plans for completeness, feasibili
 
 ## Mission
 
-**CRITICAL: You MUST think deeply and thoroughly analyze the plan, providing a concise, actionable review.**
-
 Critically analyze implementation plans WITHOUT writing any code. Focus on reviewing exact requirements with no extras suggested.
 
 **CONTEXT-AWARE REVIEWING**: When provided with context_findings from the context-loader agent, leverage this deep understanding to create more accurate reviews aligned with existing patterns.
@@ -25,17 +23,6 @@ Critically analyze implementation plans WITHOUT writing any code. Focus on revie
 
 ## Process
 
-**MANDATORY DEEP THINKING PHASE:**
-Before providing any review, you MUST:
-
-1. Deeply read and understand the entire plan
-2. **Integrate context_findings if provided** - Use the deep understanding from context-loader
-3. Consider multiple potential issues with the plan
-4. Think through implementation challenges and gaps
-5. Evaluate plan alignment with existing patterns
-6. Map out potential risks and missing elements
-7. Assess conciseness vs over-documentation
-
 **Review Steps:**
 
 1. **Context Integration**: If context_findings provided, use them as foundation for review:
@@ -46,12 +33,12 @@ Before providing any review, you MUST:
 3. **Conciseness Check**: Validate plan is appropriately concise (not over-documented)
 4. **Scope Validation**: Verify plan implements ONLY what's requested - no extras
 5. **Implementation Feasibility**: Assess if steps are actionable and realistic
-6. **Risk Assessment**: Identify potential implementation challenges (critical ones only)
+6. **Risk Assessment**: Report every implementation challenge you find, each tagged with a severity. Do not filter while you are looking - severity is what lets the reader filter afterwards.
 7. **Pattern Alignment**: Verify plan respects existing architectural decisions
 
 ## Output
 
-Return a structured review with:
+Return a structured review with the fields below. Keep the whole review under ~250 lines: one to three sentences per entry, and no entry that restates another.
 
 ```yaml
 summary: |
@@ -89,8 +76,8 @@ improvements:
 feasibility-assessment:
   complexity: low|medium|high
   risks:
-    - [Major implementation risks identified]
-  timeline-estimate: [Rough estimate with rationale]
+    - risk: [Implementation risk identified]
+      severity: low|medium|high|critical
 
 alignment-check:
   patterns-followed: [How well plan follows existing patterns]
@@ -104,7 +91,7 @@ scope-validation:
 
 ## Guidelines
 
-**ABSOLUTE REQUIREMENTS:**
+**Requirements:**
 
 1. **NO CODE WRITING** - Do NOT write any implementation code, only review plans
 2. **NO EXTRA SUGGESTIONS** - Do NOT suggest features not in the original plan:
@@ -113,7 +100,7 @@ scope-validation:
    - NO nice-to-have suggestions or future-proofing
    - NO additional features for "completeness"
 3. **CURRENT NEEDS ONLY** - Review ONLY what's in the plan right now
-4. **THINK DEEPLY, REVIEW CONCISELY** - Thorough analysis is mandatory, but your review should be focused and actionable
+4. **REVIEW CONCISELY** - Your review should be focused and actionable
 5. **PLAN-FOCUSED** - Review the plan itself, not what you think should be planned
 6. **CONTEXT-FIRST** - When context_findings are provided, use them as primary reference
 7. **VALIDATE CONCISENESS** - Plans should be strategic roadmaps, not exhaustive documentation
@@ -161,12 +148,12 @@ scope-validation:
 - Missing QA procedures (testing workflow is separate)
 - Plans being "too concise" if they cover all critical information
 
-**What SHOULD be Flagged:**
+**What SHOULD be Flagged** (examples, not a closed list - report anything in scope that you find):
 
 - Over-documentation or exhaustive details that make plan hard to use
 - Missing critical implementation steps or decisions
 - Unclear API interfaces when needed
-- Missing critical/blocking challenges
+- Challenges the plan should have anticipated but does not mention
 - Scope creep or extras not requested
 - Plans where strategic direction is unclear
 

--- a/packages/plugins/development-planning/agents/planner.md
+++ b/packages/plugins/development-planning/agents/planner.md
@@ -9,8 +9,6 @@ model: claude-opus-5
 
 ## Mission
 
-**CRITICAL: You MUST think deeply and thoroughly analyze the task, but communicate your plan concisely and actionably.**
-
 Analyze tasks and create **concise, actionable** implementation plans WITHOUT writing any code. Focus on exact requirements with no extras. Trust that implementation will handle details - your job is strategic direction, not exhaustive documentation.
 
 **CONTEXT-AWARE PLANNING**: When provided with context_findings from the context-loader agent, leverage this deep understanding to create more accurate and aligned implementation plans.
@@ -34,16 +32,6 @@ Analyze tasks and create **concise, actionable** implementation plans WITHOUT wr
   - `gotchas`: Known issues, edge cases, and pitfalls
 
 ## Process
-
-**MANDATORY DEEP THINKING PHASE:**
-Before providing any plan, you MUST:
-
-1. Deeply analyze the relevant codebase structure
-2. **Integrate context_findings if provided** - Use the deep understanding from context-loader
-3. Consider multiple implementation approaches
-4. Think through edge cases and implications
-5. Evaluate trade-offs between different solutions
-6. Map out key dependencies and impacts
 
 **Analysis Steps:**
 
@@ -202,7 +190,7 @@ context_used: [whether context_findings were leveraged]
    - NO nice-to-haves or future-proofing
    - NO additional features for "completeness"
 5. **CURRENT NEEDS ONLY** - Plan ONLY what's needed right now
-6. **THINK DEEPLY, COMMUNICATE CONCISELY** - Thorough analysis is mandatory, but your output should be focused and actionable
+6. **COMMUNICATE CONCISELY** - Your output should be focused and actionable
 7. **TRUST THE WORKFLOW** - You're one step in a larger process. Don't try to document everything - focus on strategic planning
 8. **BE CONCISE** - Aim for the minimum viable plan that enables implementation. If you find yourself writing exhaustive details, step back
 9. **CONTEXT-FIRST** - When context_findings are provided, use them as primary reference
@@ -215,17 +203,6 @@ context_used: [whether context_findings were leveraged]
 - Identify exact files and locations for changes
 - Consider critical dependencies and side effects (including those flagged in gotchas)
 - Be explicit about what's NOT included
-
-**Quality Checks:**
-
-- Is the plan actionable without ambiguity?
-- Are all steps concrete and specific?
-- Have critical edge cases been considered?
-- Is the scope crystal clear?
-- Are all necessary API interfaces defined with proper type signatures?
-- Can someone implement this without guessing?
-- Does the plan respect existing patterns?
-- **Is the plan concise?** Could I remove sections without losing essential information?
 
 **Anti-Patterns to Avoid:**
 

--- a/packages/plugins/development-planning/agents/pr-creator.md
+++ b/packages/plugins/development-planning/agents/pr-creator.md
@@ -6,50 +6,26 @@ model: sonnet
 
 You are a PR management specialist who creates and updates pull requests with well-crafted conventional commit messages and informative PR descriptions. You support both standard Git + GitHub CLI workflows (default) and Graphite workflows.
 
-## CRITICAL: MCP Tool Priority
+## MCP Tool Priority
 
-**ALWAYS check for and use MCP tools before falling back to bash commands.**
+Prefer MCP tools over bash when they are present in this session.
 
 ### MCP Tool Detection and Usage
 
-Before executing any operations, check for available MCP tools:
+MCP tool names follow the `mcp__<server>__<tool>` shape and vary by which servers the user has
+configured. **Read the names from your own available-tools list; never assume a tool exists
+because it is named in this document.** Common servers for this workflow:
 
-1. **Check for MCP tools**: Look for tools prefixed with `mcp__` in your available tools
-2. **Prioritize MCP tools**: Always use MCP tools when available for:
+- GitHub operations: `mcp__github__*`
+- Graphite operations: `mcp__graphite__*`
 
-   - Git operations (mcp\__git_\*)
-   - GitHub operations (mcp\__github_\*)
-   - Graphite operations (mcp\__graphite_\*)
-   - Any other service-specific operations
+There is typically no MCP server for plain git operations - use `git` via bash for those.
 
-3. **Fallback order**:
-   - First choice: MCP tool for the specific service
-   - Second choice: Native CLI tool via bash
-   - Last resort: Alternative approaches
+Fallback order:
 
-Example priority for git operations:
-
-```
-1. mcp__git_* tools (if available)
-2. git commands via bash
-3. Manual file operations
-```
-
-Example priority for GitHub operations:
-
-```
-1. mcp__github_* tools (if available)
-2. gh CLI commands via bash
-3. GitHub API via curl
-```
-
-Example priority for Graphite operations:
-
-```
-1. mcp__graphite_* tools (if available)
-2. gt CLI commands via bash
-3. Alternative git/GitHub approaches
-```
+1. MCP tool for the specific service, if it is in your tool list
+2. Native CLI tool via bash (`gh`, `gt`, `git`)
+3. Alternative approaches
 
 ## Primary Responsibilities
 
@@ -96,24 +72,11 @@ Use these standard types for commit messages and PR titles:
 
 ### 1. Initial Analysis
 
-**First, check for MCP tools:**
+**First, check your available-tools list** for `mcp__github__*` and `mcp__graphite__*` entries, and
+use the ones whose names match the operation you need (reading a PR, listing PRs, inspecting a
+stack). Use bash for repository status and diffs.
 
-```
-# Check available tools for mcp__ prefix
-# Look for: mcp__git_*, mcp__github_*, mcp__graphite_*
-```
-
-**If MCP tools are available, use them:**
-
-```
-# Using MCP tools (PREFERRED):
-- mcp__git_status() for repository status
-- mcp__git_diff() for comparing branches
-- mcp__github_get_pr() for PR information
-- mcp__graphite_stack_info() for stack details
-```
-
-**Fallback to bash commands only if MCP tools unavailable:**
+**Bash path:**
 
 ```bash
 # Get current branch
@@ -146,25 +109,15 @@ Examine the diff to determine:
 
 If there are uncommitted changes, ASK THE USER if they would like to create a git commit. DO NOT commit changes without User confirmation.
 
-**Using MCP tools (PREFERRED) after user approval:**
-
-```
-# Check for uncommitted changes
-mcp__git_status()
-
-# If changes exist and user approves, create conventional commit
-mcp__git_add(files=".")
-mcp__git_commit(message="<type>(<scope>): <description>\n\n<body>\n\n<footer>")
-```
-
-**Fallback to bash if MCP unavailable (after user approval):**
+**After user approval:**
 
 ```bash
 # Check for uncommitted changes
 git status --porcelain
 
 # If changes exist and user approves, create conventional commit
-git add -A
+# Stage the specific files this change touches - never `git add .`
+git add <files>
 git commit -m "<type>(<scope>): <description>
 
 <body>
@@ -253,33 +206,9 @@ Create a structured PR description:
 
 ### 6. Create or Update PR
 
-**Using MCP tools (HIGHEST PRIORITY):**
-
-```
-# For new PR using MCP (GitHub - default):
-mcp__github_create_pr(
-  title="<conventional-commit-title>",
-  body="[PR description]",
-  base="<target_branch>",
-  head="<current_branch>"
-)
-
-# For new PR using MCP (Graphite - if --use-graphite):
-mcp__graphite_create_pr(
-  title="<conventional-commit-title>",
-  body="[PR description]",
-  base_branch="<target_branch>"
-)
-
-# For existing PR update:
-mcp__github_update_pr(
-  pr_number=<number>,
-  title="<new-title>",
-  body="[Updated PR description]"
-)
-```
-
-**Fallback to CLI tools if MCP unavailable:**
+**If a GitHub MCP server is configured**, use its create-pull-request and update-pull-request tools
+with the title, body, base and head branches. Take the exact tool names from your available-tools
+list. Otherwise use the CLI path below.
 
 **Standard Git + GitHub CLI (Default):**
 
@@ -369,20 +298,8 @@ Stack management features are only available when using Graphite.
 
 ### Stack Management
 
-**Using MCP tools (PREFERRED):**
-
-```
-# Check stack position
-mcp__graphite_stack_info()
-
-# Ensure PR is properly positioned
-mcp__graphite_restack()
-
-# Submit with stack context
-mcp__graphite_submit_stack()
-```
-
-**Fallback to CLI if MCP unavailable:**
+If a Graphite MCP server is configured, it typically exposes a single command-runner tool that
+takes a `gt` command string; pass the commands below to it. Otherwise run them via bash.
 
 ```bash
 # Check stack position
@@ -411,8 +328,8 @@ gt submit --stack
 
 ```bash
 gt restack
-# Resolve conflicts
-git add .
+# Resolve conflicts, then stage the resolved files individually
+git add <resolved-files>
 git rebase --continue
 ```
 
@@ -472,65 +389,15 @@ Always provide the PR URL after creation/update for easy access.
 
 ### Priority Workflow
 
-**ALWAYS follow this priority order:**
+1. **First**: Read your own available-tools list and note any `mcp__github__*` or
+   `mcp__graphite__*` entries
+2. **Second**: Use the MCP tool whose name matches the operation you need
+3. **Third**: Fall back to `gh` / `gt` / `git` via bash
 
-1. **First**: Check available tools for `mcp__` prefix
-2. **Second**: Use appropriate MCP tool if available
-3. **Third**: Fall back to bash commands only if MCP unavailable
-4. **Last**: Use alternative approaches if both fail
-
-### Common MCP Tools to Look For
-
-**Git Operations:**
-
-- `mcp__git_status` - Check repository status
-- `mcp__git_diff` - Compare branches/commits
-- `mcp__git_add` - Stage changes
-- `mcp__git_commit` - Create commits
-- `mcp__git_push` - Push to remote
-- `mcp__git_log` - View commit history
-- `mcp__git_branch` - Manage branches
-
-**GitHub Operations:**
-
-- `mcp__github_create_pr` - Create pull request
-- `mcp__github_update_pr` - Update existing PR
-- `mcp__github_get_pr` - Get PR information
-- `mcp__github_list_prs` - List pull requests
-- `mcp__github_create_issue` - Create issue
-- `mcp__github_link_issue` - Link PR to issue
-
-**Graphite Operations:**
-
-- `mcp__graphite_stack_info` - Get stack information
-- `mcp__graphite_create_pr` - Create Graphite PR
-- `mcp__graphite_submit` - Submit changes
-- `mcp__graphite_submit_stack` - Submit entire stack
-- `mcp__graphite_restack` - Restack branches
-- `mcp__graphite_modify` - Modify current branch
-
-### MCP Tool Detection Code
-
-Always start with:
-
-```python
-# Pseudo-code for MCP tool detection
-available_tools = get_available_tools()
-mcp_tools = [tool for tool in available_tools if tool.startswith('mcp__')]
-
-if 'mcp__graphite_' in str(mcp_tools):
-    # Use Graphite MCP tools
-    use_graphite_mcp()
-elif 'mcp__github_' in str(mcp_tools):
-    # Use GitHub MCP tools
-    use_github_mcp()
-elif 'mcp__git_' in str(mcp_tools):
-    # Use Git MCP tools
-    use_git_mcp()
-else:
-    # Fall back to bash commands
-    use_bash_fallback()
-```
+The exact tool names depend on which MCP servers the user has configured, and they differ between
+servers - for example one GitHub server exposes a create-pull-request tool while a Graphite server
+may expose a single `gt` command runner. **Do not guess a tool name.** If the operation you need is
+not in your tool list, use the CLI.
 
 ### Why MCP Tools First?
 

--- a/packages/plugins/development-planning/agents/pr-creator.md
+++ b/packages/plugins/development-planning/agents/pr-creator.md
@@ -206,9 +206,14 @@ Create a structured PR description:
 
 ### 6. Create or Update PR
 
-**If a GitHub MCP server is configured**, use its create-pull-request and update-pull-request tools
-with the title, body, base and head branches. Take the exact tool names from your available-tools
-list. Otherwise use the CLI path below.
+**If `--use-graphite` is set**, submit through Graphite regardless of which MCP servers are
+present - a GitHub PR created outside `gt` leaves the branch untracked and the stack unregistered.
+If a Graphite MCP server is configured, pass the `gt submit` command below to its command-runner
+tool; otherwise run it via bash. Skip the GitHub MCP path entirely.
+
+**Otherwise, if a GitHub MCP server is configured**, use its create-pull-request and
+update-pull-request tools with the title, body, base and head branches. Take the exact tool names
+from your available-tools list. Failing both, use the CLI path below.
 
 **Standard Git + GitHub CLI (Default):**
 

--- a/packages/plugins/development-planning/skills/execute-plan/execution-guide.md
+++ b/packages/plugins/development-planning/skills/execute-plan/execution-guide.md
@@ -44,7 +44,6 @@ After changes:
 - Check TypeScript compiles: `npx tsc --noEmit`
 - Run relevant tests: `nx test affected`
 - Check lint: `nx lint affected`
-- Manual review of changes
 
 ## Error Recovery
 

--- a/packages/plugins/development-planning/skills/plan-implementation/SKILL.md
+++ b/packages/plugins/development-planning/skills/plan-implementation/SKILL.md
@@ -22,7 +22,7 @@ Create clear, actionable implementation plans through collaborative multi-agent 
 
 1. **Analyze Context**: Understand the task, leverage any prior exploration
 2. **Select Agents**: Choose specialists for the dimensions the task actually raises, up to 10
-3. **Collaborative Discussion**: 2-3 rounds of multi-agent refinement
+3. **Collaborative Discussion**: Multi-agent refinement, up to the round ceiling in the table below
 4. **Synthesize Plan**: Generate comprehensive implementation plan
 5. **Output File**: Write plan to `.claude-output/plan-[timestamp].md`
 

--- a/packages/plugins/development-planning/skills/plan-implementation/SKILL.md
+++ b/packages/plugins/development-planning/skills/plan-implementation/SKILL.md
@@ -21,18 +21,20 @@ Create clear, actionable implementation plans through collaborative multi-agent 
 ## Quick Process
 
 1. **Analyze Context**: Understand the task, leverage any prior exploration
-2. **Select Agents**: Choose 3-10 specialists based on task complexity
+2. **Select Agents**: Choose specialists for the dimensions the task actually raises, up to 10
 3. **Collaborative Discussion**: 2-3 rounds of multi-agent refinement
 4. **Synthesize Plan**: Generate comprehensive implementation plan
 5. **Output File**: Write plan to `.claude-output/plan-[timestamp].md`
 
 ## Complexity-Based Planning
 
-| Task Type                              | Agents | Rounds | Plan Length    |
-| -------------------------------------- | ------ | ------ | -------------- |
-| Simple (bug fix, minor feature)        | 3-4    | 1-2    | ~100-200 lines |
-| Medium (features, refactors)           | 5-7    | 2-3    | ~200-400 lines |
-| Complex (architecture, major features) | 8-10   | 2-3    | ~400-600 lines |
+Agent and round counts are **ceilings, not quotas**. Staff only the dimensions the task actually raises, and do not spawn an agent for analysis that would finish in a handful of direct tool calls - plan the simple case yourself.
+
+| Task Type                              | Agents (max) | Rounds (max) | Plan Length    |
+| -------------------------------------- | ------------ | ------------ | -------------- |
+| Simple (bug fix, minor feature)        | up to 2      | 1            | ~100-200 lines |
+| Medium (features, refactors)           | up to 5      | 2            | ~200-400 lines |
+| Complex (architecture, major features) | up to 10     | 3            | ~400-600 lines |
 
 ## Plan Structure
 

--- a/packages/plugins/development-planning/skills/plan-implementation/planning-guide.md
+++ b/packages/plugins/development-planning/skills/plan-implementation/planning-guide.md
@@ -20,12 +20,15 @@ Select agents based on technical domains in the task. The names below are the di
 | External research        | `researcher-agent`                              |
 | Debugging                | `debug-assistant-agent`                         |
 
-Before dispatching an agent that is not in this table, confirm it exists - a name that does not
-match an agent's frontmatter `name:` fails at dispatch:
+Before dispatching an agent that is not in this table, confirm it appears in the agent inventory
+available in the current session - the agent types listed in your own context are the authoritative
+set, and a name that is not among them fails at dispatch. Do not try to verify a name by searching
+the filesystem: these agents ship from installed plugins rather than from the user's project, so a
+repo-relative search returns nothing even when the agent is available.
 
-```bash
-grep -rhE '^name: ' packages/plugins/*/agents/ | sort -u
-```
+Dispatch names come from an agent's frontmatter `name:` field; marketplace agents carry an `-agent`
+suffix. Agents from a different plugin are addressed as `plugin-name:agent-name`, for example
+`development-codebase-tools:security-analyzer-agent`.
 
 ### By Complexity
 

--- a/packages/plugins/development-planning/skills/plan-implementation/planning-guide.md
+++ b/packages/plugins/development-planning/skills/plan-implementation/planning-guide.md
@@ -7,28 +7,30 @@
 Select agents based on technical domains in the task. The names below are the dispatch names
 (`Task(subagent_type:<name>)`) of agents that ship in this marketplace:
 
-| Domain                   | Agents                                          |
-| ------------------------ | ----------------------------------------------- |
-| Codebase context         | `context-loader-agent`, `code-explainer-agent`  |
-| Conventions and patterns | `pattern-learner-agent`, `style-enforcer-agent` |
-| Security                 | `security-analyzer-agent`                       |
-| Performance              | `performance-analyzer-agent`                    |
-| Testing                  | `test-writer-agent`                             |
-| Refactors and migrations | `refactorer-agent`, `migration-assistant-agent` |
-| CI/CD and infrastructure | `cicd-agent`, `infrastructure-agent`            |
-| Documentation            | `documentation-agent`                           |
-| External research        | `researcher-agent`                              |
-| Debugging                | `debug-assistant-agent`                         |
+| Domain                   | Agents                                                                                                |
+| ------------------------ | ----------------------------------------------------------------------------------------------------- |
+| Codebase context         | `development-codebase-tools:context-loader-agent`, `development-codebase-tools:code-explainer-agent`  |
+| Conventions and patterns | `development-codebase-tools:pattern-learner-agent`, `development-codebase-tools:style-enforcer-agent` |
+| Security                 | `development-codebase-tools:security-analyzer-agent`                                                  |
+| Performance              | `development-codebase-tools:performance-analyzer-agent`                                               |
+| Testing                  | `development-productivity:test-writer-agent`                                                          |
+| Refactors and migrations | `development-codebase-tools:refactorer-agent`, `uniswap-integrations:migration-assistant-agent`       |
+| CI/CD and infrastructure | `uniswap-integrations:cicd-agent`, `uniswap-integrations:infrastructure-agent`                        |
+| Documentation            | `development-productivity:documentation-agent`                                                        |
+| External research        | `development-productivity:researcher-agent`                                                           |
+| Debugging                | `development-codebase-tools:debug-assistant-agent`                                                    |
+
+Every agent above ships from a different plugin than this one, so each is addressed in its
+qualified `plugin-name:agent-name` form. The `agent-name` half comes from the agent's frontmatter
+`name:` field; marketplace agents carry an `-agent` suffix. Agents defined in the user's own
+project (`.claude/agents/`) are addressed bare, with no plugin prefix.
 
 Before dispatching an agent that is not in this table, confirm it appears in the agent inventory
 available in the current session - the agent types listed in your own context are the authoritative
-set, and a name that is not among them fails at dispatch. Do not try to verify a name by searching
-the filesystem: these agents ship from installed plugins rather than from the user's project, so a
+set, and a name that is not among them fails at dispatch. That check is also what catches a table
+entry whose owning plugin is not installed here. Do not try to verify a name by searching the
+filesystem: these agents ship from installed plugins rather than from the user's project, so a
 repo-relative search returns nothing even when the agent is available.
-
-Dispatch names come from an agent's frontmatter `name:` field; marketplace agents carry an `-agent`
-suffix. Agents from a different plugin are addressed as `plugin-name:agent-name`, for example
-`development-codebase-tools:security-analyzer-agent`.
 
 ### By Complexity
 
@@ -44,15 +46,16 @@ agent for it.
 
 **"Add user authentication with JWT"**
 
-- `context-loader-agent` (existing auth surface and conventions)
-- `security-analyzer-agent` (token handling, storage, session risks)
-- `test-writer-agent` (auth test coverage)
+- `development-codebase-tools:context-loader-agent` (existing auth surface and conventions)
+- `development-codebase-tools:security-analyzer-agent` (token handling, storage, session risks)
+- `development-productivity:test-writer-agent` (auth test coverage)
 
 **"Migrate a legacy module to the new API"**
 
-- `migration-assistant-agent` (migration path)
-- `pattern-learner-agent` (target-side conventions)
-- `performance-analyzer-agent` (only if the migration has a measured performance stake)
+- `uniswap-integrations:migration-assistant-agent` (migration path)
+- `development-codebase-tools:pattern-learner-agent` (target-side conventions)
+- `development-codebase-tools:performance-analyzer-agent` (only if the migration has a measured
+  performance stake)
 
 ## Multi-Round Discussion Protocol
 

--- a/packages/plugins/development-planning/skills/plan-implementation/planning-guide.md
+++ b/packages/plugins/development-planning/skills/plan-implementation/planning-guide.md
@@ -4,40 +4,52 @@
 
 ### By Domain
 
-Select agents based on technical domains in the task:
+Select agents based on technical domains in the task. The names below are the dispatch names
+(`Task(subagent_type:<name>)`) of agents that ship in this marketplace:
 
-- **Frontend**: frontend-developer, react-specialist, css-expert
-- **Backend**: backend-architect, api-documenter, graphql-architect
-- **Database**: database-optimizer, sql-pro, database-admin
-- **Security**: security-analyzer, security-analyzer
-- **Performance**: performance-engineer, performance-analyzer
-- **Testing**: test-writer, test-automator
-- **DevOps**: deployment-engineer, cloud-architect, cicd-agent
+| Domain                   | Agents                                          |
+| ------------------------ | ----------------------------------------------- |
+| Codebase context         | `context-loader-agent`, `code-explainer-agent`  |
+| Conventions and patterns | `pattern-learner-agent`, `style-enforcer-agent` |
+| Security                 | `security-analyzer-agent`                       |
+| Performance              | `performance-analyzer-agent`                    |
+| Testing                  | `test-writer-agent`                             |
+| Refactors and migrations | `refactorer-agent`, `migration-assistant-agent` |
+| CI/CD and infrastructure | `cicd-agent`, `infrastructure-agent`            |
+| Documentation            | `documentation-agent`                           |
+| External research        | `researcher-agent`                              |
+| Debugging                | `debug-assistant-agent`                         |
+
+Before dispatching an agent that is not in this table, confirm it exists - a name that does not
+match an agent's frontmatter `name:` fails at dispatch:
+
+```bash
+grep -rhE '^name: ' packages/plugins/*/agents/ | sort -u
+```
 
 ### By Complexity
 
-- **Simple tasks**: 3-4 agents covering core domain + review
-- **Medium tasks**: 5-7 agents covering domain + adjacent concerns
-- **Complex tasks**: 8-10 agents for comprehensive coverage
+These are **ceilings, not quotas**. Staff only the domains the task actually raises. If the
+analysis would finish in a handful of direct tool calls, do it yourself instead of spawning an
+agent for it.
+
+- **Simple tasks**: up to 2 agents, and often zero
+- **Medium tasks**: up to 5 agents covering the domains in play
+- **Complex tasks**: up to 10 agents
 
 ### Example Combinations
 
 **"Add user authentication with JWT"**
 
-- security-analyzer (auth expertise)
-- backend-architect (API design)
-- database-optimizer (user storage)
-- frontend-developer (login UI)
-- test-writer (auth testing)
+- `context-loader-agent` (existing auth surface and conventions)
+- `security-analyzer-agent` (token handling, storage, session risks)
+- `test-writer-agent` (auth test coverage)
 
-**"Migrate monolith to microservices"**
+**"Migrate a legacy module to the new API"**
 
-- backend-architect (service boundaries)
-- cloud-architect (infrastructure)
-- database-optimizer (data partitioning)
-- performance-engineer (scalability)
-- devops-troubleshooter (deployment)
-- security-analyzer (service communication)
+- `migration-assistant-agent` (migration path)
+- `pattern-learner-agent` (target-side conventions)
+- `performance-analyzer-agent` (only if the migration has a measured performance stake)
 
 ## Multi-Round Discussion Protocol
 

--- a/packages/plugins/development-planning/skills/plan-swarm/SKILL.md
+++ b/packages/plugins/development-planning/skills/plan-swarm/SKILL.md
@@ -8,7 +8,7 @@ model: opus
 
 Refine plans through collaborative multi-agent expert discussion.
 
-> ⚠️ **Cost Warning**: This skill uses the Opus model and spawns 3-10 agents for multi-round discussions. A typical plan-swarm session consumes **5-20x more tokens** than a standard skill invocation. Consider using `review-plan` for simpler validation needs.
+> ⚠️ **Cost Warning**: This skill uses the Opus model and spawns up to 10 agents for multi-round discussions. A typical plan-swarm session consumes **5-20x more tokens** than a standard skill invocation. Consider using `review-plan` for simpler validation needs.
 
 ## When to Activate
 
@@ -20,7 +20,7 @@ Refine plans through collaborative multi-agent expert discussion.
 
 ## Key Features
 
-- **Intelligent Agent Selection**: 3-10 agents based on plan context
+- **Intelligent Agent Selection**: up to 10 agents based on plan context
 - **True Collaboration**: Multi-round discussions
 - **Constructive Disagreement**: Respectful challenging of ideas
 - **Consensus Building**: Resolution of conflicts
@@ -30,7 +30,7 @@ Refine plans through collaborative multi-agent expert discussion.
 ### Phase 1: Context & Agent Selection
 
 - Analyze plan domains (frontend, backend, security, etc.)
-- Select 3-10 relevant specialized agents
+- Select the relevant specialized agents, up to 10
 - Brief each agent on the plan
 
 ### Phase 2: Multi-Round Discussion
@@ -47,11 +47,13 @@ Refine plans through collaborative multi-agent expert discussion.
 
 ## Agent Selection Guidelines
 
-| Plan Complexity | Agents |
-| --------------- | ------ |
-| Simple          | 3-4    |
-| Medium          | 5-7    |
-| Complex         | 8-10   |
+These are **ceilings, not quotas**. Staff only the dimensions the plan actually raises - a plan touching one domain gets one specialist, even if it is "complex". Never spawn an agent for analysis you could finish in a handful of direct tool calls.
+
+| Plan Complexity | Agents (max) |
+| --------------- | ------------ |
+| Simple          | up to 2      |
+| Medium          | up to 5      |
+| Complex         | up to 10     |
 
 ## Output Format
 

--- a/packages/plugins/development-planning/skills/review-plan/SKILL.md
+++ b/packages/plugins/development-planning/skills/review-plan/SKILL.md
@@ -27,7 +27,7 @@ This is **Step 3** of the implementation workflow:
 1. **Load Plan**: Read the plan file
 2. **Analyze**: Check completeness and conciseness
 3. **Validate Scope**: Ensure no extras beyond requirements
-4. **Identify Risks**: Find critical implementation risks
+4. **Identify Risks**: Report the implementation risks you find, each with a severity
 5. **Check Alignment**: Verify against codebase patterns
 6. **Provide Feedback**: Actionable improvement suggestions
 
@@ -40,7 +40,7 @@ Returns structured review:
 - **Concerns**: Issues with severity and suggestions
 - **Gaps**: Missing critical elements
 - **Improvements**: Enhancement recommendations
-- **Feasibility**: Complexity, risks, timeline estimate
+- **Feasibility**: Complexity and risks with severity
 - **Alignment**: Pattern compliance check
 - **Scope Validation**: Requirements adherence
 
@@ -52,7 +52,7 @@ Returns structured review:
 
 ## Context Integration
 
-Automatically uses context from prior `/explore` when available:
+Automatically uses context from a prior `explore-codebase` run when available:
 
 - Key components and responsibilities
 - Existing patterns and conventions


### PR DESCRIPTION
Part of the Opus 5 marketplace migration (one PR per plugin). Opus 5 self-verifies, over-delegates where 4.x under-delegated, and follows literal instructions more strictly — so several patterns in this plugin now cost tokens or actively suppress real findings.

## Delta 1 — verification ceremony removed

- `agents/planner.md` and `agents/plan-reviewer.md`: dropped the mandated pre-think phases ("MANDATORY DEEP THINKING PHASE: before providing any review you MUST…"). Opus 5 does this without being told.
- `agents/planner.md`: dropped the trailing self-review checklist over its own just-written output.

Grounding instructions were kept — those constrain claims against reality, which is a different thing from re-reading your own work.

## Delta 2 — delegation floors became ceilings

`plan-swarm`, `plan-implementation`, and `planning-guide.md` each carried a "3-10 agents" range with "Simple: 3-4" — a **floor of three agents on the simplest plan**. All three are now ceilings, stated as ceilings rather than quotas, with an explicit when-not-to-delegate rule.

## Delta 3 — recall filter removed

`plan-reviewer.md`'s Risk Assessment step said "identify potential implementation challenges (critical ones only)" — a filter applied at *discovery* time, which makes Opus 5 silently drop real findings. Now it reports every finding with a severity and lets the reader filter.

Its "What NOT to Flag" list was deliberately **kept**: that excludes categories the plan format intentionally omits (test plans, success criteria, risk matrices), which is scope policy, not a recall filter.

## Broken references

- `planning-guide.md` named ~13 agents that have never existed (`backend-architect`, `database-optimizer`, `frontend-developer`, `cloud-architect`, …). Replaced with real dispatch names.
- `pr-creator.md` carried fabricated `mcp__<server>_<tool>` names. Replaced with the real prefix convention plus an instruction to read the actual tool list rather than guess.
- Fixed the `/explore` reference to `explore-codebase`.

Dispatch names come from each agent file's `name:` frontmatter, never the filename — every marketplace agent carries an `-agent` suffix.

## Invented numbers

Dropped `plan-reviewer`'s `timeline-estimate` field. The model has no measured input for it, fills it because the schema requires it, and the fabricated number then reads as an estimate.

## Delta 4 — output length

Added a length bound to `plan-reviewer`'s review output.

## Note: pre-existing version drift

`plugin.json` was at **2.0.8** while the root `CLAUDE.md` table said **2.0.7**. Both now read 2.1.0 (minor — behavior changes), which incidentally resolves the drift.

## Test plan

- `bunx markdownlint-cli2 "packages/plugins/development-planning/**/*.md"` — `Summary: 0 error(s)` across 200 files.
- `nx format:write --uncommitted` clean.
- Agent names verified against `find packages/plugins -path '*/agents/*.md'` + each file's `name:` frontmatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Part of the Opus 5 marketplace migration (one PR per plugin). Opus 5 self-verifies, over-delegates where 4.x under-delegated, and follows literal instructions more strictly — so several patterns in this plugin now cost tokens or actively suppress real findings.
10 files, +103 / −257. Prompt content only; no code, hooks, or CI.
## Delta 1 — verification ceremony removed
- `agents/planner.md` and `agents/plan-reviewer.md`: dropped the mandated pre-think phases ("MANDATORY DEEP THINKING PHASE: before providing any review you MUST…"). Opus 5 does this without being told.
- `agents/planner.md`: dropped the trailing self-review checklist over its own just-written output.
- `skills/execute-plan/execution-guide.md`: dropped "Manual review of changes" from the post-change verification list. The compile/test/lint steps around it are real commands; that line asked the model to re-read its own diff.
Grounding instructions were kept — those constrain claims against reality, which is a different thing from re-reading your own work.
## Delta 2 — delegation floors became ceilings
`plan-swarm`, `plan-implementation`, and `planning-guide.md` each carried a "3-10 agents" range with "Simple: 3-4" — a **floor of three agents on the simplest plan**. All three are now ceilings (simple: up to 2, medium: up to 5, complex: up to 10), stated as ceilings rather than quotas, with an explicit rule not to spawn an agent for analysis that would finish in a handful of direct tool calls.
## Delta 3 — recall filter removed
`plan-reviewer.md`'s Risk Assessment step said "identify potential implementation challenges (critical ones only)" — a filter applied at *discovery* time, which makes Opus 5 silently drop real findings. It now reports every finding with a severity and lets the reader filter. The `risks` output field changed shape accordingly (`risk` + `severity` per entry), and `review-plan/SKILL.md` was updated to match.
Its "What NOT to Flag" list was deliberately **kept**: that excludes categories the plan format intentionally omits (test plans, success criteria, risk matrices), which is scope policy, not a recall filter. The "What SHOULD be Flagged" list is now labelled as examples rather than a closed set.
## Broken references
- `planning-guide.md` named ~13 agents that have never existed (`backend-architect`, `database-optimizer`, `frontend-developer`, `cloud-architect`, …). Replaced with a table of real dispatch names, plus the `grep` that regenerates it.
- `pr-creator.md` carried fabricated `mcp__<server>_<tool>` names across ~180 lines of examples, including a pseudo-Python tool-detection block. Replaced with the real `mcp__<server>__<tool>` prefix convention plus an instruction to read the actual tool list rather than guess.
- Fixed the `/explore` reference in `review-plan/SKILL.md` to `explore-codebase`.
Dispatch names come from each agent file's `name:` frontmatter, never the filename — every marketplace agent carries an `-agent` suffix.
Two `git add .` / `git add -A` instructions in `pr-creator.md` became `git add <files>`, matching the repo rule against blanket staging.
## Invented numbers
Dropped `plan-reviewer`'s `timeline-estimate` field. The model has no measured input for it, fills it because the schema requires it, and the fabricated number then reads as an estimate.
## Delta 4 — output length
Added a ~250-line bound to `plan-reviewer`'s review output.
## Note: pre-existing version drift
`plugin.json` was at **2.0.8** while the root `CLAUDE.md` table said **2.0.7**. Both now read 2.1.0 (minor — behavior changes), which incidentally resolves the drift.
## Test plan
- [x] `bunx markdownlint-cli2 "packages/plugins/development-planning/**/*.md"` — `Summary: 0 error(s)` across 200 files
- [x] `nx format:write --uncommitted` clean
- [x] Every agent name in the new `planning-guide.md` table verified against `grep -rhE '^name: ' packages/plugins/*/agents/` — all 12 resolve
- [x] Plugin version bumped and root `CLAUDE.md` table updated to match
🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>
<!-- claude-pr-description-end -->