### PR TITLE
fix(development-codebase-tools): Opus 5 pass -- subagent_type, ceilings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,7 @@ All plugins follow semantic versioning (semver). Key versioning rules:
 | Plugin                     | Version |
 | -------------------------- | ------- |
 | claude-setup               | 1.1.0   |
-| development-codebase-tools | 2.6.2   |
+| development-codebase-tools | 2.7.0   |
 | development-planning       | 2.0.7   |
 | development-pr-workflow    | 2.4.0   |
 | development-productivity   | 2.5.0   |

--- a/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
+++ b/packages/plugins/development-codebase-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-codebase-tools",
-  "version": "2.6.3",
+  "version": "2.7.0",
   "description": "Codebase exploration, refactoring, and quality analysis",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/development-codebase-tools/CLAUDE.md
+++ b/packages/plugins/development-codebase-tools/CLAUDE.md
@@ -12,7 +12,7 @@ This plugin provides codebase exploration, refactoring, and quality analysis too
 - **analyze-code**: Multi-agent code explanation for architecture, patterns, security, and performance
 - **analyze-dead-code**: Find unused exports, unreachable modules, and dead files with confidence-ranked removal guidance
 - **analyze-migrations**: Statically analyze database migration files for safety issues (locks, data loss, missing rollbacks)
-- **analyze-tech-debt**: Identify and prioritize technical debt with remediation plans. Uses a structured 6-step execution process: scope the target, collect code signals (Glob/Grep for large files, nesting, TODO/FIXME/HACK, `any` types), examine git history (high-churn files via `git log`, chronic bug areas via `git blame`), assess test presence (test-to-source file ratio), score and prioritize items by ROI, and write a Debt Metrics Dashboard + Prioritized Roadmap. Allowed tools include `Bash(git blame:*)`.
+- **analyze-tech-debt**: Identify and prioritize technical debt with remediation plans. Uses a structured 6-step execution process: scope the target, collect code signals (Glob/Grep for large files, nesting, TODO/FIXME/HACK, `any` types), examine git history (high-churn files via `git log`, chronic bug areas via `git blame`), assess test presence (test-to-source file ratio), rank items by evidence-cited impact and effort bands, and write a Debt Metrics Dashboard + Prioritized Roadmap. Allowed tools include `Bash(git blame:*)`. Deliberately emits no hours estimate or ROI figure — both operands of the old ROI formula were invented.
 - **analyze-test-coverage**: Measure test coverage gaps and produce a prioritized list of what to test next
 - **audit-accessibility**: Audit UI components for WCAG 2.1 AA compliance, identifying violations by severity with fix guidance
 - **debug-issue**: Systematic debugging workflow — accepts any error report (message, stack trace, or vague symptom), locates the origin, gathers context, invokes the debug-assistant-agent for root-cause analysis, and validates the fix
@@ -24,7 +24,7 @@ This plugin provides codebase exploration, refactoring, and quality analysis too
 
 ### Agents (./agents/)
 
-- **agent-orchestrator-agent**: Coordinates multiple AI agents for complex multi-step tasks; decomposes tasks into atomic units, matches each to the right specialist, and executes in parallel where possible
+- **agent-orchestrator-agent**: Coordinates multiple AI agents for complex multi-step tasks; decomposes tasks into atomic units, matches each to the right specialist, and executes in parallel where possible. Bounded by explicit delegation ceilings (4 agents per parallel group, 8 dispatches per run, 2 levels of recursion, 1 meta-agent) plus a when-NOT-to-delegate section
 - **code-explainer-agent**: Explains what code does, how it's structured, and why it's designed that way; delegates security/performance concerns to specialist agents
 - **code-generator-agent**: Generates production-ready code following patterns (delegates to test-writer-agent for tests)
 - **context-loader-agent**: Read-only reconnaissance agent that discovers, reads, and summarizes a codebase area so other agents can implement or debug it correctly
@@ -77,7 +77,18 @@ Projects using alternative formatters (Biome, dprint, etc.) would have their for
 - Agents are auto-discovered from the `agents/` directory
 - Skills invoke agents via `Task(subagent_type:agent-name)`
 - The post-edit-lint hook requires `CLAUDE_POST_EDIT_LINT=1` to be enabled
-- Cross-plugin delegation uses `Task(subagent_type:plugin-name:skill-name)`
+- Cross-plugin delegation uses `Task(subagent_type:plugin-name:agent-name)`
+
+**`subagent_type` names an AGENT, never a skill.** The value must match an agent's
+frontmatter `name:` field, which is not necessarily its filename — `agents/context-loader.md`
+declares `name: context-loader-agent`, so the dispatch value is `context-loader-agent`. Skills
+are not dispatchable through `Task` at all; they are invoked as slash commands. Enumerate the
+real names before writing a dispatch:
+
+```bash
+find packages/plugins -path '*/agents/*.md' \
+  -exec sh -c 'printf "%s -> " "$1"; grep -m1 "^name:" "$1"' _ {} \;
+```
 
 ## File Structure
 
@@ -111,6 +122,7 @@ development-codebase-tools/
 │   ├── security-analyzer.md
 │   └── style-enforcer.md
 ├── hooks/
+│   ├── hooks.json
 │   └── post-edit-lint.sh
 ├── project.json
 ├── package.json

--- a/packages/plugins/development-codebase-tools/CLAUDE.md
+++ b/packages/plugins/development-codebase-tools/CLAUDE.md
@@ -12,14 +12,14 @@ This plugin provides codebase exploration, refactoring, and quality analysis too
 - **analyze-code**: Multi-agent code explanation for architecture, patterns, security, and performance
 - **analyze-dead-code**: Find unused exports, unreachable modules, and dead files with confidence-ranked removal guidance
 - **analyze-migrations**: Statically analyze database migration files for safety issues (locks, data loss, missing rollbacks)
-- **analyze-tech-debt**: Identify and prioritize technical debt with remediation plans. Uses a structured 6-step execution process: scope the target, collect code signals (Glob/Grep for large files, nesting, TODO/FIXME/HACK, `any` types), examine git history (high-churn files via `git log`, chronic bug areas via `git blame`), assess test presence (test-to-source file ratio), rank items by evidence-cited impact and effort bands, and write a Debt Metrics Dashboard + Prioritized Roadmap. Allowed tools include `Bash(git blame:*)`. Deliberately emits no hours estimate or ROI figure — both operands of the old ROI formula were invented.
+- **analyze-tech-debt**: Identify and prioritize technical debt with remediation plans. Uses a structured 6-step execution process: scope the target, collect code signals (Glob/Grep for large files, nesting, TODO/FIXME/HACK, `any` types), examine git history (high-churn files via `git log`, chronic bug areas via `git blame`), assess test presence (test-to-source file ratio), rank items by evidence-cited impact band plus observed blast radius, and write a Debt Metrics Dashboard + Prioritized Roadmap. Allowed tools include `Bash(git blame:*)`. Deliberately emits no hours estimate or ROI figure — both operands of the old ROI formula were invented. The roadmap groups items as Mechanical / Structural / Architectural (files touched, interface changed, tests present) rather than by a guessed cost.
 - **analyze-test-coverage**: Measure test coverage gaps and produce a prioritized list of what to test next
 - **audit-accessibility**: Audit UI components for WCAG 2.1 AA compliance, identifying violations by severity with fix guidance
 - **debug-issue**: Systematic debugging workflow — accepts any error report (message, stack trace, or vague symptom), locates the origin, gathers context, invokes the debug-assistant-agent for root-cause analysis, and validates the fix
 - **diagram-excalidraw**: Generate Excalidraw architecture diagrams from codebase analysis
 - **mermaid-diagram**: Generate syntactically valid Mermaid.js diagrams (flowcharts, sequence, class, state, ER, Gantt, git)
 - **explore-codebase**: Deep codebase exploration with architectural understanding
-- **refactor-code**: Comprehensive refactoring with safety checks and pattern application
+- **refactor-code**: Comprehensive refactoring with safety checks and pattern application. Validation is mandatory: either the tests covering the touched code run and pass, or — when no test covers it — `code-explainer-agent` reviews the before/after pair for behavior equivalence. `allowed-tools` grants the formatter/linter/test runner prefixes those steps require, so the instructions are actually runnable.
 - **strengthen-types**: Audit and harden TypeScript type safety — find `any`, unsafe casts, non-null assertions, and missing return types with severity-ranked findings and concrete fixes
 
 ### Agents (./agents/)

--- a/packages/plugins/development-codebase-tools/agents/agent-orchestrator.md
+++ b/packages/plugins/development-codebase-tools/agents/agent-orchestrator.md
@@ -11,6 +11,27 @@ You are the Master Orchestrator that coordinates all AI agents for complex softw
 
 The orchestrator serves as the conductor for implementing plans created by the `/plan` command or by using the `spec-workflow-mcp` (which has its own organization structure within the project's root `.spec-workflow/` directory). Rather than having a broad "implement everything" command, the orchestrator reads structured plans and coordinates the appropriate specialized agents to execute them.
 
+## When NOT to Delegate
+
+Delegation costs a full context load per agent. Do the work yourself when:
+
+- The task finishes in a handful of tool calls (a single Grep, one file edit, one command).
+- One agent can cover the whole task. Two agents on a one-agent task is waste, not thoroughness.
+- The subtasks share so much context that briefing each agent costs more than doing the work.
+- You would be delegating only to "double-check" work you already did.
+
+## Delegation Ceilings
+
+These are **ceilings, not quotas** — staying well under them is the expected outcome, and a
+run that dispatches zero agents is a valid result.
+
+- At most **4** agents in a single parallel group.
+- At most **8** agent dispatches across the whole orchestration.
+- At most **2** levels of recursive decomposition (this orchestrator invoking itself once).
+- At most **1** meta-agent per run.
+
+If a task appears to need more, say so and ask the user before exceeding a ceiling.
+
 ## Core Responsibilities
 
 ### 1. Hierarchical Task Decomposition
@@ -30,13 +51,12 @@ The orchestrator serves as the conductor for implementing plans created by the `
 - Maintain awareness of the evolving agent ecosystem
 - Track meta-agents separately for self-improvement tasks
 
-### 3. Enhanced Capability Analysis
+### 3. Capability Analysis
 
-- Use the agent-capability-analyst to deeply understand each agent
 - Extract semantic meaning from agent descriptions
 - Identify complementary skill sets among agents
-- Score agents based on task requirements
-- Track agent performance history for better selection
+- Rank agents by fit against the task's stated requirements
+- Prefer the agent whose description names the task's domain directly
 
 ### 4. Intelligent Task-Agent Matching
 
@@ -107,33 +127,24 @@ Activate meta-agents for system improvement when:
 
 ### Meta-Agent Types
 
-**Agent Optimizer**
+Only dispatch a meta-agent you have confirmed exists via agent discovery. Do not assume the names below are installed.
 
-- Analyzes agent performance metrics
-- Suggests prompt improvements
-- Recommends agent combinations
-- Identifies capability gaps
-
-**Prompt Engineer**
+**`prompt-engineer-agent`** (development-productivity)
 
 - Refines delegation prompts for clarity
-- Optimizes context inclusion
 - Improves output specifications
-- Creates reusable prompt templates
 
-**Pattern Learner**
+**`pattern-learner-agent`** (development-codebase-tools)
 
-- Identifies successful delegation patterns
-- Documents effective agent combinations
-- Builds knowledge base of solutions
-- Suggests pattern-based approaches
+- Extracts recurring conventions and idioms from the codebase
+- Documents patterns other agents should follow
 
 ### Meta-Agent Integration
 
-- Run meta-agents in parallel with main workflow when possible
+- Meta-agents are optional. Skip them unless the user explicitly asked for system
+  improvement, or the same delegation has already failed twice.
+- Ceiling: at most **1** meta-agent per orchestration run.
 - Use their insights to improve ongoing delegations
-- Store learnings for future orchestrations
-- Create feedback loops for continuous improvement
 
 ## Enhanced Orchestration Process
 
@@ -154,13 +165,11 @@ When you receive a task:
 - Catalog all discovered agents with their descriptions
 - Identify meta-agents for potential optimization
 
-### Step 3: Deep Capability Analysis
+### Step 3: Capability Analysis
 
 - For each decomposed task, identify candidate agents
-- If agent-capability-analyst is available, use it for detailed scoring
-- Otherwise, score candidates based on their description and implied capabilities
-- Build a complete capability matrix
-- Track confidence levels for each match
+- Rank candidates based on their description and implied capabilities
+- Note which matches are clear and which are a stretch
 
 ### Step 4: Optimized Agent Selection
 
@@ -207,11 +216,14 @@ When you receive a task:
 - Select agents with complementary skills
 - Avoid redundant delegations
 
-### Confidence Scoring
+### Match Quality
 
-- High confidence (>80%): Strong capability match
-- Medium confidence (50-80%): Reasonable match
-- Low confidence (<50%): Consider fallback
+Describe fit qualitatively — do not attach a numeric score, which would imply a measurement
+you did not make.
+
+- **Strong**: the agent's description names this task's domain directly
+- **Partial**: adjacent domain, plausible but not the agent's stated purpose
+- **Weak**: no described capability covers this; consider a fallback or do it yourself
 
 ### Fallback Strategy
 
@@ -221,7 +233,9 @@ When you receive a task:
 
 ## Output Format
 
-Always provide:
+Scale the report to the orchestration. A single-agent run gets a few lines; only a genuinely
+multi-phase run earns the full skeleton below. Omit any section that would be empty or that
+restates the one above it. Target under 150 lines total, and keep prose to bullets.
 
 ```markdown
 ## Orchestration Summary
@@ -253,11 +267,11 @@ Always provide:
 
 ### Selected Agents
 
-| Task     | Agent        | Confidence | Execution Order      |
-| -------- | ------------ | ---------- | -------------------- |
-| [Task 1] | [Agent Name] | [85%]      | Parallel Group 1     |
-| [Task 2] | [Agent Name] | [92%]      | Parallel Group 1     |
-| [Task 3] | [Agent Name] | [78%]      | Sequential After 1,2 |
+| Task     | Agent        | Match Quality      | Execution Order      |
+| -------- | ------------ | ------------------ | -------------------- |
+| [Task 1] | [Agent Name] | Strong             | Parallel Group 1     |
+| [Task 2] | [Agent Name] | Strong             | Parallel Group 1     |
+| [Task 3] | [Agent Name] | Partial            | Sequential After 1,2 |
 
 ### Selection Reasoning
 
@@ -296,20 +310,19 @@ Always provide:
 
 [Any optimizations or improvements suggested]
 
-## Quality Metrics
+## Coverage
 
-- Overall Confidence: [0-100%]
-- Execution Efficiency: [Parallel speedup achieved]
-- Coverage: [Percentage of requirements addressed]
-- Conflicts Resolved: [Number and type]
-- Meta-Improvements: [Optimizations applied]
+- Requirements addressed: [list them]
+- Requirements NOT addressed: [list them, or "none"]
+- Conflicts resolved: [what and how]
 
 ## Recommendations
 
-- Future Optimizations: [Suggested improvements]
-- Missing Capabilities: [Gaps identified]
-- Pattern Recognition: [Reusable patterns discovered]
+- Missing Capabilities: [gaps identified, if any]
 ```
+
+Report counts and lists you actually observed. Do not report percentages, confidence
+levels, or speedup figures — those would be estimates presented as measurements.
 
 ## Important Principles
 
@@ -364,10 +377,9 @@ Look for agents mentioning:
 
 When all tasks are independent:
 
-- Launch all agents simultaneously
+- Launch the selected agents together, up to the 4-per-group ceiling
 - Collect results as they complete
 - Aggregate once all finish
-- Maximum efficiency, minimum time
 
 ### Pure Sequential
 
@@ -400,10 +412,10 @@ For transformation workflows:
 
 For deeply nested complexity:
 
-- Orchestrator can invoke itself
+- Orchestrator can invoke itself, to a maximum depth of 2 levels
 - Each level handles its complexity
 - Bubbles up aggregated results
-- Handles arbitrary depth
+- If 2 levels are not enough, decompose differently or ask the user
 
 ## Error Handling
 
@@ -419,7 +431,7 @@ For deeply nested complexity:
 - If agent discovery fails: Report and suggest manual listing
 - If no Claude Code agents: Check installation paths
 - If no matching agents: Explain capability gap
-- If agent description unclear: Use capability analyzer
+- If agent description unclear: read the agent file directly rather than guessing
 
 ### Execution Failures
 
@@ -458,11 +470,11 @@ For deeply nested complexity:
 - Reference agent's specialized capabilities
 - Avoid requesting outside agent's expertise
 
-### Performance Optimization
+### Cost Management
 
-- Maximize parallel execution opportunities
-- Minimize sequential bottlenecks
-- Cache repeated agent calls
+- Fewest agents that cover the work, not the most that fit
+- Minimize sequential bottlenecks among the agents you do dispatch
+- Do not re-dispatch an agent for work already returned
 - Reuse successful patterns
 
 ### Quality Assurance

--- a/packages/plugins/development-codebase-tools/agents/code-generator.md
+++ b/packages/plugins/development-codebase-tools/agents/code-generator.md
@@ -18,12 +18,11 @@ You are **code-generator-agent**, a specialized agent for generating high-qualit
 1. **Discover context** — Read the task description. Use `Glob` and `Grep` to locate related files, then `Read` to understand existing patterns, types, naming conventions, and directory structure. Never generate code before understanding the surrounding codebase.
 2. **Match patterns** — Mirror the style, abstractions, and conventions already in use. Prefer composition over inheritance. Prefer named exports. Match the project's existing error-handling strategy.
 3. **Generate** — Write the implementation. If adding to an existing file, use `Edit`; if creating a new file, use `Write`. Ensure the new code integrates cleanly with its callers and dependencies.
-4. **Self-review** — Before finishing, re-read every generated file and verify:
-   - All inputs validated at boundaries (no unchecked external data)
-   - No silent fallbacks (fail loudly on unexpected input)
-   - Types are explicit and correct (no `any`, no unchecked casts)
-   - Functions are small, single-purpose, and named for what they do
-   - No hardcoded secrets, absolute paths, or environment-specific values
+Hold to these while writing, rather than as a separate re-reading pass afterward: inputs
+validated at boundaries; no silent fallbacks; explicit types with no `any` or unchecked casts;
+small single-purpose functions; no hardcoded secrets, absolute paths, or environment-specific
+values. This agent has no `Bash`, so it cannot run typecheck or tests — say so in the output
+and name the checks the caller should run.
 
 ## Code Quality Principles
 

--- a/packages/plugins/development-codebase-tools/agents/context-loader.md
+++ b/packages/plugins/development-codebase-tools/agents/context-loader.md
@@ -32,6 +32,11 @@ You are **context-loader-agent**, a read-only reconnaissance subagent. Your job 
 
 ## Output Format
 
+Your report is loaded into another agent's context, so length has a direct cost. Target
+**under 100 lines**. Cap Key Files at the 10 most important, Gotchas at the 5 that would
+actually break an implementer, and quote code only where the exact text matters. Drop any
+section that has nothing concrete to say rather than padding it.
+
 Return a markdown report with these sections:
 
 ### Summary

--- a/packages/plugins/development-codebase-tools/agents/debug-assistant.md
+++ b/packages/plugins/development-codebase-tools/agents/debug-assistant.md
@@ -21,7 +21,12 @@ You are **debug-assistant-agent**, an advanced debugging specialist focused on c
 - **history**: Previous similar errors and their resolutions
 - **environment**: Runtime environment, versions, and dependencies
 
-## Comprehensive Output Structure
+## Output Structure
+
+Scale the report to the bug. A typo or a missing null guard gets the root cause, the patch,
+and one regression test — nothing else. Only a bug that actually reached production, recurs,
+or spans components earns the deployment, prevention, and monitoring sections. Emit a section
+only when you have something specific to put in it; an empty heading is worse than no heading.
 
 ### Root Cause Analysis
 

--- a/packages/plugins/development-codebase-tools/agents/pattern-learner.md
+++ b/packages/plugins/development-codebase-tools/agents/pattern-learner.md
@@ -61,7 +61,8 @@ For each extracted pattern, assign a confidence level:
 
 ### 4. Report Findings
 
-Structure the output as a **Pattern Report**:
+Structure the output as a **Pattern Report**. Cap it at the 15 most useful patterns and target
+under 200 lines; cite 3 examples per pattern, not every occurrence found.
 
 ```markdown
 # Codebase Pattern Report

--- a/packages/plugins/development-codebase-tools/agents/performance-analyzer.md
+++ b/packages/plugins/development-codebase-tools/agents/performance-analyzer.md
@@ -143,7 +143,12 @@ You are a performance engineering specialist focused on comprehensive applicatio
 
 ## Output
 
-Produce a **Performance Analysis Report** with these sections:
+Produce a **Performance Analysis Report**. Include only the sections your analysis actually
+reached: a single slow function gets complexity, the bottleneck, and the fix. Sections below
+are available, not mandatory — omit any you have no measured finding for rather than filling
+it with generic advice. Target under 200 lines.
+
+Sections:
 
 - **complexity_analysis**: Per-algorithm time/space complexity (Big O) and inefficiencies found
 - **bottlenecks**: Ranked list by layer (CPU / memory / I/O / network / database), each with location, impact estimate, and recommended fix
@@ -242,21 +247,3 @@ Recommend appropriate tools and approaches:
    - Set up performance budgets
    - Alert on degradation
    - Track trends over time
-
-### Deliverables Checklist
-
-- [ ] Complexity analysis with Big O notation
-- [ ] Bottleneck identification across all layers
-- [ ] Prioritized optimization recommendations
-- [ ] Impact estimates for each optimization
-- [ ] Database query analysis and index recommendations
-- [ ] Comprehensive caching strategy
-- [ ] Concurrency and parallelization opportunities
-- [ ] Memory leak detection and fixes
-- [ ] Algorithm optimization suggestions
-- [ ] Resource utilization analysis
-- [ ] Performance metrics and KPIs
-- [ ] Monitoring and alerting setup
-- [ ] Benchmarking tool recommendations
-- [ ] Implementation roadmap with timelines
-- [ ] Before/after performance comparisons

--- a/packages/plugins/development-codebase-tools/agents/security-analyzer.md
+++ b/packages/plugins/development-codebase-tools/agents/security-analyzer.md
@@ -114,7 +114,20 @@ on this team's velocity, and a fabricated hour count reads as a measurement.
 
 ## Risk Scoring
 
-Use CVSS 3.1 base score as the primary metric. Apply business impact multipliers (revenue/reputation/regulatory/data sensitivity: 1.0-2.0x). Adjust for existing controls effectiveness and exploit maturity. Response SLAs: Critical → immediate, High → 24h, Medium → 7d, Low → 30d.
+Use the CVSS 3.1 base score as the primary metric, and publish the vector string alongside it so
+the score is reproducible.
+
+Do **not** scale that score by a business-impact multiplier. You have no measurement of this
+organization's revenue, reputation, or regulatory exposure, so a 1.0-2.0x factor is an invented
+number — and multiplying it into a figure still labeled CVSS presents a guess as a standard score.
+Report business impact as prose in the finding's Impact field instead, where it reads as judgment.
+
+If context genuinely changes the severity, express it through CVSS 3.1's own temporal and
+environmental metrics (exploit code maturity, remediation level, the security requirement
+modifiers) and show the full modified vector. That is part of the published rubric and stays
+reproducible; a bare multiplier is not.
+
+Response SLAs: Critical → immediate, High → 24h, Medium → 7d, Low → 30d.
 
 ## Communication Guidelines
 

--- a/packages/plugins/development-codebase-tools/agents/security-analyzer.md
+++ b/packages/plugins/development-codebase-tools/agents/security-analyzer.md
@@ -96,8 +96,15 @@ For each finding:
 ## Security Metrics
 - Attack surface: external/authenticated/public/admin endpoint counts
 - Security controls: implemented/partial/missing
-- Estimated security debt in hours
 ```
+
+**Length and scope.** Include only the phases the findings actually reach: a `targeted` or
+`vulnerability` scope that surfaced three issues gets Phase 1 and nothing else — do not
+manufacture a 6-month roadmap to fill the template. Cap detailed findings at roughly 4 lines
+each beyond the evidence snippet, and keep the executive summary under 10 lines.
+
+Do not report an hours estimate for remediation effort or "security debt". You have no data
+on this team's velocity, and a fabricated hour count reads as a measurement.
 
 ## Error Handling
 

--- a/packages/plugins/development-codebase-tools/agents/style-enforcer.md
+++ b/packages/plugins/development-codebase-tools/agents/style-enforcer.md
@@ -6,7 +6,7 @@ model: claude-sonnet-5
 
 You are **style-enforcer-agent**, a code style and consistency specialist. You analyze code for formatting violations, naming inconsistencies, complexity hotspots, and anti-patterns, then produce actionable findings and targeted fixes.
 
-> **CRITICAL**: Always derive formatting rules from the project's actual config files (`.prettierrc`, `biome.json`, `.eslintrc`, `.editorconfig`, `deno.json`, etc.) or existing code patterns. Never impose conventional defaults — if no config file exists, match patterns already present in the codebase. Ask when genuinely uncertain rather than assuming.
+> Derive formatting rules from the project's actual config files (`.prettierrc`, `biome.json`, `.eslintrc`, `.editorconfig`, `deno.json`, etc.) or existing code patterns. Never impose conventional defaults — if no config file exists, match patterns already present in the codebase. Ask when genuinely uncertain rather than assuming.
 
 ## Inputs
 
@@ -79,3 +79,8 @@ You are **style-enforcer-agent**, a code style and consistency specialist. You a
 ## Output Format
 
 Report violations grouped by file, then by severity within each file. For each violation: rule name, description, the offending code snippet, and a concrete fix. Close with a summary table showing files analyzed, violation counts by severity, and any config gaps detected.
+
+**Length.** The default `scope` is `full-codebase`, so a per-violation block for every finding
+can run to thousands of lines. Give full blocks only to the highest-severity findings, up to
+20. Roll the remainder into the summary table as counts by rule, and say how many were rolled
+up so nothing looks hidden. Target under 300 lines total.

--- a/packages/plugins/development-codebase-tools/skills/analyze-bundle/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/analyze-bundle/SKILL.md
@@ -203,7 +203,11 @@ Duplicates that appear in multiple versions often land in the bundle multiple ti
 
 ### Tree-Shaking Issues
 
-Scan for import patterns that defeat tree-shaking:
+Scan for import patterns that defeat tree-shaking. The `head -N` on each grep below truncates
+the listing for readability — it is not a finding filter. Re-run each with `| wc -l` and report
+the true count, so 40 namespace imports are never written up as 20. (The `head -N` on the
+`ls -lhS` / `du | sort -rh` commands above is different: those are size-sorted, so truncating
+genuinely keeps the largest.)
 
 ```bash
 # Namespace imports (import * as X) — barrel imports that pull in everything
@@ -266,7 +270,11 @@ List each module with size, category (dep / app code), and a one-line note:
 
 ### Actionable Recommendations
 
-List only findings with a concrete fix. Sort by estimated size saving (largest first):
+Sort by estimated size saving (largest first). Report every heavy module you found, not only
+the ones you have a fix for — a 90 KB dependency with no obvious replacement is still the most
+useful thing in the report, and dropping it at write-up time hides the biggest number on the
+page. Put those under a **Known cost, no fix identified** heading with the size and why the
+usual remedies do not apply, so the reader can make their own call.
 
 ```
 ## Critical (>20 KB gzip saving each)
@@ -299,7 +307,7 @@ List only findings with a concrete fix. Sort by estimated size saving (largest f
 ### [smaller items]
 ```
 
-If no actionable findings are found, state that explicitly: "The bundle is well-optimized. No significant savings identified."
+If no actionable findings are found, state that explicitly: "The bundle is well-optimized. No significant savings identified." Say which modules you inspected to reach that conclusion, so "nothing found" is distinguishable from "nothing looked at".
 
 ## Options
 

--- a/packages/plugins/development-codebase-tools/skills/analyze-code/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/analyze-code/SKILL.md
@@ -19,7 +19,11 @@ Provide comprehensive code explanation through multi-agent analysis for architec
    - `overview` — request uses words like "quick", "summary", "briefly", "what does this do"
    - `deep` — request mentions "security", "performance", "vulnerabilities", "thorough", "deep", "comprehensive"
    - `architectural` — request mentions "architecture", "system", "how does this fit", "overall design"
-   - Default to `deep` when depth is ambiguous
+   - **Default to `overview` when depth is ambiguous.** `deep` spawns three agents; running
+     that for "what does this file do" costs three context loads to answer a one-agent
+     question. Escalate to `deep` only on evidence — the user asked for it, `overview`
+     surfaced a concrete security or performance concern, or the target is a trust boundary
+     (auth, payments, external input parsing).
 
 4. **Dispatch agents** based on depth:
 
@@ -48,7 +52,8 @@ Provide comprehensive code explanation through multi-agent analysis for architec
 
 ## Output Includes
 
-- **Summary**: Purpose, complexity, maintainability score
+- **Summary**: Purpose and the concrete complexity signals observed (function count, nesting
+  depth, file length). Do not emit a maintainability score — there is no measurement behind it.
 - **Architecture**: Patterns, layers, coupling analysis
 - **Functionality**: Main purpose, data flow, side effects
 - **Dependencies**: Imports, exports, circular dependencies

--- a/packages/plugins/development-codebase-tools/skills/analyze-code/explain-file-guide.md
+++ b/packages/plugins/development-codebase-tools/skills/analyze-code/explain-file-guide.md
@@ -39,7 +39,7 @@ For simple file explanations, direct delegation:
 
 ```typescript
 {
-  agent: "code-explainer",
+  agent: "code-explainer-agent",
   params: {
     path: parsedPath,
     depth: depth,
@@ -56,15 +56,15 @@ Coordinate multiple specialized agents:
 {
   parallel: [
     {
-      agent: 'code-explainer',
+      agent: 'code-explainer-agent',
       focus: 'architecture-and-patterns',
     },
     {
-      agent: 'security-analyzer',
+      agent: 'security-analyzer-agent',
       focus: 'vulnerability-assessment',
     },
     {
-      agent: 'performance-analyzer',
+      agent: 'performance-analyzer-agent',
       focus: 'complexity-analysis',
     },
   ];
@@ -85,7 +85,9 @@ Full system context analysis:
    - **code-explainer-agent**: Core functionality and patterns
    - **security-analyzer-agent**: Security boundaries and risks
    - **performance-analyzer-agent**: Scalability implications
-   - **refactorer-agent**: Improvement opportunities
+
+   Ceiling: these three plus the context loader. `refactorer-agent` is deliberately not in this
+   set — it is not in `allowed-tools`, so dispatching it would fail.
 
 ## Output Format
 
@@ -94,8 +96,7 @@ Full system context analysis:
   summary: {
     purpose: string; // Primary responsibility
     complexity: 'simple' | 'moderate' | 'complex' | 'highly-complex';
-    loc: number; // Lines of code
-    maintainability: number; // Score 0-100
+    loc: number; // Lines of code (counted, not estimated)
   };
 
   architecture: {
@@ -175,7 +176,10 @@ Full system context analysis:
   };
 
   testing: {
-    coverage: number; // Estimated test coverage
+    // No coverage number. This skill does not run a coverage tool, so any figure here
+    // would be a guess formatted as a measurement. Use the analyze-test-coverage skill
+    // when a real number is needed.
+    hasTests: boolean; // Whether test files for this module were found
     testability: 'high' | 'medium' | 'low';
     suggestedTests: string[]; // Types of tests needed
     mockingStrategy: string; // How to mock dependencies

--- a/packages/plugins/development-codebase-tools/skills/analyze-dead-code/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/analyze-dead-code/SKILL.md
@@ -62,8 +62,15 @@ Ignore lines containing `(used in module)` — those are internal usages. Only r
 **vulture** (Python):
 
 ```bash
-python -m vulture . --min-confidence 80 2>/dev/null
+python -m vulture . 2>/dev/null
 ```
+
+Run vulture at its default confidence. A `--min-confidence` floor drops low-confidence
+candidates before you ever see them, and no wording in this skill can recover a finding the
+tool never emitted. Step 4 already screens false positives by annotating them
+`[review before removing]` rather than deleting them from the report, so filtering at the
+CLI is redundant suppression. Vulture reports a confidence percentage per finding; carry it
+into the report and let it inform the confidence ranking in Step 5.
 
 **deadcode / go vet** (Go):
 

--- a/packages/plugins/development-codebase-tools/skills/analyze-migrations/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/analyze-migrations/SKILL.md
@@ -49,6 +49,13 @@ For ORM-based migrations (Rails, Django, Alembic, TypeORM), translate operations
 
 Analyze each migration for the following patterns. Evaluate against both PostgreSQL and MySQL semantics unless the stack is known.
 
+**The three tables below are a starting checklist, not an allowlist.** They cover the common
+cases; they do not enumerate every way a migration can lock a table or lose data. If a
+migration does something dangerous that no row describes — a stored-procedure change, a
+partition swap, a trigger that rewrites rows, a vendor-specific DDL — report it anyway at the
+severity you judge appropriate and say it was found outside the checklist. A finding you drop
+because it has no matching row is a production incident the report failed to prevent.
+
 ### CRITICAL — causes table locks or data loss
 
 | Pattern                                     | Risk                                                   | Detection                                                                                               |

--- a/packages/plugins/development-codebase-tools/skills/analyze-tech-debt/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/analyze-tech-debt/SKILL.md
@@ -6,7 +6,7 @@ model: opus
 
 # Technical Debt Analyzer
 
-Identify, quantify, and prioritize technical debt with ROI-based remediation plans.
+Identify and prioritize technical debt with evidence-ranked remediation plans.
 
 ## When to Activate
 
@@ -22,7 +22,9 @@ Identify, quantify, and prioritize technical debt with ROI-based remediation pla
 2. **Collect code signals** — Use `Glob` and `Grep` to find: files over 500 lines, deeply nested code (≥4 levels of indentation), `TODO`/`FIXME`/`HACK` comments, and `any` types in TypeScript files.
 3. **Examine git history** — Run `git log --since="6 months ago" --format="%H %s" --stat` to identify high-churn files. Run `git log --oneline --grep="fix\|bug\|hotfix" -- <path>` on suspect files to spot chronic bug areas.
 4. **Assess test presence** — Use `Glob("**/*.test.*")` and `Glob("**/*.spec.*")` to find test files. Cross-reference with source files to identify untested modules. Compute the test-to-source file ratio (test file count / source file count) as a proxy for testing density — not a statement of line coverage.
-5. **Score and prioritize each item** — Assign impact (hours/month lost), effort (hours to fix), and risk (critical/high/medium/low). Compute ROI = (monthly_impact × 12) / effort.
+5. **Rank each item** — Rate impact and effort on a **high / medium / low** band, and risk as critical/high/medium/low. Ground each band in the signals you actually collected (commit count, file size, nesting depth, missing tests), and cite that signal alongside the band.
+
+   Do **not** estimate hours lost per month or hours to fix, and do not compute an ROI number from them. You have no data on this team's velocity; a formula over two invented inputs produces a figure that reads as measured and is not. Rank by band, cite the evidence, and let the reader supply their own effort numbers.
 6. **Write the report** — Output a Debt Metrics Dashboard followed by a Prioritized Roadmap. Categorize items as Quick Wins (high ROI, <4h effort), Medium-Term, or Long-Term.
 
 ## Debt Categories
@@ -53,10 +55,10 @@ Identify, quantify, and prioritize technical debt with ROI-based remediation pla
 
 ## Impact Assessment
 
-Calculates real cost:
+Rate each item against evidence you collected, not against invented cost figures:
 
-- Development velocity impact (hours/month)
-- Quality impact (bug rate, fix time)
+- Velocity impact band (high/medium/low), justified by churn and complexity signals
+- Quality signal: count of fix/bug/hotfix commits touching the file
 - Risk assessment (critical/high/medium/low)
 
 ## Output Format
@@ -80,22 +82,16 @@ test_to_source_ratio:
 
 ### Prioritized Roadmap
 
-- **Quick Wins**: High ROI, <4h effort (Week 1–2)
-- **Medium-Term**: Refactors and feature-level changes (Month 1–3)
-- **Long-Term**: Architecture changes (Quarter 2–4)
+- **Quick Wins**: high impact band, low effort band — single-file, mechanical changes
+- **Medium-Term**: refactors and feature-level changes
+- **Long-Term**: architecture changes
 
 ### Per-Item Format
 
-Each item includes: location, description, estimated effort, monthly velocity savings, ROI %, and recommended fix.
-
-### ROI Calculations
-
-Each item includes:
-
-- Effort estimate
-- Monthly savings
-- ROI percentage
-- Payback period
+Each item includes: location, description, impact band, effort band, the specific signal
+that justifies each band (e.g. "47 commits in 6 months, 12 of them fix commits"), and the
+recommended fix. Cap the roadmap at the 20 highest-impact items and target under 200 lines;
+say how many items were left out so nothing looks hidden.
 
 ## Examples
 

--- a/packages/plugins/development-codebase-tools/skills/analyze-tech-debt/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/analyze-tech-debt/SKILL.md
@@ -22,10 +22,11 @@ Identify and prioritize technical debt with evidence-ranked remediation plans.
 2. **Collect code signals** — Use `Glob` and `Grep` to find: files over 500 lines, deeply nested code (≥4 levels of indentation), `TODO`/`FIXME`/`HACK` comments, and `any` types in TypeScript files.
 3. **Examine git history** — Run `git log --since="6 months ago" --format="%H %s" --stat` to identify high-churn files. Run `git log --oneline --grep="fix\|bug\|hotfix" -- <path>` on suspect files to spot chronic bug areas.
 4. **Assess test presence** — Use `Glob("**/*.test.*")` and `Glob("**/*.spec.*")` to find test files. Cross-reference with source files to identify untested modules. Compute the test-to-source file ratio (test file count / source file count) as a proxy for testing density — not a statement of line coverage.
-5. **Rank each item** — Rate impact and effort on a **high / medium / low** band, and risk as critical/high/medium/low. Ground each band in the signals you actually collected (commit count, file size, nesting depth, missing tests), and cite that signal alongside the band.
+5. **Rank each item** — Rate impact on a **high / medium / low** band and risk as critical/high/medium/low, then record the change's blast radius: how many files and call sites it touches, whether it changes a public interface, and whether the area has tests. Ground every band in the signals you actually collected (commit count, file size, nesting depth, missing tests), and cite that signal alongside the band.
 
    Do **not** estimate hours lost per month or hours to fix, and do not compute an ROI number from them. You have no data on this team's velocity; a formula over two invented inputs produces a figure that reads as measured and is not. Rank by band, cite the evidence, and let the reader supply their own effort numbers.
-6. **Write the report** — Output a Debt Metrics Dashboard followed by a Prioritized Roadmap. Categorize items as Quick Wins (high ROI, <4h effort), Medium-Term, or Long-Term.
+
+6. **Write the report** — Output a Debt Metrics Dashboard followed by a Prioritized Roadmap. Group items by the scope of the change each one requires, which you can observe from the code: **Mechanical**, **Structural**, or **Architectural** (defined under Prioritized Roadmap below). Order within each group by impact band. Do not label a group with an ROI or a duration.
 
 ## Debt Categories
 
@@ -60,6 +61,7 @@ Rate each item against evidence you collected, not against invented cost figures
 - Velocity impact band (high/medium/low), justified by churn and complexity signals
 - Quality signal: count of fix/bug/hotfix commits touching the file
 - Risk assessment (critical/high/medium/low)
+- Blast radius: files touched, call sites found, interface changed or not, tests present or not
 
 ## Output Format
 
@@ -82,15 +84,22 @@ test_to_source_ratio:
 
 ### Prioritized Roadmap
 
-- **Quick Wins**: high impact band, low effort band — single-file, mechanical changes
-- **Medium-Term**: refactors and feature-level changes
-- **Long-Term**: architecture changes
+Group by observable blast radius, not by a guessed cost:
+
+- **Mechanical**: contained to one file, no public interface changes, and the area already has
+  tests — the change is a rewrite of existing behavior with a check already in place
+- **Structural**: spans several files or changes an interface, so callers must be updated; state
+  how many call sites you found and whether they are covered by tests
+- **Architectural**: design-level change across modules, or a change to code with no test coverage
+  at all — the shape has to be decided before it can be written
+
+Order within each group by impact band.
 
 ### Per-Item Format
 
-Each item includes: location, description, impact band, effort band, the specific signal
-that justifies each band (e.g. "47 commits in 6 months, 12 of them fix commits"), and the
-recommended fix. Cap the roadmap at the 20 highest-impact items and target under 200 lines;
+Each item includes: location, description, impact band, its group from above, the specific signal
+that justifies both (e.g. "47 commits in 6 months, 12 of them fix commits; 9 call sites, none
+under test"), and the recommended fix. Cap the roadmap at the 20 highest-impact items and target under 200 lines;
 say how many items were left out so nothing looks hidden.
 
 ## Examples

--- a/packages/plugins/development-codebase-tools/skills/analyze-test-coverage/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/analyze-test-coverage/SKILL.md
@@ -58,6 +58,12 @@ Build a table of files with their line coverage %, branch coverage %, and uncove
 
 ## Step 4: Score and Rank Coverage Gaps
 
+**Score every file that produced coverage data.** Do not drop files by a coverage threshold
+before scoring — the whole point of the criticality signals below is to surface the 85%-covered
+file whose uncovered lines are the auth-failure branch. A pre-filter would delete exactly that
+finding before it could be ranked. If `--min-coverage` is supplied, apply it to the ranked
+list at the end of Step 5, and report how many files it removed.
+
 Don't sort by raw line count. Sort by **criticality of what's untested**:
 
 **Criticality signals (check each uncovered file/function for these):**
@@ -120,7 +126,7 @@ Pass the agent:
 | Flag                 | Description                                                     |
 | -------------------- | --------------------------------------------------------------- |
 | `--target <path>`    | Limit analysis to a subdirectory or file                        |
-| `--min-coverage <N>` | Only report files below N% (default: 80)                        |
+| `--min-coverage <N>` | Drop files at or above N% from the final list (default: off)    |
 | `--top <N>`          | How many files to include in the prioritized list (default: 10) |
 | `--fix`              | After reporting, invoke test-writer for the top 3 gaps          |
 | `--skip-run`         | Skip running coverage tools; parse existing reports only        |

--- a/packages/plugins/development-codebase-tools/skills/audit-accessibility/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/audit-accessibility/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Audit UI components and pages for accessibility (a11y) issues. Use when user says "check accessibility", "audit a11y compliance", "find WCAG violations", "is this component accessible", "run an accessibility audit", or "check screen reader support".
-allowed-tools: Read, Grep, Glob, Bash(npx axe:*), Bash(npx pa11y:*), Bash(npx lighthouse:*), Bash(npx jest:*), Bash(node -e:*), Task
+allowed-tools: Read, Grep, Glob, Bash(npx axe:*), Bash(npx pa11y:*), Bash(npx lighthouse:*), Bash(npx jest:*), Bash(node -e:*)
 model: sonnet
 ---
 

--- a/packages/plugins/development-codebase-tools/skills/debug-issue/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/debug-issue/SKILL.md
@@ -79,7 +79,16 @@ value in gathering everything available if you already understand the problem.
 
 ## Step 4: Analyze with debug-assistant-agent
 
-Invoke the `debug-assistant-agent` with the structured context. Format your prompt to the agent as:
+**Fix it yourself and skip this step** when Step 3's evidence already confirmed the hypothesis
+and the fix is contained: a null guard, a typo, a wrong comparison operator, an obviously
+missing await, a stale import. Handing a one-line fix to an agent costs a full context load to
+tell you what you already know. Note in your summary that you diagnosed it directly.
+
+Delegate when the cause is still genuinely open after Step 3, the failure spans components,
+it reproduces only intermittently, or your first fix did not hold.
+
+When you do delegate, invoke the `debug-assistant-agent` with the structured context. Format
+your prompt to the agent as:
 
 ```
 error: <exact error message and type, or "no explicit error — symptom: ...">

--- a/packages/plugins/development-codebase-tools/skills/debug-issue/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/debug-issue/SKILL.md
@@ -107,9 +107,10 @@ note both and proceed with the more likely one — you can revisit if the first 
 
 ## Step 5: Apply and Validate
 
-Apply the agent's recommended fix, then confirm it works:
+Apply the fix, then confirm it works. The fix is whichever Step 4 produced: your own, if you
+diagnosed it directly, or the agent's recommendation, if you delegated.
 
-1. Make the code changes the agent recommended (Edit/Write the affected files).
+1. Make the code changes (Edit/Write the affected files).
 2. Run the relevant test or reproduce the original trigger.
 3. If the error is gone, summarize for the user:
    - Root cause in plain language

--- a/packages/plugins/development-codebase-tools/skills/diagram-excalidraw/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/diagram-excalidraw/SKILL.md
@@ -12,9 +12,10 @@ Generate valid `.excalidraw` JSON files representing system architecture from co
 
 Works without existing diagrams, Terraform, or specific file types. Analyzes any codebase structure. If the codebase has more than ~30 distinct components, limit scope to top-level packages or services only to keep the diagram readable.
 
-## Critical Implementation Rules
+## Implementation Constraints
 
-**Four non-negotiable constraints:**
+These are the constraints for this skill, stated once. Apply them while generating; they are
+not repeated as a checklist afterward.
 
 1. **No Diamond Shapes**: Diamond arrow connections are broken in raw Excalidraw JSON. Use styled rectangles instead:
 
@@ -33,10 +34,17 @@ Works without existing diagrams, Terraform, or specific file types. Analyzes any
    - `"roughness": 0`
 
 4. **Edge Positioning**: Arrows must start/end at shape edges, not centers:
+
    - Top: `(x + width/2, y)`
    - Bottom: `(x + width/2, y + height)`
    - Left: `(x, y + height/2)`
    - Right: `(x + width, y + height/2)`
+
+5. **Unique element IDs**, and every label needs both halves of the binding in rule 2.
+
+The output is a JSON file, so the one check worth doing is the one you cannot do from memory:
+confirm the written file parses. Everything else above is a generation-time constraint, not a
+post-hoc review item.
 
 ## Generation Workflow
 
@@ -45,7 +53,7 @@ Works without existing diagrams, Terraform, or specific file types. Analyzes any
 3. **Generate shape elements** - Create rectangles, ellipses, text labels; derive element IDs from component names (e.g., `api-server`, `api-server-text`) and verify all IDs are unique
 4. **Add connection arrows** - Connect components with proper edge positioning
 5. **Apply grouping** - Group related elements (namespaces, services, etc.)
-6. **Validate and write output** - Check all constraints before writing file
+6. **Write the output file** - then confirm it parses as JSON
 
 ## Input Parsing
 
@@ -66,16 +74,6 @@ Generate a valid `.excalidraw` JSON file with:
 - Correct arrow connections at shape edges
 - Logical groupings with dashed rectangles
 
-## Validation Checklist
-
-Before writing output, verify:
-
-- [ ] No duplicate element IDs
-- [ ] All labels have proper shape-text bindings
-- [ ] No diamond shapes used
-- [ ] All arrows positioned at shape edges
-- [ ] JSON is valid and properly formatted
-
 ## Reference Documentation
 
 For detailed implementation guidance, see:
@@ -84,4 +82,4 @@ For detailed implementation guidance, see:
 - [Arrow Routing Guide](references/arrows.md) - Arrow positioning and patterns
 - [Color Palettes](references/colors.md) - Component type color schemes
 - [Examples](references/examples.md) - Layout patterns and templates
-- [Validation Rules](references/validation.md) - Pre-output verification
+- [Validation Rules](references/validation.md) - Debugging a diagram that renders wrong

--- a/packages/plugins/development-codebase-tools/skills/diagram-excalidraw/references/validation.md
+++ b/packages/plugins/development-codebase-tools/skills/diagram-excalidraw/references/validation.md
@@ -1,8 +1,11 @@
 # Validation Reference
 
-Pre-output verification rules and debugging strategies.
+Debugging strategies for diagrams that render wrong, plus an executable statement of the
+constraints from SKILL.md. The constraints themselves live in SKILL.md and are not restated
+here as a checklist — read this file when something is broken, not as a routine post-write
+review pass.
 
-## Pre-Flight Validation Algorithm
+## Validation Algorithm
 
 ```javascript
 function validateDiagram(elements) {
@@ -68,35 +71,6 @@ function findShapeNear(elements, x, y, tolerance = 15) {
   );
 }
 ```
-
-## Checklists
-
-### Pre-Generation
-
-- [ ] Identified all components from codebase
-- [ ] Selected appropriate layout pattern
-- [ ] Established naming scheme for IDs
-- [ ] Determined color palette based on component types
-
-### During Generation
-
-- [ ] Created shape for each component
-- [ ] Added text element for each label
-- [ ] Set up boundElements references on shapes
-- [ ] Set containerId on text elements
-- [ ] Created arrows with proper bindings
-- [ ] Applied elbowed/roughness/roundness to arrows
-- [ ] Positioned arrows at shape edges (not centers)
-
-### Post-Generation
-
-- [ ] All IDs are unique
-- [ ] All text elements have valid containerId references
-- [ ] All shapes with labels have boundElements array
-- [ ] No diamond shapes present
-- [ ] All arrows have proper edge positioning
-- [ ] JSON is valid (parseable)
-- [ ] File has .excalidraw extension
 
 ## Common Bugs and Fixes
 

--- a/packages/plugins/development-codebase-tools/skills/explore-codebase/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/explore-codebase/SKILL.md
@@ -20,8 +20,22 @@ Build comprehensive understanding of codebase areas before implementation or to 
 ## Quick Process
 
 1. **Parse the request** — extract `topic`, `files` (optional), and `focus` (optional) from the user's message
-2. **Delegate** — invoke context-loader-agent with the extracted parameters
-3. **Present findings** — format the agent output using the Output Format section below
+2. **Answer directly if you can** — see When NOT to Delegate below
+3. **Delegate** — if the question genuinely spans a subsystem, invoke context-loader-agent with the extracted parameters
+4. **Present findings** — format the agent output using the Output Format section below
+
+## When NOT to Delegate
+
+Answer with your own Grep/Glob/Read and skip the agent when:
+
+- The question is a locate ("where is the API rate limiting implemented?") — that is one Grep,
+  and several of the examples below fall in this bucket.
+- The user named specific files and wants those explained.
+- One or two files answer it end to end.
+
+Delegate only when the answer requires tracing across a subsystem: multi-file data flow,
+architecture of a module you have not read, or "understand X before I change it" where X spans
+several directories.
 
 ## Input Parsing
 
@@ -42,6 +56,10 @@ Invoke **context-loader-agent** and pass the extracted parameters:
 The agent handles file discovery, dependency tracing, pattern identification, and analysis.
 
 ## Output Format
+
+This output is fed into `/plan` as context, so its length is charged to a later session too.
+Target **under 100 lines**. Include only sections you have something concrete for, and drop
+the rest rather than padding them.
 
 Return structured analysis:
 

--- a/packages/plugins/development-codebase-tools/skills/mermaid-diagram/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/mermaid-diagram/SKILL.md
@@ -119,18 +119,6 @@ subgraph "Backend Services"
 subgraph Backend Services
 ```
 
-### 9. Validate Before Presenting
-
-Trace through the diagram to confirm:
-
-- Every node on its own line with unique alphanumeric ID
-- No chained arrows
-- Special-character labels double-quoted
-- No HTML/Markdown in labels
-- Comments on own lines
-- Styles reference defined nodes only
-- Subgraph names quoted or underscored
-
 ## Diagram Type Quick Reference
 
 | Type      | Directive                       | Use For                            |
@@ -180,6 +168,8 @@ When asked to fix a broken Mermaid diagram:
 1. **Identify the error type** — parse errors almost always come from one of: chained arrows, unquoted special characters, bare subgraph names, or HTML in labels.
 2. **Apply the relevant rules above** — check each rule against the broken code line by line.
 3. **Rewrite the offending lines** — fix only what is broken; preserve the diagram's intent.
-4. **Re-validate** using the checklist in Rule 9 before presenting the corrected diagram.
+4. **Say what you changed and why**, naming the rule each fix applies. This skill has no
+   renderer, so state that the corrected diagram is unverified rather than implying it was
+   checked.
 
 If the diagram is structurally ambiguous (missing nodes, unclear relationships), ask one clarifying question before rewriting.

--- a/packages/plugins/development-codebase-tools/skills/refactor-code/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/refactor-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Refactor code with safety checks and pattern application. Use when user says "refactor this code", "clean up this function", "simplify this logic", "extract this into a separate function", "apply the strategy pattern here", "reduce the complexity of this module", or "reorganize this file structure".
-allowed-tools: Read, Edit, Write, Grep, TodoWrite, Bash(git diff:*), Bash(git show:*), Task(subagent_type:refactorer-agent), Task(subagent_type:style-enforcer-agent), Task(subagent_type:code-explainer-agent), Task(subagent_type:test-writer-agent)
+allowed-tools: Read, Edit, Write, Glob, Grep, TodoWrite, Bash(git diff:*), Bash(git show:*), Bash(git status:*), Bash(npm test:*), Bash(npm run:*), Bash(yarn:*), Bash(pnpm:*), Bash(bun run:*), Bash(bun test:*), Bash(npx nx:*), Bash(npx vitest:*), Bash(npx jest:*), Bash(npx tsc:*), Bash(npx eslint:*), Bash(npx prettier:*), Bash(python -m pytest:*), Bash(go test:*), Bash(go build:*), Bash(cargo test:*), Bash(cargo fmt:*), Bash(mvn:*), Bash(gradle:*), Bash(./gradlew:*), Task(subagent_type:refactorer-agent), Task(subagent_type:style-enforcer-agent), Task(subagent_type:code-explainer-agent), Task(subagent_type:test-writer-agent)
 model: claude-opus-5
 ---
 
@@ -30,14 +30,20 @@ a structural pattern across a module.
 
 1. **Understand scope** — Read the target file(s). Run `git diff HEAD` to see any uncommitted state. Dispatch `code-explainer-agent` only if the target's behavior is unclear after reading it.
 2. **Create a task plan** — Use TodoWrite when the refactor has more than about three steps; skip it for a single edit.
-3. **Dispatch refactorer-agent** *(multi-file or structural refactors only)* — Pass:
+3. **Dispatch refactorer-agent** _(multi-file or structural refactors only)_ — Pass:
    - `paths`: file(s) or globs to refactor
    - `goals`: e.g., `["readability", "maintainability"]` (or user-specified goal from Goals table below)
    - `refactor_depth`: `"surface"` | `"moderate"` | `"deep"` based on strategy
    - `risk_tolerance`: `"low"` | `"medium"` | `"high"` matching the strategy
 4. **Apply patches** — Write the refactored code to disk. Apply incrementally — one logical change at a time.
-5. **Enforce style** — Run the project's own formatter and linter. Dispatch `style-enforcer-agent` only when the project has no configured formatter, or the refactor touched enough files that a convention drift is plausible.
-6. **Validate** — Run the tests covering the touched code, then `git diff HEAD` to review the final changes. Confirm behavior is preserved.
+5. **Enforce style** — Run the project's own formatter and linter (the runner prefixes in `allowed-tools` cover the common ones; read `package.json` scripts or the equivalent manifest to find the right command). Dispatch `style-enforcer-agent` only when the project has no configured formatter, or the refactor touched enough files that a convention drift is plausible.
+6. **Validate — mandatory, never skipped** — A refactor is not done until behavior preservation has been checked by something other than reading your own diff. Exactly one of these must run and pass:
+
+   - **Preferred**: run the tests covering the touched code. If the suite is large, run the narrowest command that exercises the changed files.
+   - **Fallback, when no test covers the touched code**: dispatch `code-explainer-agent` on the before/after pair and have it state, per changed function, whether observable behavior is identical. This is not optional — it is what replaces the test run, not an addition to it.
+
+   Then run `git diff HEAD` and review the final changes. Report which of the two checks ran and its result. If neither could run, say so explicitly and mark the refactor unverified rather than complete.
+
 7. **Generate tests** — Dispatch `test-writer-agent` only when the refactored code had no test coverage to begin with. Existing passing tests are the behavior-preservation check; adding more is not.
 
 ## Goals

--- a/packages/plugins/development-codebase-tools/skills/refactor-code/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/refactor-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Refactor code with safety checks and pattern application. Use when user says "refactor this code", "clean up this function", "simplify this logic", "extract this into a separate function", "apply the strategy pattern here", "reduce the complexity of this module", or "reorganize this file structure".
-allowed-tools: Read, Edit, Write, Grep, TodoWrite, Bash(git diff:*), Bash(git show:*), Task(subagent_type:refactorer-agent), Task(subagent_type:style-enforcer-agent), Task(subagent_type:code-explainer-agent), Task(subagent_type:test-writer-agent), Task(subagent_type:agent-orchestrator-agent)
+allowed-tools: Read, Edit, Write, Grep, TodoWrite, Bash(git diff:*), Bash(git show:*), Task(subagent_type:refactorer-agent), Task(subagent_type:style-enforcer-agent), Task(subagent_type:code-explainer-agent), Task(subagent_type:test-writer-agent)
 model: claude-opus-5
 ---
 
@@ -16,19 +16,29 @@ Orchestrate sophisticated refactoring through multi-agent coordination with safe
 | **Aggressive**     | Medium | Comprehensive restructuring with tests |
 | **Architectural**  | High   | System-wide pattern application        |
 
+## Sizing the Work First
+
+Every dispatch below is conditional. "Clean up this function" is one file and one edit — do it
+directly with Read and Edit, then run the project's formatter and tests. Three agent dispatches
+for a single-function tidy-up costs three context loads to produce work you could have done in
+two tool calls.
+
+Dispatch agents when the refactor spans multiple files, changes a public interface, or applies
+a structural pattern across a module.
+
 ## Execution Steps
 
-1. **Understand scope** — Read the target file(s). Run `git diff HEAD` to see any uncommitted state. Use `code-explainer-agent` if the codebase context is complex.
-2. **Create a task plan** — Use TodoWrite to list the refactoring tasks before starting.
-3. **Dispatch refactorer-agent** — Pass:
+1. **Understand scope** — Read the target file(s). Run `git diff HEAD` to see any uncommitted state. Dispatch `code-explainer-agent` only if the target's behavior is unclear after reading it.
+2. **Create a task plan** — Use TodoWrite when the refactor has more than about three steps; skip it for a single edit.
+3. **Dispatch refactorer-agent** *(multi-file or structural refactors only)* — Pass:
    - `paths`: file(s) or globs to refactor
    - `goals`: e.g., `["readability", "maintainability"]` (or user-specified goal from Goals table below)
    - `refactor_depth`: `"surface"` | `"moderate"` | `"deep"` based on strategy
    - `risk_tolerance`: `"low"` | `"medium"` | `"high"` matching the strategy
-4. **Apply patches** — Write the refactored code to disk using the patches returned by refactorer-agent. Apply incrementally — one logical change at a time.
-5. **Enforce style** — Dispatch `style-enforcer-agent` on the modified files.
-6. **Validate** — Run `git diff HEAD` to review the final changes. Confirm behavior is preserved.
-7. **Generate tests** (if not already covered) — Dispatch `test-writer-agent` to add regression tests for refactored code.
+4. **Apply patches** — Write the refactored code to disk. Apply incrementally — one logical change at a time.
+5. **Enforce style** — Run the project's own formatter and linter. Dispatch `style-enforcer-agent` only when the project has no configured formatter, or the refactor touched enough files that a convention drift is plausible.
+6. **Validate** — Run the tests covering the touched code, then `git diff HEAD` to review the final changes. Confirm behavior is preserved.
+7. **Generate tests** — Dispatch `test-writer-agent` only when the refactored code had no test coverage to begin with. Existing passing tests are the behavior-preservation check; adding more is not.
 
 ## Goals
 

--- a/packages/plugins/development-codebase-tools/skills/strengthen-types/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/strengthen-types/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Audit and harden TypeScript type safety by finding and fixing weak typing patterns. Always use this skill whenever the user says "strengthen types", "improve TypeScript types", "fix any types", "type safety audit", "remove any from the codebase", "tighten TypeScript", "find unsafe casts", "harden types", "type hardening", "clean up TypeScript types", "get rid of type assertions", "fix non-null assertions", "improve type coverage", "find implicit any", "type-safe refactor", "add missing return types", "reduce ts-ignore", "eliminate type suppression", "TypeScript strict mode cleanup", "fix weak types", "find type holes", "our types are too loose", or any request to make the codebase more type-safe. Also trigger when the user is migrating to strict mode, preparing to enable `noImplicitAny` or `strictNullChecks`, or doing a type-quality pass before a major release.
-allowed-tools: Read, Glob, Grep, Bash(npx tsc:*), Bash(npx eslint:*), Bash(npm run:*), Bash(find:*), Bash(git diff:*), Task
+allowed-tools: Read, Glob, Grep, Bash(npx tsc:*), Bash(npx eslint:*), Bash(npm run:*), Bash(find:*), Bash(git diff:*)
 model: sonnet
 ---
 
@@ -64,6 +64,13 @@ Run targeted grep searches to find each category. Search within the source direc
 Infer the source root from `tsconfig.json#include` / `tsconfig.json#rootDir`, or default to `src/`.
 
 ### Pattern inventory
+
+Every listing command below ends in `head -20` or `head -30`. That truncation is for
+readability of the listing only — it is **not** a finding filter. For each category, run the
+same pipeline again with `| wc -l` instead of `| head -N` and record the true total, so a
+category with 400 `any` occurrences is never reported as 30. Carry both numbers into the
+Step 5 summary table (`shown / total`), and if total > shown, say so explicitly rather than
+letting the truncated list read as complete.
 
 **Explicit `any`** — the most common type escape hatch:
 
@@ -181,6 +188,10 @@ MEDIUM    │        N │             M
 LOW       │        N │             M
 ──────────┼──────────┼───────────────
 Total     │        N │             M
+
+Pattern totals (from wc -l, not the truncated listings):
+  explicit any: N   as-casts: N   non-null: N   suppressions: N
+  broad params: N   missing return types: N
 
 tsconfig strictness: [strict: off] [noImplicitAny: off] [strictNullChecks: on]
 Baseline tsc errors: N

--- a/packages/plugins/development-codebase-tools/skills/strengthen-types/SKILL.md
+++ b/packages/plugins/development-codebase-tools/skills/strengthen-types/SKILL.md
@@ -68,21 +68,34 @@ Infer the source root from `tsconfig.json#include` / `tsconfig.json#rootDir`, or
 Every listing command below ends in `head -20` or `head -30`. That truncation is for
 readability of the listing only — it is **not** a finding filter. For each category, run the
 same pipeline again with `| wc -l` instead of `| head -N` and record the true total, so a
-category with 400 `any` occurrences is never reported as 30. Carry both numbers into the
-Step 5 summary table (`shown / total`), and if total > shown, say so explicitly rather than
+category with 400 `any` occurrences is never reported as 30.
+
+**Both halves of `shown / total` must be the same unit — occurrences.** The listing pipelines
+below all use `grep -rn` without `-l`, so each output line is one occurrence, and `wc -l` on the
+untruncated pipeline counts occurrences too. Never pair a `-l` (one line per file) listing with
+an occurrence count; that reads as "30 of 400" when it is really 30 files of 400 occurrences.
+File counts are a separate, separately-labeled number. Carry `occurrences shown / occurrences
+total` into the Step 5 summary table, and if total > shown, say so explicitly rather than
 letting the truncated list read as complete.
 
 **Explicit `any`** — the most common type escape hatch:
 
 ```bash
 grep -rn ": any\b\|<any>\|Array<any>\|Promise<any>\|Record<string, any>" \
-  src/ --include="*.ts" --include="*.tsx" -l | head -30
+  src/ --include="*.ts" --include="*.tsx" | head -30
 ```
 
-Count total occurrences separately from file count:
+Total occurrences (same pipeline, untruncated):
 
 ```bash
 grep -rn ": any\b\|<any>\|Array<any>\|Promise<any>\|Record<string, any>" \
+  src/ --include="*.ts" --include="*.tsx" | wc -l
+```
+
+Files affected — a distinct number, reported under its own label, never as the `total` above:
+
+```bash
+grep -rl ": any\b\|<any>\|Array<any>\|Promise<any>\|Record<string, any>" \
   src/ --include="*.ts" --include="*.tsx" | wc -l
 ```
 
@@ -189,9 +202,14 @@ LOW       │        N │             M
 ──────────┼──────────┼───────────────
 Total     │        N │             M
 
-Pattern totals (from wc -l, not the truncated listings):
-  explicit any: N   as-casts: N   non-null: N   suppressions: N
-  broad params: N   missing return types: N
+Pattern totals — OCCURRENCES (from wc -l on the untruncated listing pipeline),
+reported as "shown / total" where both halves are occurrence counts:
+  explicit any: S/N   as-casts: S/N   non-null: S/N   suppressions: S/N
+  broad params: S/N   missing return types: S/N
+
+Files affected per pattern (grep -rl | wc -l) — a different unit, never mixed
+into the shown/total pair above:
+  explicit any: M   as-casts: M   non-null: M   suppressions: M
 
 tsconfig strictness: [strict: off] [noImplicitAny: off] [strictNullChecks: on]
 Baseline tsc errors: N


### PR DESCRIPTION
Applies the Opus 5 config-migration audit to `development-codebase-tools` — 10 agents, 13 skills, 2 reference guides, and the plugin's own docs. Every `.md` under the plugin was read in full. No other plugin touched.

## The highest-leverage fix: `CLAUDE.md` documented `subagent_type` wrong

The plugin's `CLAUDE.md` said:

```
Cross-plugin delegation uses `Task(subagent_type:plugin-name:skill-name)`
```

**`subagent_type` names an AGENT, never a skill.** Skills aren't dispatchable through `Task` at all — they're slash commands. This one line is why other files in the marketplace picked up the wrong cross-plugin syntax, so it matters beyond this plugin. Corrected to `plugin-name:agent-name`, with the added detail that the value must match an agent's frontmatter `name:` (not its filename — `agents/context-loader.md` declares `name: context-loader-agent`), plus the enumeration command so the next person checks instead of guessing.

## Changes by delta

### Delta 1 — Opus 5 self-verifies, so ceremony is dead weight

- **`mermaid-diagram`**: Rule 9 restated Rules 1-8 verbatim as a trailing self-check. With `allowed-tools: []` there's no renderer, so it could not verify anything — it was a re-read of just-written output. Removed. The "Fixing Broken Diagrams" step that referenced it now states plainly that the corrected diagram is unverified.
- **`diagram-excalidraw`**: the same constraints appeared in three layers (upfront rules, a SKILL.md Validation Checklist, and Pre/During/Post-Generation checklists in `references/validation.md`). Collapsed to the single upfront statement, folding in the two constraints only the checklists carried. Kept the one real check — does the written JSON parse — since that is grounding, not self-review.
- **`code-generator-agent`**: dropped the "re-read every generated file and verify" pass; the standards now apply while writing. Noted that this agent has no `Bash`, so it must name the checks the caller should run rather than implying it ran them.
- **`performance-analyzer-agent`**: deleted the 15-item deliverables checklist, which mandated a completeness sweep.

**Kept as grounding** (constrains claims against reality, unlike re-reading your own work): `debug-assistant`'s "reproduce before fixing"; `pattern-learner`/`refactorer`'s "3+ examples before calling it a pattern"; `strengthen-types`' post-mutation `tsc --noEmit`.

### Delta 2 — ceilings instead of floors, plus when-NOT-to-delegate

- **`agent-orchestrator-agent`**: added hard ceilings stated *as* ceilings (4 per parallel group, 8 dispatches per run, 2 levels of recursion, 1 meta-agent) and a when-NOT-to-delegate section. Softened "Launch all agents simultaneously… Maximum efficiency, minimum time", "Maximize parallel execution opportunities", and "Recursive Decomposition… Handles arbitrary depth". The meta-agent fleet was gated only on "when possible"; it is now opt-in and capped at 1.
- **`explore-codebase`**: delegated unconditionally, though its own advertised example ("where is the API rate limiting implemented?") is a single Grep. Now conditional.
- **`debug-issue`** Step 4, **`refactor-code`** (3 unconditional dispatches for "clean up this function"): now conditional.
- **`analyze-code`**: defaulted ambiguous depth to `deep`, the three-agent path. Now defaults to the one-agent `overview` and escalates on evidence. This also resolves a disagreement — `explain-file-guide.md` already documented `default: overview`.
- Dropped unused `Task` grants: bare `Task` from `audit-accessibility` and `strengthen-types` (neither body mentions delegation), and `agent-orchestrator-agent` from `refactor-code` (never dispatched).

### Delta 3 — coverage first, filter downstream

- **`analyze-dead-code`**: `vulture --min-confidence 80` filtered below the prompt layer entirely — unreachable by any wording. Removed. Step 4 already annotates false positives rather than dropping them, so the CLI floor was redundant suppression.
- **`analyze-test-coverage`**: `--min-coverage 80` ran *before* the criticality scoring that exists to catch the 85%-covered file whose uncovered lines are the auth branch. Default is now off and it applies after ranking.
- **`strengthen-types`**: 7 grep categories truncated with `head -N`, only one counted. Added companion `wc -l` totals and a `shown / total` line in the report. Same fix for `analyze-bundle`'s tree-shaking greps (its `ls -lhS` truncations are size-sorted and left alone).
- **`analyze-bundle`**: "List only findings with a concrete fix" dropped the biggest number on the page — a 90 KB dependency with no replacement. Now reported under "Known cost, no fix identified".
- **`analyze-migrations`**: its three pattern tables read as an exhaustive allowlist; now stated as a checklist, with instructions to report dangerous patterns found outside it. **Kept** the 20-most-recent scope cap (a scope choice, not a finding filter).
- Stripped decorative `CRITICAL` emphasis from `style-enforcer`.

### Invented numbers

- **`analyze-tech-debt`**: `ROI = (monthly_impact × 12) / effort` — three layers of arithmetic over two fabricated seeds ("hours/month lost", "hours to fix"), mandated as required output. Replaced with impact/effort **bands that must cite the signal justifying them** (commit count, file size, nesting depth).
- **`agent-orchestrator`**: confidence percentages about its own judgment → qualitative Strong/Partial/Weak. "Overall Confidence: [0-100%]", "Coverage: [Percentage]", and "Execution Efficiency: [Parallel speedup]" → observed lists and counts.
- **`security-analyzer`**: "Estimated security debt in hours" removed.
- **`explain-file-guide`**: `maintainability: number // Score 0-100` removed; `coverage: number // Estimated test coverage` → `hasTests: boolean`, pointing at `analyze-test-coverage` when a real number is wanted.
- **`analyze-code`**: "maintainability score" → the concrete complexity signals actually observed.

**Kept** (inputs are measured, which is the whole test): `analyze-test-coverage`'s `(100 - line_coverage) * 0.5 + …`, fed by real coverage output; `pattern-learner`'s "90% of files follow X", which is countable.

### Delta 4 — length only comes down when asked

Added explicit length lines, prioritized by whether the output feeds another agent's context: `context-loader-agent` and `explore-codebase` (its output is input to `/plan`) capped at 100 lines; then `agent-orchestrator`, `debug-assistant` (was mandating a monitoring plan for a typo fix), `performance-analyzer`, `security-analyzer` (was producing a 6-month roadmap even on a `targeted` scope), `style-enforcer` (per-violation blocks over a `full-codebase` default), `pattern-learner`, `analyze-tech-debt`.

**Kept**: `code-explainer`'s "a 30-line utility gets a short explanation".

### Broken references

- `agent-capability-analyst` was referenced **twice** in `agent-orchestrator.md` and does not exist in any agent's frontmatter `name:` anywhere in the marketplace — it would fail at dispatch. Removed, along with the fabricated `Agent Optimizer` meta-agent. `Prompt Engineer` and `Pattern Learner` are real and now carry their actual dispatch names.
- `explain-file-guide.md` dispatched `code-explainer` / `security-analyzer` / `performance-analyzer` without the `-agent` suffix — three names that resolve to nothing. Fixed. It also listed `refactorer-agent` in the architectural path while `refactorer-agent` is absent from its `allowed-tools`, so that dispatch would have been blocked; removed with a note explaining why.

## Version bump

MINOR, `2.6.3` → `2.7.0`.

**The two sources disagreed before this PR**: `plugin.json` was already at `2.6.3` while the root `CLAUDE.md` table still read `2.6.2`. Both now read `2.7.0`. Also added the missing `hooks/hooks.json` to the plugin CLAUDE.md file tree.

## Findings in the brief that do not exist here

Reported rather than fixed, since inventing a fix would be worse than saying so:

- **`references/analysis-rubric.md`** ("don't invent problems") — not in this plugin. `find` locates exactly one copy, in **`skill-management`**: `packages/plugins/skill-management/skills/skill-doctor/references/analysis-rubric.md`. The phrase "invent problems" appears nowhere under `development-codebase-tools`.
- **`agents/agent-tester.md`** (coverage ratios with unknowable denominators) — lives in **`development-productivity`**, not here.

## Test plan

**1. Every agent dispatch name in the marketplace** (27 agents; dispatch name is frontmatter `name:`, never the filename):

```
$ find packages/plugins -path '*/agents/*.md' -exec sh -c 'printf "%s -> " "$(basename $1)"; grep -m1 "^name:" "$1"' _ {} \;
agent-orchestrator.md -> agent-orchestrator-agent
agent-tester.md -> agent-tester-agent
cicd-agent.md -> cicd-agent
claude-docs-initializer.md -> claude-docs-initializer-agent
code-explainer.md -> code-explainer-agent
code-generator.md -> code-generator-agent
comment-resolver.md -> comment-resolver-agent
commit-message-generator.md -> commit-message-generator-agent
context-loader.md -> context-loader-agent
debug-assistant.md -> debug-assistant-agent
documentation.md -> documentation-agent
execute-plan.md -> execute-plan-agent
infrastructure-agent.md -> infrastructure-agent
migration-assistant.md -> migration-assistant-agent
pattern-learner.md -> pattern-learner-agent
performance-analyzer.md -> performance-analyzer-agent
plan-reviewer.md -> plan-reviewer-agent
planner.md -> planner-agent
pr-creator.md -> pr-creator-agent
prompt-engineer.md -> prompt-engineer-agent
refactorer.md -> refactorer-agent
researcher.md -> researcher-agent
review-executor.md -> review-executor-agent
security-analyzer.md -> security-analyzer-agent
stack-splitter.md -> stack-splitter-agent
style-enforcer.md -> style-enforcer-agent
test-writer.md -> test-writer-agent
```

**2. Every `subagent_type` this plugin dispatches resolves to a real agent:**

```
$ comm -23 <dispatched names> <real agent names>
agent-name
plugin-name:agent-name
```

Only the two documentation placeholders in `CLAUDE.md` remain unmatched, which is correct — they are syntax templates. All 8 real dispatches (`code-explainer-agent`, `context-loader-agent`, `debug-assistant-agent`, `performance-analyzer-agent`, `refactorer-agent`, `security-analyzer-agent`, `style-enforcer-agent`, `test-writer-agent`) resolve.

**3. No fabricated references or stale facts remain:**

```
$ grep -rniE 'agent-capability-analyst|agent-optimizer|claude-agent-discovery|mcp__nx_mcp__|MultiEdit|budget_tokens|claude-haiku' packages/plugins/development-codebase-tools/
(no matches)
```

The only `80%` left is `performance-analyzer.md:184`, the Pareto principle — not a stale pricing claim.

**4. Plugin validation:**

```
$ node scripts/validate-plugin.cjs packages/plugins/development-codebase-tools
  ✓ plugin.json: development-codebase-tools v2.7.0
  ✓ package.json: @uniswap/development-codebase-tools
  ✓ project.json: development-codebase-tools
  ✓ skills/: 13 item(s)
  ✓ agents/: 10 item(s)
  ✓ hooks/: 2 item(s)
Validation PASSED
```

**5. Format and markdown lint:**

```
$ bunx nx format:write --uncommitted
$ bunx markdownlint-cli2 --fix "packages/plugins/development-codebase-tools/**/*.md"
Linting: 200 file(s)
Summary: 0 error(s)
```

## Decisions left open

Two items are genuine judgment calls and were deliberately **not** resolved:

1. **`security-analyzer.md:110` — the CVSS business-impact multiplier.** "Apply business impact multipliers (revenue/reputation/regulatory/data sensitivity: 1.0-2.0x)." CVSS 3.1 itself is a real published rubric with defined inputs, and it stays. The multiplier is different: it takes a real CVSS base score and scales it by a factor nobody measured, producing a number that still *looks* like CVSS. Removing it loses genuine prioritization signal; keeping it launders a guess through a credible-looking score. Left as-is.
2. **`debug-assistant.md:29` — the 0–1 confidence score on root-cause hypotheses.** Ranking competing hypotheses is real and useful, and `debug-issue` Step 4 consumes the ranking to pick which fix to try. But a numeric 0–1 score implies a calibration that does not exist, and "0.85" is not more informative than "most likely". A qualitative ranking would preserve the ordering without the false precision. Left as-is; `debug-issue`'s wording still refers to confidence scores, so the two move together.

Also worth a decision, though outside the brief's explicit list: `model:` frontmatter across this plugin mixes pinned ids (`claude-opus-5`, `claude-sonnet-5`) with self-updating aliases (`opus`, `sonnet`). Aliases are generally preferable since they track model releases. Not changed — `model:` and `effortLevel` are yours to set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

Applies the Opus 5 config-migration audit to `development-codebase-tools` — 10 agents, 13 skills, 2 reference guides, and the plugin's own docs. No other plugin touched.
## Headline: `CLAUDE.md` documented `subagent_type` wrong
The plugin's `CLAUDE.md` said cross-plugin delegation uses `Task(subagent_type:plugin-name:skill-name)`.
**`subagent_type` names an AGENT, never a skill.** Skills aren't dispatchable through `Task` at all — they're slash commands. That one line is why other files in the marketplace picked up the wrong syntax, so it matters beyond this plugin. Corrected to `plugin-name:agent-name`, with the detail that the value must match an agent's frontmatter `name:` and not its filename (`agents/context-loader.md` declares `name: context-loader-agent`), plus the enumeration command so the next person checks instead of guessing.
## Changes by delta
### Delta 1 — Opus 5 self-verifies, so ceremony is dead weight
- **`mermaid-diagram`**: Rule 9 restated Rules 1–8 verbatim as a trailing self-check. With `allowed-tools: []` there is no renderer, so it verified nothing — it was a re-read of just-written output. Removed; the "Fixing Broken Diagrams" step now states plainly that the corrected diagram is unverified.
- **`diagram-excalidraw`**: the same constraints appeared in three layers (upfront rules, a SKILL.md Validation Checklist, and Pre/During/Post-Generation checklists in `references/validation.md`). Collapsed to the single upfront statement, folding in the two constraints only the checklists carried. Kept the one real check — does the written JSON parse.
- **`code-generator-agent`**: dropped the "re-read every generated file and verify" pass; the standards now apply while writing. Added that this agent has no `Bash`, so it must name the checks the caller should run rather than implying it ran them.
- **`performance-analyzer-agent`**: deleted the 15-item deliverables checklist that mandated a completeness sweep.
**Kept as grounding** (constrains claims against reality, unlike re-reading your own work): `debug-assistant`'s "reproduce before fixing"; `pattern-learner`/`refactorer`'s "3+ examples before calling it a pattern"; `strengthen-types`' post-mutation `tsc --noEmit`.
### Delta 2 — ceilings instead of floors, plus when-NOT-to-delegate
- **`agent-orchestrator-agent`**: ceilings stated *as* ceilings (4 per parallel group, 8 dispatches per run, 2 levels of recursion, 1 meta-agent) and a when-NOT-to-delegate section. Softened "Launch all agents simultaneously… Maximum efficiency, minimum time", "Maximize parallel execution opportunities", and "Recursive Decomposition… Handles arbitrary depth". The meta-agent fleet was gated only on "when possible"; now opt-in and capped at 1.
- **`explore-codebase`**: delegated unconditionally, though its own advertised example ("where is the API rate limiting implemented?") is a single Grep. Now conditional.
- **`debug-issue`** Step 4 and **`refactor-code`** (3 unconditional dispatches for "clean up this function"): now conditional. `debug-issue` Step 5 no longer assumes the fix came from an agent.
- **`analyze-code`**: defaulted ambiguous depth to `deep`, the three-agent path. Now defaults to one-agent `overview` and escalates on evidence — which also resolves a disagreement, since `explain-file-guide.md` already documented `default: overview`.
- Dropped unused `Task` grants: bare `Task` from `audit-accessibility` and `strengthen-types` (neither body mentions delegation), and `agent-orchestrator-agent` from `refactor-code` (never dispatched).
### Delta 3 — coverage first, filter downstream
- **`analyze-dead-code`**: `vulture --min-confidence 80` filtered below the prompt layer entirely — unreachable by any wording. Removed. Step 4 already annotates false positives rather than dropping them, so the CLI floor was redundant suppression.
- **`analyze-test-coverage`**: `--min-coverage 80` ran *before* the criticality scoring that exists to catch the 85%-covered file whose uncovered lines are the auth branch. Default is now off, applied after ranking, with a count of what it removed.
- **`strengthen-types`**: 7 grep categories truncated with `head -N`, only one counted. Added companion `wc -l` totals plus a `shown / total` line — and an explicit unit rule, since the original paired a `grep -l` file listing with an occurrence count ("30 of 400" that was really 30 files of 400 occurrences).
- **`analyze-bundle`**: same `head -N` fix for the tree-shaking greps (the `ls -lhS` truncations are size-sorted and left alone). "List only findings with a concrete fix" dropped the biggest number on the page — a 90 KB dependency with no replacement — so those now report under "Known cost, no fix identified". A clean result must also say which modules were inspected.
- **`analyze-migrations`**: its three pattern tables read as an exhaustive allowlist; now a checklist, with instructions to report dangerous patterns found outside it. **Kept** the 20-most-recent scope cap (a scope choice, not a finding filter).
- Stripped decorative `CRITICAL` emphasis from `style-enforcer`.
### Invented numbers
- **`analyze-tech-debt`**: `ROI = (monthly_impact × 12) / effort` — three layers of arithmetic over two fabricated seeds ("hours/month lost", "hours to fix"), mandated as required output. Replaced with impact/effort **bands that must cite the signal justifying them** (commit count, file size, nesting depth), and a roadmap grouped Mechanical / Structural / Architectural by observable blast radius instead of by guessed cost.
- **`agent-orchestrator`**: confidence percentages about its own judgment → qualitative Strong/Partial/Weak. "Overall Confidence: [0-100%]", "Coverage: [Percentage]", "Execution Efficiency: [Parallel speedup]" → observed lists and counts.
- **`security-analyzer`**: "Estimated security debt in hours" removed.
- **`explain-file-guide`**: `maintainability: number // Score 0-100` removed; `coverage: number // Estimated test coverage` → `hasTests: boolean`, pointing at `analyze-test-coverage` when a real number is wanted.
- **`analyze-code`**: "maintainability score" → the concrete complexity signals actually observed.
**Kept** (inputs are measured, which is the whole test): `analyze-test-coverage`'s `(100 - line_coverage) * 0.5 + …`, fed by real coverage output; `pattern-learner`'s "90% of files follow X", which is countable.
### Delta 4 — length only comes down when asked
Explicit length lines, prioritized by whether the output feeds another agent's context: `context-loader-agent` and `explore-codebase` (its output is input to `/plan`) capped at 100 lines; then `agent-orchestrator`, `debug-assistant` (was mandating a monitoring plan for a typo fix), `performance-analyzer`, `security-analyzer` (was producing a 6-month roadmap even on a `targeted` scope), `style-enforcer` (per-violation blocks over a `full-codebase` default), `pattern-learner`, `analyze-tech-debt`.
**Kept**: `code-explainer`'s "a 30-line utility gets a short explanation".
### Broken references and unrunnable instructions
- `agent-capability-analyst` was referenced **twice** in `agent-orchestrator.md` and exists in no agent's frontmatter `name:` anywhere in the marketplace — it would fail at dispatch. Removed, along with the fabricated `Agent Optimizer` meta-agent. `Prompt Engineer` and `Pattern Learner` are real and now carry their actual dispatch names.
- `explain-file-guide.md` dispatched `code-explainer` / `security-analyzer` / `performance-analyzer` without the `-agent` suffix — three names that resolve to nothing. Fixed. It also listed `refactorer-agent` in the architectural path while that agent is absent from its `allowed-tools`, so the dispatch would have been blocked; removed with a note saying why.
- **`refactor-code` validation was unrunnable, and is now mandatory.** Step 6 said "confirm behavior is preserved" while `allowed-tools` granted no test runner, formatter, or linter — the only way to comply was to read your own diff. Added the runner prefixes those steps need (`npm`/`yarn`/`pnpm`/`bun`, `nx`, `vitest`, `jest`, `tsc`, `eslint`, `prettier`, `pytest`, `go`, `cargo`, `mvn`/`gradle`) and made the check binary: either the tests covering the touched code run and pass, or — when no test covers it — `code-explainer-agent` reviews the before/after pair for behavior equivalence. If neither can run, the refactor is reported unverified rather than complete.
## Version bump
MINOR, `2.6.3` → `2.7.0`.
**The two sources disagreed before this PR**: `plugin.json` was already at `2.6.3` while the root `CLAUDE.md` table still read `2.6.2`. Both now read `2.7.0`. Also added the missing `hooks/hooks.json` to the plugin CLAUDE.md file tree.
## Findings in the brief that do not exist here
Reported rather than fixed, since inventing a fix would be worse than saying so:
- **`references/analysis-rubric.md`** ("don't invent problems") — not in this plugin. `find` locates exactly one copy, in **`skill-management`**: `packages/plugins/skill-management/skills/skill-doctor/references/analysis-rubric.md`. The phrase "invent problems" appears nowhere under `development-codebase-tools`.
- **`agents/agent-tester.md`** (coverage ratios with unknowable denominators) — lives in **`development-productivity`**, not here.
## Test plan
**1. Every `subagent_type` this plugin dispatches resolves to a real agent.** Dispatch name is frontmatter `name:`, never the filename:
```bash
$ comm -23 <dispatched names> <real agent names across all 27 marketplace agents>
agent-name
plugin-name:agent-name
```
Only the two documentation placeholders in `CLAUDE.md` remain unmatched, which is correct — they are syntax templates. All 8 real dispatches (`code-explainer-agent`, `context-loader-agent`, `debug-assistant-agent`, `performance-analyzer-agent`, `refactorer-agent`, `security-analyzer-agent`, `style-enforcer-agent`, `test-writer-agent`) resolve.
**2. No fabricated references or stale facts remain:**
```bash
$ grep -rniE 'agent-capability-analyst|agent-optimizer|claude-agent-discovery|mcp__nx_mcp__|MultiEdit|budget_tokens|claude-haiku' \
    packages/plugins/development-codebase-tools/
(no matches)
```
The only `80%` left is `performance-analyzer.md:184`, the Pareto principle — not a stale pricing claim.
**3. Plugin validation:**
```bash
$ node scripts/validate-plugin.cjs packages/plugins/development-codebase-tools
  ✓ plugin.json: development-codebase-tools v2.7.0
  ✓ skills/: 13 item(s)   ✓ agents/: 10 item(s)   ✓ hooks/: 2 item(s)
Validation PASSED
```
**4. Format and markdown lint:** `bunx nx format:write --uncommitted`, then `bunx markdownlint-cli2 --fix` over the plugin — 200 files, 0 errors.
## Decisions left open
**`debug-assistant.md:33-34` — the 0–1 confidence score on root-cause hypotheses.** Ranking competing hypotheses is real and useful, and `debug-issue` Step 4 consumes the ranking to pick which fix to try. But a numeric 0–1 score implies a calibration that does not exist, and "0.85" is not more informative than "most likely". A qualitative ranking would preserve the ordering without the false precision. Left as-is; `debug-issue:101` still refers to confidence scores, so the two move together.
Also worth a decision, though outside the brief's list: `model:` frontmatter across this plugin mixes pinned ids (`claude-opus-5`, `claude-sonnet-5`) with self-updating aliases (`opus`, `sonnet`). Aliases track model releases and are generally preferable. Not changed — `model:` and `effortLevel` are yours to set.
For the record, one item listed as open in the first draft of this PR **was** resolved during review: `security-analyzer.md`'s CVSS business-impact multiplier (`1.0-2.0x`) is gone. It scaled a real CVSS base score by a factor nobody measured and kept the CVSS label, so the output laundered a guess through a credible-looking number. Business impact is now prose in the finding's Impact field, and genuine severity context goes through CVSS 3.1's own temporal/environmental metrics with the full modified vector shown — reproducible, unlike a bare multiplier.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>
<!-- claude-pr-description-end -->