### PR TITLE
fix(uniswap-integrations): Opus 5 migration audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,7 +230,7 @@ All plugins follow semantic versioning (semver). Key versioning rules:
 | development-productivity   | 2.4.1   |
 | skill-management           | 1.2.0   |
 | spec-workflow              | 2.1.0   |
-| uniswap-integrations       | 2.6.1   |
+| uniswap-integrations       | 2.7.0   |
 
 **Note:** Keep this table updated when versions change.
 

--- a/packages/plugins/uniswap-integrations/.claude-plugin/plugin.json
+++ b/packages/plugins/uniswap-integrations/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uniswap-integrations",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "External service integrations (Linear, Notion, Nx, Chrome DevTools, GitHub, Slack, Amplitude, Datadog) and deployment orchestration",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/uniswap-integrations/skills/daily-standup/standup-guide.md
+++ b/packages/plugins/uniswap-integrations/skills/daily-standup/standup-guide.md
@@ -168,7 +168,7 @@ The workflow will:
   - Use `mcp__github__search_issues` with queries like:
     - `org:Uniswap author:<username> created:>YYYY-MM-DD` (PRs/issues created)
     - `org:Uniswap involves:<username> updated:>YYYY-MM-DD` (all activity including comments, reviews)
-  - Get PR details for any PRs found using `mcp__github__get_pull_request`
+  - Get PR details for any PRs found using `mcp__github__pull_request_read`
   - Include PR status (open/merged/closed) and review status
 - **Fetch Linear Issues**:
   - Call Linear MCP with the assignee parameter

--- a/packages/plugins/uniswap-integrations/skills/datadog-cost-tracker/SKILL.md
+++ b/packages/plugins/uniswap-integrations/skills/datadog-cost-tracker/SKILL.md
@@ -33,6 +33,10 @@ Analyze Datadog ingestion costs across logs, APM spans, and other estimated-usag
 
 ## Output Format
 
+Keep the whole report under ~400 words outside the tables. One or two sentences per section; the
+ranked table carries the detail. Do not restate the table in prose, and do not pad sections that
+have nothing to report — write "none" and move on.
+
 **Cost Summary** — total estimated ingestion for the period by signal type.
 
 **Top Ingesters** — ranked table: service | volume | WoW delta | notes.

--- a/packages/plugins/uniswap-integrations/skills/investigate-incident/SKILL.md
+++ b/packages/plugins/uniswap-integrations/skills/investigate-incident/SKILL.md
@@ -32,6 +32,9 @@ Investigate production incidents by querying Datadog for logs, metrics, and trac
 
 ## Output Format
 
+Keep the report under ~500 words outside quoted log lines and metric values. Evidence is what
+earns length; narration is not. Omit a section that has nothing to report rather than padding it.
+
 **Incident Summary**
 
 - What happened, when it started, and estimated user/system impact

--- a/packages/plugins/uniswap-integrations/skills/orchestrate-deployment/deploy-guide.md
+++ b/packages/plugins/uniswap-integrations/skills/orchestrate-deployment/deploy-guide.md
@@ -1,8 +1,9 @@
 ---
 description: Orchestrate deployment pipelines, infrastructure setup, and CI/CD configuration using specialized deployment agents.
 argument-hint: <target> [--strategy blue-green|canary|rolling] [--environment dev|staging|prod] [--dry-run]
-allowed-tools: Read(*), Write(*), Task(subagent_type:cicd-agent), Task(subagent_type:infrastructure-agent), Task(subagent_type:agent-orchestrator-agent)
-# Note: agent-orchestrator-agent is from development-codebase-tools plugin (optional - see fallback below)
+allowed-tools: Read(*), Write(*), Task(subagent_type:cicd-agent), Task(subagent_type:infrastructure-agent), Task(subagent_type:development-codebase-tools:agent-orchestrator-agent)
+# Note: agent-orchestrator-agent is from the development-codebase-tools plugin, so it needs the
+# plugin-qualified dispatch name (optional - see fallback below)
 ---
 
 ## Inputs
@@ -36,7 +37,9 @@ Orchestrate complete deployment workflow through specialized agents:
 
 ## Orchestration Strategy
 
-> **Note**: This skill uses **agent-orchestrator-agent** from the development-codebase-tools plugin when available. If not installed, the skill will execute infrastructure-agent and cicd-agent sequentially instead of in parallel coordination.
+> **Note**: This skill uses **development-codebase-tools:agent-orchestrator-agent** when that plugin is installed. If not, execute infrastructure-agent and cicd-agent sequentially instead of in parallel coordination.
+
+**Delegate only when the work warrants it.** The agent split below is a ceiling, not a quota: at most one infrastructure-agent and one cicd-agent per deployment. When a phase finishes in a handful of direct tool calls (reading an existing workflow file, a single `kubectl rollout status`, a dry-run with no infrastructure changes), do it inline rather than spawning an agent for it.
 
 ### Phase 1: Pre-Deployment Analysis
 
@@ -179,8 +182,13 @@ Use **cicd-agent** for observability setup:
       loadBalancing: object;
       networking: object;
     };
-    costs: {
-      estimated: string; // Monthly cost estimate
+    // Omit `costs` entirely unless a real pricing source was queried (cloud pricing API,
+    // `infracost breakdown`, an existing billing dashboard). Do not derive a monthly figure
+    // from instance types and rate cards you recalled rather than read - a fabricated number
+    // reads as measured once it lands in the report.
+    costs?: {
+      estimated: string; // Monthly cost estimate, with the source that produced it
+      source: string; // e.g. "infracost breakdown", "AWS Pricing API"
       breakdown: object;
     };
   };

--- a/packages/plugins/uniswap-integrations/skills/refine-linear-task/SKILL.md
+++ b/packages/plugins/uniswap-integrations/skills/refine-linear-task/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Refine and enhance Linear task descriptions. Use when user says "refine this Linear task", "improve task description", "make this task clearer", "enhance Linear issue", or needs to improve clarity, completeness, and actionability of Linear issues.
-allowed-tools: Read(*), Glob(*), Grep(*), Task(subagent_type:Explore), WebSearch(*), WebFetch(*), mcp__linear__linear_search_issues(*), mcp__linear__linear_update_issue(*), mcp__linear__linear_add_comment(*)
+allowed-tools: Read(*), Glob(*), Grep(*), Task(subagent_type:Explore), WebSearch(*), WebFetch(*), mcp__linear__get_issue(*), mcp__linear__list_issues(*), mcp__linear__save_issue(*), mcp__linear__save_comment(*)
 ---
 
 # Linear Task Refiner
@@ -37,7 +37,7 @@ Parse from request:
 
 ### Phase 1: Fetch and Analyze Current Task
 
-1. **Fetch Issue Details** via Linear MCP tools
+1. **Fetch Issue Details** via `mcp__linear__get_issue` (or `mcp__linear__list_issues` when resolving an issue from a partial reference)
 2. **Display Current State**: Show issue details and description
 3. **Analyze for Gaps**: Evaluate against criteria:
    - Clarity: Is the problem/goal clearly stated?
@@ -75,8 +75,8 @@ Create comprehensive, well-structured description:
 
 ### Phase 5: Update Linear (with approval)
 
-1. **Update Issue Description** via Linear MCP
-2. **Add Comment** (optional): Note the refinement
+1. **Update Issue Description** via `mcp__linear__save_issue`
+2. **Add Comment** (optional) via `mcp__linear__save_comment`: note the refinement
 3. **Confirm Success**: Provide issue URL
 
 ## Focus Areas


### PR DESCRIPTION
Opus 5 migration audit of `packages/plugins/uniswap-integrations/`. Every `.md` under the plugin was read in full except `skills/github-setup/SKILL.md`.

**`skills/github-setup/SKILL.md` is deliberately untouched** — PR #565 owns it (credential-leak fix). That PR bumps the plugin to 2.6.1 on its own branch; this branch is off `next` where the plugin was still 2.6.0, so it bumps 2.6.0 → 2.7.0. The version collision is expected and resolves at merge.

## Deltas addressed

### Broken references (verified against the live MCP tool surfaces, not recalled)

- **`skills/refine-linear-task/SKILL.md`** — `allowed-tools` declared `mcp__linear__linear_search_issues`, `mcp__linear__linear_update_issue`, `mcp__linear__linear_add_comment`. None of those exist on `https://mcp.linear.app/mcp`, the server this plugin configures in `.mcp.json`; they are third-party-server names. Replaced with the real surface (`get_issue`, `list_issues`, `save_issue`, `save_comment`), and named the specific tool at the two body steps that previously said only "via Linear MCP". Every other Linear reference in this repo already uses the unprefixed form, so this file was the outlier.
- **`skills/daily-standup/standup-guide.md:171`** — `mcp__github__get_pull_request` is not a tool on the GitHub MCP (`api.githubcopilot.com/mcp`); PR reads go through `pull_request_read`. Fixed. (`mcp__github__search_issues` and `mcp__linear__list_issues`, also referenced in this skill, are real and were left alone.)
- **`skills/orchestrate-deployment/deploy-guide.md:4`** — `agent-orchestrator-agent` was dispatched bare, but it lives in the `development-codebase-tools` plugin, so it needs the plugin-qualified form `development-codebase-tools:agent-orchestrator-agent`. Fixed in the frontmatter and in the fallback note.

### Invented numbers

- **`deploy-guide.md`** output shape required `costs: { estimated: string; // Monthly cost estimate }`. Nothing upstream in the skill queries a pricing source, so a model filling that required field fabricates a dollar figure that then reads as measured. Made the field optional, added a required `source`, and stated explicitly not to derive a figure from recalled rate cards.

### Output length (Delta 4)

Effort settings do not shorten authored deliverables; only explicit length instructions do. Both report-generating skills had multi-section unbounded output formats:

- **`skills/datadog-cost-tracker/SKILL.md`** (specifically flagged) — bounded to ~400 words outside tables, with "don't restate the table in prose".
- **`skills/investigate-incident/SKILL.md`** — same defect class, bounded to ~500 words outside quoted evidence.

### Delegation (Delta 2)

- **`deploy-guide.md`** Phase 2 mandated parallel dispatch of two agents with no opt-out. Restated as a ceiling (at most one of each) and added a when-NOT-to-delegate rule for phases that finish in a handful of direct tool calls.

## Findings in the brief that do not exist in this plugin

Reported rather than papered over:

1. **`git add -A` in `linear-task-and-pr-from-changes.md:308`** — that file is `packages/plugins/development-pr-workflow/commands/`, not this plugin. This plugin has no `commands/` directory at all.
2. **`mcp__linear__create_issue` in 2 commands** — same: both occurrences are in `development-pr-workflow` (`linear-task-and-pr-from-changes.md:188`, `start-linear-task.md:190`). The finding is real, the plugin is not this one.
3. **`--skip-graphite` in `start-linear-task.md:406`** — also `development-pr-workflow`.
4. **`mcp__nx_mcp__` (underscores)** — searched; zero occurrences anywhere in this plugin.

All three files should be picked up by whoever takes `development-pr-workflow`.

## Deltas that produced no changes

- **Delta 1 (verification ceremony)** — none present. Every `verify`/`Verify` in the plugin is either a grounding instruction (`use-datadog`'s "check pup is installed and authenticated"; the cost-tracker's "retrieve the metric's tag context before concluding a service has zero ingestion") or a real deployment/rollback gate in the three agents. All kept per the brief.
- **Delta 3 (literal following / recall filters)** — no discovery-time filters, and the single `**IMPORTANT**` in the plugin (`standup-guide.md:164`, "prompt for GitHub username FIRST before fetching any data") is a real ordering constraint, not decoration. `use-datadog`'s "Critical Rules" heading covers genuine constraints (APM durations are nanoseconds, always pass `--from`). Left alone.
- **Stale model facts** — searched for `claude-opus-4`, `claude-sonnet-4`, `haiku-3`, `MultiEdit`, `budget_tokens`, and the "~80% cheaper / 5x cheaper" pricing claim. Zero hits. The two `model:` values present (`haiku`, `claude-haiku-4-5`, `sonnet`) are current and are frontmatter, so untouched per the brief.
- **`agents/cicd-agent.md`, `agents/infrastructure-agent.md`, `agents/migration-assistant.md`** — audited in full. All three are generic domain-reference documents with no migration defects. Their frontmatter `name:` values (`cicd-agent`, `infrastructure-agent`, `migration-assistant-agent`) match how `CLAUDE.md` and `README.md` list them, and match how `orchestrate-deployment` dispatches them.
- **`CLAUDE.md` / `README.md`** — no documented behavior drifted. The MCP server tables, skill lists, and agent lists all still match `plugin.json` and disk. Only the root `CLAUDE.md` version-table row changed.

## Test plan

Version sources agreed before the bump (checked rather than assumed, since a sibling plugin was reported drifted):

```
$ grep -n '"version"' packages/plugins/uniswap-integrations/.claude-plugin/plugin.json
3:  "version": "2.6.0",
$ grep -n "uniswap-integrations" CLAUDE.md
233:| uniswap-integrations       | 2.6.0   |
```

Both now read 2.7.0. MINOR, because correcting a fabricated MCP tool name changes runtime behavior.

Plugin structure validation:

```
$ node scripts/validate-plugin.cjs packages/plugins/uniswap-integrations
  ✓ plugin.json: uniswap-integrations v2.7.0
  ✓ skills/: 7 item(s)
  ✓ agents/: 3 item(s)
  ✓ .mcp.json: 11 MCP server(s)
Validation PASSED
```

Markdown lint (repo config, plugin scope):

```
$ bunx markdownlint-cli2 --fix "packages/plugins/uniswap-integrations/**/*.md"
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Linting: 200 file(s)
Summary: 0 error(s)
```

Format:

```
$ bunx nx format:write --uncommitted
```

Lefthook pre-commit ran the full gate on the staged set and passed:

```
✔️ format (1.30 seconds)
✔️ lint (0.13 seconds)
✔️ lint-markdown (1.05 seconds)
✔️ test (0.61 seconds)
✔️ typecheck (0.59 seconds)
✔️ update-lockfile (1.01 seconds)
```

Confirmed `github-setup/SKILL.md` is absent from the diff:

```
$ git diff --name-only origin/next...HEAD
CLAUDE.md
packages/plugins/uniswap-integrations/.claude-plugin/plugin.json
packages/plugins/uniswap-integrations/skills/daily-standup/standup-guide.md
packages/plugins/uniswap-integrations/skills/datadog-cost-tracker/SKILL.md
packages/plugins/uniswap-integrations/skills/investigate-incident/SKILL.md
packages/plugins/uniswap-integrations/skills/orchestrate-deployment/deploy-guide.md
packages/plugins/uniswap-integrations/skills/refine-linear-task/SKILL.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
