### PR TITLE
fix(skill-management): remove broken agent refs and widen audit recall

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,7 +228,7 @@ All plugins follow semantic versioning (semver). Key versioning rules:
 | development-planning       | 2.0.7   |
 | development-pr-workflow    | 2.4.0   |
 | development-productivity   | 2.4.1   |
-| skill-management           | 1.2.0   |
+| skill-management           | 1.3.0   |
 | spec-workflow              | 2.1.0   |
 | uniswap-integrations       | 2.6.1   |
 

--- a/packages/plugins/skill-management/.claude-plugin/plugin.json
+++ b/packages/plugins/skill-management/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-management",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Audit, map, mine, and improve your Claude Code skills, agents, and slash commands. Inventories your whole customization surface, flags overlaps/gaps/weak triggering descriptions, and mines sessions for workflows worth codifying into new skills or agents. Also migrates full Claude Code configs (CLAUDE.md, rules, settings, hooks, CI scripts) for new model generations like Opus 5.",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/skill-management/README.md
+++ b/packages/plugins/skill-management/README.md
@@ -46,8 +46,8 @@ The hook is a dependency-free Node script invoked via `node ${CLAUDE_PLUGIN_ROOT
 
 `/skill-map`, `/skill-mine`, and `/skill-new` are thin prompts that invoke the **skill-doctor** skill
 in a specific run mode. The skill does the _finding_ — what to add, merge, fix, or codify — then hands
-the deep work to the tools that own it (`skill-creator` for drafting/evals, `agent-optimizer` /
-`prompt-engineer` for agent tuning). It never auto-applies a change: it proposes a prioritized menu and
+the deep work to the tools that own it (`skill-creator` for drafting/evals,
+`development-productivity:prompt-engineer-agent` for agent tuning). It never auto-applies a change: it proposes a prioritized menu and
 lets you pick. Personal config under `~/.claude/{skills,agents,commands}` is edited in place; skill /
 agent / command files that live inside a git repo are delivered as a **draft PR** off the repo's
 default branch.

--- a/packages/plugins/skill-management/skills/migrate-config-to-opus-5/SKILL.md
+++ b/packages/plugins/skill-management/skills/migrate-config-to-opus-5/SKILL.md
@@ -71,3 +71,5 @@ Present the "user decision" findings via AskUserQuestion (batch related ones; re
 ## Output
 
 End with: scope migrated, a per-commit list of what changed and why, findings deliberately left alone (with the policy reason), anything out of reach (other machines, external repos), and the checkpoint date.
+
+Keep it to what the user has to act on — one line per commit, one line per left-alone finding. No restated summary of the audit, no filler sections.

--- a/packages/plugins/skill-management/skills/skill-doctor/SKILL.md
+++ b/packages/plugins/skill-management/skills/skill-doctor/SKILL.md
@@ -8,9 +8,9 @@ description: >
   skills do I have", "suggest skill improvements", "are any of my skills
   redundant", "clean up my skills", "turn this into a skill", "should this be a
   skill or an agent", "codify this workflow", or invokes /skill-map, /skill-mine,
-  or /skill-new. Also use PROACTIVELY after finishing a multi-step workflow that
-  the user is likely to repeat (especially right after opening a PR) to ask
-  whether it should become a skill or agent. It inventories every
+  or /skill-new. Also applies after finishing a multi-step workflow the user is
+  likely to repeat (especially right after opening a PR), to ask whether it
+  should become a skill or agent. It inventories every
   skill/agent/command across the user's own dirs AND all installed marketplaces,
   flags overlaps / gaps / weak triggering descriptions, and — when there's real
   prior work in the session — proposes new or edited skills/agents grounded in

--- a/packages/plugins/skill-management/skills/skill-doctor/SKILL.md
+++ b/packages/plugins/skill-management/skills/skill-doctor/SKILL.md
@@ -26,11 +26,11 @@ the deep work to the tools that already own it. **Reuse, don't reinvent:**
 - **Creating or iterating a skill (drafting, evals, description optimization, packaging)** → invoke the `skill-creator` skill if it's
   installed (it ships in Anthropic's agent-skills marketplace and bundles
   `improve_description.py`, `run_loop.py`, `package_skill.py`, `quick_validate.py`).
-- **Tuning an agent's prompt** → delegate to the `agent-optimizer` or `prompt-engineer` agents.
-- **Scoring an agent's capabilities / team fit** → the `agent-capability-analyst` agent.
-- **Cataloging agents** → the `claude-agent-discovery` agent.
+- **Tuning an agent's prompt** → delegate to the
+  `development-productivity:prompt-engineer-agent` agent. Verify the name resolves
+  before dispatching; if that plugin isn't installed, do the tuning inline.
 - **"This is really a standing rule, not a skill"** → write it into the relevant
-  `CLAUDE.md` (e.g. via an `update-claude-md` skill) or the project's memory store.
+  `CLAUDE.md` (e.g. via the `/update-claude-md` command) or the project's memory store.
 - **Auditing / cleaning up the memory store itself** (orphans vs `MEMORY.md`, stale
   memories, dedupe, "scope memories into skills") → the `memory-doctor` skill if
   installed, the sibling of this one for the memory surface. skill-doctor _reads_
@@ -108,7 +108,13 @@ Reason over the map (not the raw files). Produce a **prioritized, numbered list*
 of suggested improvements. For each: target file, problem, proposed change, and
 whether it's `writable`. Cover:
 
-- **Overlaps / duplicates.** Use the `duplicate_names` and
+The script's flags are a starting point, not the boundary of the audit. Read the
+whole map and report every genuine issue you see, including ones the script did
+not flag — the flags are keyword and threshold heuristics, so a real overlap or a
+weak description can sit in an unflagged row. Rank at the end; do not filter
+during discovery.
+
+- **Overlaps / duplicates.** Start from the `duplicate_names` and
   `near_duplicate_descriptions` flags. Ignore `mirror-only` duplicates
   (marketplace↔plugin-cache are just install mirrors of the same upstream item).
   Focus on `[editable]` collisions and genuinely distinct skills doing the same
@@ -116,13 +122,15 @@ whether it's `writable`. Cover:
 - **Gaps.** Recurring needs with no skill. Cross-reference the project's memory
   store if one exists — many feedback memories encode repeated corrections that
   may deserve a skill.
-- **Trigger-quality.** Use `weak_or_missing_description` and
-  `no_trigger_language`. For the handful of **writable** items you'll actually
-  propose changing, deep-read them **via a subagent** (Explore or general-purpose)
-  so main context stays bounded — ask the subagent to return the current
-  description + body summary + a tightened description proposal. For rigorous
-  triggering work, hand the item to skill-creator's `improve_description.py` /
-  `run_loop.py` loop.
+- **Trigger-quality.** Start from `weak_or_missing_description` and
+  `no_trigger_language`, and flag any other description that reads weak on the
+  rubric. Deep-read the **writable** items you'll actually propose changing. Read
+  them directly when there are only a few (a handful of reads is cheaper inline
+  than a dispatch); delegate to a single Explore or general-purpose subagent only
+  when the set is large enough that reading it inline would crowd out main
+  context — ask that subagent to return the current description + body summary +
+  a tightened description proposal per item. For rigorous triggering work, hand
+  the item to skill-creator's `improve_description.py` / `run_loop.py` loop.
 - **Oversized bodies.** `oversized_body` items (>500 lines) are candidates for
   progressive disclosure (move detail into `references/`).
 
@@ -153,11 +161,14 @@ turn that motivates it. Vague "you could add a skill for X" proposals aren't use
 ### Step 5 — Present & apply (all modes)
 
 Show the consolidated, prioritized menu. Mark each item `[editable]` or
-`[read-only]`. Let the user choose. Then, for accepted items only:
+`[read-only]`. Keep each entry to a line or two — target, problem, proposed change
+— so the menu stays scannable; detail belongs in the follow-up on the items the
+user picks. Let the user choose. Then, for accepted items only:
 
 - New/iterated skill → `skill-creator` skill.
-- Agent prompt tuning → `agent-optimizer` / `prompt-engineer` agents.
-- Standing rule → an `update-claude-md` skill or a memory file.
+- Agent prompt tuning → the `development-productivity:prompt-engineer-agent` agent
+  (inline if that plugin isn't installed).
+- Standing rule → the `/update-claude-md` command or a memory file.
 - Direct small edits (e.g. a tightened description):
   - under `~/.claude/…` (non-git) → edit in place; show the before/after first.
   - inside a git repo → open a **draft PR** per "Delivering changes once

--- a/packages/plugins/skill-management/skills/skill-doctor/references/analysis-rubric.md
+++ b/packages/plugins/skill-management/skills/skill-doctor/references/analysis-rubric.md
@@ -3,6 +3,13 @@
 Heuristics for the analysis + mining passes. Keep judgments concrete and tied to
 the inventory data; don't invent problems.
 
+Precision and coverage are both required, and they pull against each other.
+"Don't invent problems" constrains what you _assert_, not what you _look at_ —
+report every issue you actually found, including ones you are unsure about or
+judge low-severity, and mark that uncertainty rather than dropping the finding.
+An audit that silently omits a real issue fails the same way as one that
+fabricates a fake one, and the omission is harder to notice.
+
 ## What a good triggering description looks like
 
 The `description` is the _only_ thing Claude sees when deciding whether to


### PR DESCRIPTION
Applies the Opus 5 migration audit to `packages/plugins/skill-management/`. Every `.md` under the plugin was read in full; only files with an actual migration defect were touched.

## Deltas addressed

### Broken references (dispatch names verified against disk)

`skills/skill-doctor/SKILL.md` routed deep work to four names, three of which do not exist:

| Name | Status | Action |
| --- | --- | --- |
| `agent-capability-analyst` | No `name:` frontmatter anywhere in the marketplace or `~/.claude` | Bullet removed |
| `claude-agent-discovery` | Same — does not exist | Bullet removed |
| `agent-optimizer` | Same — does not exist | Dropped from the pair |
| `prompt-engineer` | Real agent is `prompt-engineer-agent` (development-productivity) | Corrected to `development-productivity:prompt-engineer-agent` |

Verification — the only hits anywhere on disk for the three phantom names are copies of this same plugin:

```
$ /usr/bin/grep -rn 'agent-optimizer\|agent-capability-analyst\|claude-agent-discovery' \
    ~/.claude/plugins ~/.claude/agents
~/.claude/plugins/cache/uniswap-ai-toolkit/skill-management/1.0.1/skills/skill-doctor/SKILL.md:29,30,31,159
~/.claude/plugins/cache/uniswap-ai-toolkit/skill-management/1.0.2/skills/skill-doctor/SKILL.md:29,30,31,159
~/.claude/plugins/cache/uniswap-ai-toolkit/skill-management/1.0.{1,2}/README.md:46
```

Also corrected: `update-claude-md` was described as a *skill*; it is a **command** (`development-productivity/commands/update-claude-md.md`). Now referenced as `/update-claude-md`.

The same `prompt-engineer` correction was applied in `README.md`.

### Delta 2 — delegation

`skill-doctor` Step 3 mandated `deep-read them **via a subagent**` for what its own sentence called "the handful of writable items you'll actually propose changing". Now conditional: read directly when there are only a few, delegate to a single subagent only when the set is large enough that inline reading would crowd out main context. An explicit when-NOT-to-delegate clause is stated inline ("a handful of reads is cheaper inline than a dispatch").

### Delta 3 — recall filter at discovery time

`skill-doctor` Step 3 told the analysis pass to `Use the duplicate_names / near_duplicate_descriptions / weak_or_missing_description / no_trigger_language flags`, which reads as a discovery-time boundary: an overlap the script's heuristics did not flag gets silently dropped. Reshaped coverage-first — the flags are now a starting point, the whole map gets read, ranking happens at the end rather than during discovery. Bullet verbs changed from "Use" to "Start from".

No emphasis stripping was needed. `CRITICAL|MUST|NEVER|ALWAYS|ABSOLUTE` counts across the plugin: 2 in `audit-patterns.md`, 1 in `migrate-config-to-opus-5/SKILL.md`, 0 everywhere else — all load-bearing.

### Delta 4 — output length

- `skills/migrate-config-to-opus-5/SKILL.md` `## Output` had no deliverable-length line, while its own `references/audit-patterns.md:54` is the text instructing *other* configs to add one. The skill now follows its own advice.
- `skill-doctor` Step 5's consolidated menu now caps each entry at a line or two, with detail deferred to the items the user actually picks.

### Verified, deliberately unchanged

- **Delta 1 (verification ceremony)** — no defect found. `migrate-config` Step 5's `claude -p` probe and Step 2's "spot-check each proposed edit against the actual file" both check work against external reality, which is grounding, not self-review. `skill-doctor`'s "suggest re-running inventory.py to confirm the flag cleared" is likewise a tool re-run, not a re-read of just-written output.
- **Stale facts in `audit-patterns.md`** — re-verified and correct, left untouched: Opus 5 $5/$25 vs Sonnet 5 $3/$15 → ~1.7x (with the ~2.5x intro-pricing caveat through 2026-08-31), Haiku $1/$5 → ~5x under Opus; model IDs `claude-opus-5` / `claude-sonnet-5` / `claude-haiku-4-5` / `claude-fable-5` with the alias preference; `budget_tokens` 400s on the Claude 5 family.
- **Invented numbers** — none found. The one numeric instruction (`count CRITICAL|MUST|NEVER|ALWAYS per file`) is arithmetic over real grep output.
- **`MultiEdit` / `Task(subagent_type:)`** — no occurrences in this plugin.
- **`memory-doctor`** — referenced but does not exist on disk. Left as-is because the reference is explicitly hedged ("the `memory-doctor` skill **if installed**"), so it cannot fail at dispatch.

## DECISION (not resolved here — needs a call)

`references/audit-patterns.md:24` lists `"PROACTIVELY" in agent descriptions` as a Delta 2 smell to flag. Its sibling `skills/skill-doctor/SKILL.md:11` says *"Also use PROACTIVELY after finishing a multi-step workflow that the user is likely to repeat"*.

- **Case for changing skill-doctor:** the plugin should not ship the pattern its own reference tells users to flag. Under Opus 5's stronger literal-following, a PROACTIVELY in a description is exactly the over-trigger nudge Delta 2 warns about.
- **Case for leaving it:** the audit-patterns line targets *agent* descriptions driving delegation fan-outs. skill-doctor is a **skill**, and its PROACTIVELY drives an *ask*, not a dispatch — it prompts the user with a question after a PR, which is policy rather than compensation. Deleting it would silently kill the PR-time nudge that `hooks/pr-skill-doctor-prompt.cjs` exists to reinforce.

Either resolution is defensible; picking one is a judgment call, so nothing was changed.

## Version

`.claude-plugin/plugin.json` 1.2.0 → **1.3.0** (MINOR: dispatch targets removed, delegation and discovery behavior changed), and the matching row in the root `CLAUDE.md` table. plugin.json and the root table **agreed** at 1.2.0 before this change — no drift.

## Test plan

```
$ node scripts/validate-plugin.cjs packages/plugins/skill-management
$ bunx nx format:write --uncommitted
$ bunx markdownlint-cli2 --fix "packages/plugins/skill-management/**/*.md"
```

Output pasted in a follow-up comment. Pre-commit (lefthook) ran clean on the commit:

```
✔️ format  ✔️ lint  ✔️ lint-markdown  ✔️ test  ✔️ typecheck  ✔️ update-lockfile
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Applies the Opus 5 migration audit (from the `migrate-config-to-opus-5` skill added in #562) to
`packages/plugins/skill-management/` itself. Every `.md` under the plugin was read in full; only files
with an actual defect were touched. 6 files, +42/-22, docs only — no code, hooks, or CI.
Three commits, four defect classes: broken dispatch targets, recall filters applied at discovery time,
unconditional delegation, and missing output-length instructions.
## 1. Broken dispatch references
`skills/skill-doctor/SKILL.md` routed deep work to four agent names. Three do not exist, so those
bullets could only ever fail at dispatch:
| Name                        | Status                                    | Action                                             |
| --------------------------- | ----------------------------------------- | -------------------------------------------------- |
| `agent-capability-analyst`  | Not defined by any agent in the marketplace | Bullet removed                                     |
| `claude-agent-discovery`    | Not defined anywhere                      | Bullet removed                                     |
| `agent-optimizer`           | Not defined anywhere                      | Dropped from the pair                              |
| `prompt-engineer`           | Real agent is `prompt-engineer-agent`     | → `development-productivity:prompt-engineer-agent` |
Verified — the first three have no defining frontmatter, the corrected name does:
```bash
$ grep -rn '^name: \(agent-optimizer\|agent-capability-analyst\|claude-agent-discovery\)$' \
    --include=*.md packages/plugins/
# (no output)
$ grep -rn '^name: prompt-engineer-agent$' --include=*.md packages/plugins/
packages/plugins/development-productivity/agents/prompt-engineer.md:2
```
The filename is `prompt-engineer.md` but the dispatch name in frontmatter is `prompt-engineer-agent` —
the path was the likely source of the original error. The surviving reference now carries an explicit
"verify the name resolves before dispatching; if that plugin isn't installed, do the tuning inline"
fallback, so a missing plugin degrades instead of failing.
Also corrected: `update-claude-md` was described as a _skill_. It is a **command**
(`packages/plugins/development-productivity/commands/update-claude-md.md`), now referenced as
`/update-claude-md`. The same `prompt-engineer` correction was applied in `README.md`.
## 2. Recall filters applied at discovery time (two sites)
**`skill-doctor/SKILL.md` Step 3** told the analysis pass to `Use the duplicate_names /
near_duplicate_descriptions / weak_or_missing_description / no_trigger_language flags`. Read as a
discovery-time boundary, an overlap the script's keyword/threshold heuristics did not flag gets
silently dropped. Reshaped coverage-first: the flags are a starting point, the whole map gets read,
ranking happens at the end rather than during discovery. Bullet verbs changed from "Use" to "Start
from".
**`skill-doctor/references/analysis-rubric.md`** opened with "don't invent problems" and nothing on the
other side. The intent is right, but an unbalanced precision instruction in an auditing prompt reads to
Opus 5 as license to drop anything it is uncertain about — the same recall filter, one level down. Added
the counterweight: the guard constrains what you _assert_, not what you _look at_; report the finding
and mark the uncertainty rather than dropping it. A silently omitted real issue fails the same way a
fabricated one does, and is harder to notice.
## 3. Delegation made conditional
`skill-doctor` Step 3 mandated deep-reading **via a subagent** for what its own sentence called "the
handful of writable items you'll actually propose changing" — a dispatch costing more than the reads it
replaces. Now conditional: read directly when there are only a few, delegate to a single subagent only
when the set is large enough that inline reading would crowd out main context. The when-NOT-to-delegate
case is stated inline ("a handful of reads is cheaper inline than a dispatch") rather than left implicit.
## 4. Output length
- `skills/migrate-config-to-opus-5/SKILL.md` `## Output` had no deliverable-length line, while its own
  `references/audit-patterns.md:54` is the text instructing _other_ configs to add one. The skill now
  follows its own advice.
- `skill-doctor` Step 5's consolidated menu now caps each entry at a line or two, with detail deferred
  to the items the user actually picks.
## 5. PROACTIVELY self-inconsistency (resolved in `48a0f0f`)
`references/audit-patterns.md:24` lists `"PROACTIVELY" in agent descriptions` as a Delta 2 smell to
flag, and `skill-doctor`'s own description used it. Shipping the pattern the plugin tells users to flag
undercuts the guidance, so the word is gone.
The **trigger is kept** — skill-doctor still applies after a repeatable multi-step workflow, especially
right after opening a PR. Only the nudge word was removed, and the PR-time prompt is delivered by
`hooks/pr-skill-doctor-prompt.cjs`, not by this description, so no behavior is lost. The plugin's only
remaining `PROACTIVELY` is now the `audit-patterns.md` line that _defines_ the smell.
## Verified, deliberately unchanged
- **Verification ceremony** — no defect. `migrate-config` Step 5's `claude -p` probe and Step 2's
  "spot-check each proposed edit against the actual file" both check work against external reality,
  which is grounding, not self-review. skill-doctor's "re-run `inventory.py` to confirm the flag
  cleared" is a tool re-run, not a re-read of just-written output.
- **Emphasis stripping** — not needed. `CRITICAL|MUST|NEVER|ALWAYS|ABSOLUTE` appears on 2 lines in
  `audit-patterns.md`, 1 in `migrate-config-to-opus-5/SKILL.md`, and 1 in `analysis-rubric.md` — the
  last being `heavy-handed ALL-CAPS MUSTs`, prose _about_ emphasis rather than emphasis itself. All
  load-bearing.
- **Stale facts in `audit-patterns.md`** — re-verified correct: Opus 5 $5/$25 vs Sonnet 5 $3/$15 →
  ~1.7x (with the intro-pricing caveat through 2026-08-31), Haiku $1/$5 → ~5x under Opus; model IDs and
  the alias preference; `budget_tokens` on the Claude 5 family.
- **Invented numbers** — none. The one numeric instruction (count emphasis words per file) is
  arithmetic over real grep output.
- **`MultiEdit` / `Task(subagent_type:)`** — no occurrences in this plugin.
- **`memory-doctor`** — referenced but not on disk. Left as-is: the reference is explicitly hedged
  ("the `memory-doctor` skill **if installed**"), so unlike the three names above it cannot fail at
  dispatch.
## Out of scope — pre-existing broken refs elsewhere
Two of the phantom names are also referenced outside this plugin. They are equally broken, but they
belong to another plugin and to `docs/`, so they would need their own version bump and are **not**
touched here:
```text
packages/plugins/development-codebase-tools/agents/agent-orchestrator.md:35,160  agent-capability-analyst
docs/examples/orchestration-workflows.md:447                                     agent-optimizer
docs/guides/creating-agents.md:23                                                agent-optimizer
```
Worth a follow-up. Note that `spec-workflow/skills/implement-spec/SKILL.md` no longer appears in this
sweep — that reference was already removed by #567.
## Version
`.claude-plugin/plugin.json` 1.2.0 → **1.3.0** (minor: dispatch targets removed, delegation and
discovery behavior changed), with the matching row in the root `CLAUDE.md` table updated in the same
commit. The two **agreed** at 1.2.0 beforehand — no pre-existing drift.
## Test plan
- [x] `node scripts/validate-plugin.cjs packages/plugins/skill-management` → **Validation PASSED**
      (`skill-management v1.3.0`, 2 skills, 3 commands, 2 hooks)
- [x] Every removed dispatch name confirmed undefined, and every replacement name confirmed defined, by
      the greps above
- [x] `PROACTIVELY` sweep across the plugin returns only the `audit-patterns.md` line that defines the
      smell
- [x] `bunx markdownlint-cli2 --fix` → 0 issues; `bunx nx format:write --uncommitted` applied
- [x] Lefthook pre-commit green on all three commits (format, lint, lint-markdown, test, typecheck,
      update-lockfile)

</details>
<!-- claude-pr-description-end -->