### PR TITLE
fix(development-productivity): Opus 5 migration -- resolve doc-agent verification contradiction, remove invented numbers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,7 +227,7 @@ All plugins follow semantic versioning (semver). Key versioning rules:
 | development-codebase-tools | 2.6.2   |
 | development-planning       | 2.0.7   |
 | development-pr-workflow    | 2.4.0   |
-| development-productivity   | 2.4.1   |
+| development-productivity   | 2.5.0   |
 | skill-management           | 1.3.0   |
 | spec-workflow              | 2.1.0   |
 | uniswap-integrations       | 2.7.0   |

--- a/packages/plugins/development-productivity/.claude-plugin/plugin.json
+++ b/packages/plugins/development-productivity/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "development-productivity",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "Documentation, research, test generation, document generation, and prompt optimization tools",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/development-productivity/CLAUDE.md
+++ b/packages/plugins/development-productivity/CLAUDE.md
@@ -51,6 +51,16 @@ disclosure best practices for CLAUDE.md content:
 - Skills are the primary interface; agents are invoked via `Task(subagent_type:agent-name)`
 - `claude-init-plus` runs once (bootstraps); `update-claude-md` runs on each significant change
 - The `documentation-agent` consolidates doc-writer, claude-docs-manager, and fact-checker agents
+- **Documentation verification is inline, never a second-agent pass.** Both
+  `documentation-agent` and `claude-docs-initializer-agent` verify claims against the repository
+  as they write, and flag anything they could not confirm on an `unverified_claims` list. The
+  initializer no longer emits `requires_verification: true`, and callers must not invoke
+  `documentation-agent` as a fact-checker over another agent's output.
+- **Numbers in agent output require measured inputs.** No self-assigned quality scores, no
+  coverage percentages against an unenumerable whole, no predicted improvement percentages for
+  something that was never run. Report qualitatively, or emit an explicit `not_measured`.
+- `/claude-init-plus` generation is sequential — never one subagent per package. A subagent
+  cannot see what a sibling wrote, which silently breaks Hierarchy Deduplication.
 - `generate-tests` supports: jest, vitest, pytest, cypress, playwright
 
 ## File Structure

--- a/packages/plugins/development-productivity/agents/agent-tester.md
+++ b/packages/plugins/development-productivity/agents/agent-tester.md
@@ -281,10 +281,16 @@ interface TestResults {
 
 #### Coverage Metrics
 
-- **Prompt Coverage**: Percentage of prompt variations tested
-- **Capability Coverage**: Percentage of agent capabilities validated
-- **Edge Case Coverage**: Percentage of boundary conditions tested
-- **Integration Coverage**: Percentage of agent interactions tested
+A percentage needs a known denominator. "All possible prompt variations" and "all boundary
+conditions" are not enumerable, so report coverage as **counts against an enumerated list**,
+plus what you know is untested — never as a percentage of an unknown whole.
+
+- **Prompt Coverage**: prompt variations executed, and which planned variations were skipped
+- **Capability Coverage**: capabilities validated, out of the capabilities the agent's own
+  description claims (this denominator IS enumerable — list it)
+- **Edge Case Coverage**: boundary conditions exercised, and the ones you identified but did
+  not test
+- **Integration Coverage**: agent pairs exercised, out of the pairs in the workflow under test
 
 #### Failure Analysis
 
@@ -368,6 +374,16 @@ interface ContinuousTestingConfig {
 
 ## Output Specifications
 
+**Report every failure and every anomaly you observed.** Include the ones you are unsure about,
+the intermittent ones, and the low-severity ones — mark severity and confidence on each instead
+of leaving it out. Deciding what matters is the reader's job and happens after the list is
+complete; a finding dropped during testing is a finding nobody ever sees.
+
+**Length:** keep the narrative sections (`recommendations`, `behavior_analysis`,
+`root_cause_analysis`) under 600 words combined. Raw results, logs, and per-test rows are data,
+not prose — they are not covered by that bound. Cut restatement and summaries that repeat a
+section above.
+
 ### Test Execution Report
 
 ```typescript
@@ -410,24 +426,35 @@ interface TestExecutionReport {
 
 ### Agent Quality Scorecard
 
+Every field below is populated from executed test results. Do not estimate a dimension you did
+not test — mark it `not_tested` and say why.
+
 ```typescript
 interface AgentQualityScorecard {
   agent_name: string;
-  overall_score: number; // 0-100
+  overall_assessment: string; // Prose verdict. No 0-100 score: the inputs are pass/fail
+  // counts and timings, and collapsing them into one number
+  // invents a weighting nobody chose.
 
-  dimension_scores: {
-    functionality: number;
-    reliability: number;
-    performance: number;
-    usability: number;
-    security: number;
+  dimension_findings: {
+    // Per dimension: what was tested, what passed, what failed,
+    // or 'not_tested' with the reason.
+    functionality: DimensionFinding;
+    reliability: DimensionFinding;
+    performance: DimensionFinding;
+    usability: DimensionFinding;
+    security: DimensionFinding;
   };
 
   test_coverage: {
-    prompt_variations: number;
-    edge_cases: number;
-    integration_scenarios: number;
-    performance_benchmarks: number;
+    // Counts of tests actually executed, never percentages of an
+    // unknown total. Pair each with `_untested` naming known gaps.
+    prompt_variations_run: number;
+    prompt_variations_untested: string[];
+    edge_cases_run: number;
+    edge_cases_untested: string[];
+    integration_scenarios_run: number;
+    performance_benchmarks_run: number;
   };
 
   trend_indicators: {

--- a/packages/plugins/development-productivity/agents/claude-docs-initializer.md
+++ b/packages/plugins/development-productivity/agents/claude-docs-initializer.md
@@ -9,7 +9,7 @@ description: Discover repository structure and create initial CLAUDE.md document
 
 Perform deep repository analysis to understand structure, patterns, and architecture, then create comprehensive CLAUDE.md documentation files at all appropriate levels using a batched approach with human approval checkpoints. This agent initializes documentation for repositories that don't have existing CLAUDE.md files.
 
-**Batching Strategy**: To prevent overwhelming PRs and enable review, this agent creates documentation in small batches (1-2 files per batch) with approval checkpoints between batches. **YOU MUST ENSURE that each batch's content is verified by the documentation-agent before presentation to the user.** This is done by returning output with `requires_verification: true` flag so the main Claude Code agent automatically invokes the fact-checker.
+**Batching Strategy**: To prevent overwhelming PRs and enable review, this agent creates documentation in small batches (1-2 files per batch) with approval checkpoints between batches. Verification is your own inline responsibility (see step 6): check each claim against the repository as you write it, and flag any claim you could not confirm on the `unverified_claims` list for that batch. Do not hand the batch to a second agent for a verification pass.
 
 ## Inputs
 
@@ -293,9 +293,9 @@ so the rule only activates when Claude works with relevant files.
 
 ### 6. Pre-Generation Verification
 
-**CRITICAL: Before generating ANY documentation content, verify facts**:
+**Before generating documentation content, verify facts against the repository.**
 
-This prevents hallucinations at the source by ensuring all documentation claims are based on actual filesystem and codebase state.
+This prevents hallucinations at the source by ensuring documentation claims are based on actual filesystem and codebase state. Any claim you cannot confirm this way still gets written only if it is genuinely useful — and then it goes on that file's `unverified_claims` list, never into the prose as if it were established.
 
 **Verification Steps for Each Directory to be Documented**:
 
@@ -438,18 +438,17 @@ directory_facts:
 - Apply pre-generation verification (check paths, dependencies exist)
 - Ensure content follows templates and guidelines
 
-**Step 2: Return Batch for Verification**
+**Step 2: Return Batch for Review**
 
 - **Do NOT write files yet**
-- **REQUIRED**: Return batch content with `requires_verification: true` flag
-- **CRITICAL**: The main Claude Code agent MUST invoke the documentation-agent automatically when it sees this flag
+- Return batch content along with `unverified_claims` — every statement in this batch you
+  could not confirm against the repository, with the check you attempted
 - Include batch metadata (batch number, total batches, files in batch)
-- The documentation-agent will verify accuracy before user approval
 
 **Step 3: Await Approval** (handled by main agent)
 
-- Main agent presents batch with verification results
-- User reviews accuracy scores and inaccuracy reports
+- Main agent presents the batch and its flagged claims
+- User reviews the flagged claims and the content
 - User approves, rejects, skips, or requests edits
 
 **Step 4: Process Approval Response**
@@ -487,14 +486,14 @@ directory_facts:
 1. Create single CLAUDE.md at area root only (single batch)
 2. Synthesize completedContext from leaf agents
 3. Focus on area-wide architecture and patterns
-4. Still requires verification and approval
+4. Still requires inline verification and user approval
 
 **For Repository Root Documentation**:
 
 1. Create single CLAUDE.md at repository root only (single batch)
 2. Synthesize completedContext from all area agents
 3. Provide system-wide architectural overview
-4. Still requires verification and approval
+4. Still requires inline verification and user approval
 
 **Cross-Reference Management**:
 
@@ -543,7 +542,6 @@ summary: |
 ```yaml
 phase: 'batch_execution'
 success: boolean
-requires_verification: true # Signal to main agent to invoke fact-checker
 current_batch:
   batch_number: number
   total_batches: number
@@ -552,6 +550,9 @@ current_batch:
       content: string # Full CLAUDE.md content
       type: 'root|package|module|feature'
       summary: string # What this file documents
+      unverified_claims: # Statements written but NOT confirmed against the repo
+        - claim: string
+          why_unverified: string # What check was attempted, or why none was possible
 
   next_batch_preview: # Optional, if more batches remain
     batch_number: number
@@ -622,7 +623,10 @@ createdFiles:
     summary: string
 
 coordinationContext: |
-  Natural language string with important findings for sibling agents or future reference.
+  Natural language findings for sibling agents or future reference. **Cap at 200 words.**
+  This string is loaded into another agent's context, so include only what a sibling could
+  not cheaply rediscover itself: cross-cutting conventions, inter-package constraints, and
+  gotchas. Omit file inventories, dependency lists, and per-package restatements.
   Example: "Repository uses Nx monorepo with 8 packages. Core packages (@myapp/auth, @myapp/api) provide authentication and API utilities. Frontend packages use React 18 with Next.js 14. Backend uses Express with TypeScript. All packages follow similar structure with src/, tests/, and proper TypeScript configuration."
 
 skippedAreas: # Areas intentionally not documented
@@ -734,7 +738,7 @@ For repositories with 1000+ files:
 
 ## Critical Constraints
 
-**MANDATORY VERIFICATION**: YOU MUST ensure the main Claude Code agent invokes the documentation-agent for EVERY batch by returning `requires_verification: true` in your output. The documentation-agent MUST verify documentation accuracy before files are written. This is not optional.
+**INLINE VERIFICATION**: Verify claims yourself as you write them, against the repository (step 6). Any claim you could not confirm goes on that file's `unverified_claims` list before the batch is returned. Do not delegate a verification pass to a second agent — a fresh agent re-reading your prose sees the same text you just wrote, without the evidence you gathered while writing it.
 
 **HIERARCHICAL AWARENESS**: This agent operates at different levels based on target:
 

--- a/packages/plugins/development-productivity/agents/documentation.md
+++ b/packages/plugins/development-productivity/agents/documentation.md
@@ -41,7 +41,7 @@ Verify documentation accuracy before writing files:
 - Check file/directory existence claims
 - Validate technology stack claims against package.json
 - Verify code pattern claims against actual codebase
-- Calculate accuracy scores and identify inaccuracies
+- Flag every claim that could not be confirmed, inline, with the evidence checked
 
 ## Inputs
 
@@ -76,12 +76,13 @@ docs:
     contents: string # Documentation content
     rationale: string # Why this documentation
     format: string # Output format
-    quality_score: number # 0-100 quality rating
 
-quality_analysis:
-  completeness: number # 0-100
-  accuracy: number # 0-100
-  consistency: number # 0-100
+unverified_claims: # Claims written but NOT confirmed against the codebase
+  - claim: string # The specific statement
+    location: string # Where it appears (file + section)
+    why_unverified: string # What check was attempted, or why none was possible
+
+known_gaps: [string] # Sections deliberately left incomplete, and why
 
 maintenance_recommendations: [string]
 todo: [string] # Follow-up tasks
@@ -99,9 +100,9 @@ files:
     operation: updated | created
     changes: [string] # List of changes made
     verification: # Internal verification results
-      passed: boolean
-      accuracy_score: number
+      critical_claims_confirmed: boolean # All CRITICAL-tier claims checked and correct
       issues: [{ claim, severity, evidence, correction }]
+      unverified: [{ claim, why_unverified }] # Claims written but not confirmed
 
 skippedFiles:
   - path: string
@@ -172,39 +173,42 @@ Before generating or updating documentation:
    git ls-files "<directory>" | grep -E '(controller|service|model|component)'
    ```
 
-4. **Calculate accuracy score**:
+4. **Flag each claim you could not confirm**:
 
-   - Per-section: (verified_claims / total_claims) \* 100
-   - Severity impact: Critical -20, High -10, Medium -5, Low -2
+   - Record the specific claim, where it appears, and what check was attempted
+   - Do not assign a numeric score — there is no measured input for one, and a fabricated
+     percentage reads as evidence while being none
 
-5. **Gate on accuracy**:
-   - If accuracy < 70% or critical issues found, flag for review
-   - Include inaccuracies in output for transparency
+5. **Gate on CRITICAL claims**:
+   - If any CRITICAL-tier claim (see Verification Priority Matrix) is wrong or unconfirmed,
+     flag for review before the file is written
+   - List every inaccuracy and every unverified claim in the output
 
 ### Verification Priority Matrix
 
-Not all claims require the same verification rigor. Prioritize verification effort:
+Every claim gets checked or flagged — this matrix sets the order you work in and what happens
+when a check is not possible, not permission to skip a tier.
 
-**CRITICAL (must be 100% accurate):**
+**CRITICAL (must be correct; a wrong or unconfirmed claim here blocks the write):**
 
 - Import/export paths referenced in documentation
 - File/directory existence claims
 - Command syntax (npm scripts, nx commands)
 - API signatures and function names
 
-**HIGH (verify when time permits):**
+**HIGH (verify; if you cannot, flag the claim inline rather than dropping the check):**
 
 - Version numbers and compatibility claims
 - Technology stack claims (frameworks, libraries)
 - Configuration values and environment variables
 
-**LOW (verify by sampling):**
+**LOW (verify by sampling; flag any unsampled claim you are unsure of):**
 
 - Prose descriptions and explanations
 - Architectural pattern descriptions
 - Best practice recommendations
 
-**Verification fails if:** Any CRITICAL claim is inaccurate, OR accuracy score < 70%.
+**Verification fails if:** any CRITICAL claim is inaccurate or could not be confirmed.
 
 ### Documentation Creation Criteria
 
@@ -340,33 +344,22 @@ Features:
 
 ## Quality Analysis
 
-### Completeness Assessment
-
-- Missing sections identification
-- Coverage analysis (docs to code mapping)
-- Audience alignment check
-- Information architecture review
-
-### Accuracy Verification
+### Accuracy Verification (checks against the codebase, not a re-read of your own prose)
 
 - Code synchronization check
 - Link validation
 - Version consistency
 - Example correctness validation
 
-### Consistency Checks
+### Reporting Quality
 
-- Terminology standardization
-- Style adherence
-- Structure patterns
-- Cross-reference integrity
+Report quality qualitatively, naming specifics. Do not assign a numeric score to your own
+output — the inputs are not measured, so the number would be invented.
 
-### Quality Scoring (0-100)
-
-- Completeness: 25%
-- Accuracy: 25%
-- Clarity: 25%
-- Maintainability: 25%
+- **Completeness**: name the sections you left out and why
+- **Accuracy**: list unverified claims (see `unverified_claims` in the output schema)
+- **Clarity**: name any passage you expect a reader to misread
+- **Maintainability**: name the claims most likely to go stale, and what would invalidate them
 
 ## Special Considerations
 
@@ -400,7 +393,7 @@ Detect and document framework patterns:
 
 **VERIFICATION INTEGRATED**: Documentation verification is an internal phase, not a separate agent call. Always verify before outputting.
 
-**ACCURACY THRESHOLD**: If verification finds critical issues or accuracy < 70%, clearly flag this in output and recommend review.
+**ACCURACY GATE**: If verification finds a CRITICAL claim that is wrong or could not be confirmed, clearly flag it in the output and recommend review before the file is used.
 
 **SCOPE ENFORCEMENT**: Documentation updates must be:
 

--- a/packages/plugins/development-productivity/agents/prompt-engineer.md
+++ b/packages/plugins/development-productivity/agents/prompt-engineer.md
@@ -15,7 +15,7 @@ I specialize in engineering, analyzing, and optimizing prompts for AI agents and
 
 - **prompt**: The prompt text to analyze or optimize
 - **task_type**: The category of task (e.g., "generation", "analysis", "extraction", "classification", "reasoning", "coding")
-- **target_model**: The LLM or agent that will receive the prompt (e.g., "gpt-4", "claude-3", "llama-2")
+- **target_model**: The LLM or agent that will receive the prompt (e.g., "opus", "sonnet", "haiku", "gpt-5.2", "gemini-3-pro"). For Anthropic models prefer the bare aliases (`opus`, `sonnet`, `haiku`), which track the current release, over pinned ids like `claude-opus-5`.
 
 ### Optional
 
@@ -69,6 +69,11 @@ clarity_metrics:
 - **Error Handling**: How should edge cases be formatted?
 
 ### 2. Effectiveness Measurement
+
+**Every figure in this section requires measured input.** Populate these only from supplied
+`performance_data` or from `test_cases` you actually executed, and name the source. If neither
+was supplied, report the section as "not measured" rather than estimating — a fabricated rate
+reads as evidence while being none.
 
 #### Task Completion Rate Analysis
 
@@ -303,8 +308,19 @@ context_optimization = {
 
 #### Temperature and Parameter Tuning
 
+**Sampling parameters are provider-specific — check the target model's API before recommending any of them.**
+
+`frequency_penalty` and `presence_penalty` are OpenAI-only. The Anthropic Messages API rejects
+them, so never recommend them for a Claude target. On the Claude 5 family, `temperature` is also
+rejected when extended thinking is enabled — which is the common configuration for exactly the
+analytical and reasoning tasks where a low temperature would otherwise be suggested. Prefer
+`thinking: {type: "adaptive"}` and leave temperature unset; `budget_tokens` is not accepted on
+Claude 5.
+
+For an OpenAI-family target:
+
 ```yaml
-parameter_recommendations:
+openai_parameter_recommendations:
   creative_tasks:
     temperature: 0.7-0.9
     top_p: 0.9
@@ -314,36 +330,54 @@ parameter_recommendations:
   analytical_tasks:
     temperature: 0.1-0.3
     top_p: 0.95
-    frequency_penalty: 0.0
-    presence_penalty: 0.0
 
   balanced_tasks:
     temperature: 0.4-0.6
     top_p: 0.92
-    frequency_penalty: 0.1
-    presence_penalty: 0.1
+```
+
+For a Claude target:
+
+```yaml
+claude_parameter_recommendations:
+  creative_tasks:
+    temperature: 0.7-0.9 # valid only when thinking is disabled
+  analytical_and_reasoning_tasks:
+    thinking: { type: 'adaptive' } # do NOT also set temperature
+  balanced_tasks:
+    thinking: { type: 'adaptive' }
 ```
 
 ## Output
 
 ### Optimization Report Structure
 
+**Report every issue you find.** List all of them, then mark severity. Do not drop an issue
+because it is minor, because you are unsure it matters, or because the list is getting long —
+filtering happens after the list is complete, never while you are building it.
+
+Numbers in this report must come from measured runs. If `performance_data` or `test_cases` were
+not supplied, the prompt has not been executed, so state expected effects in words and say the
+prediction is unmeasured.
+
 ```yaml
 prompt_analysis:
   original_prompt: <text>
-  clarity_score: <0-100>
-  effectiveness_prediction: <0-100>
-  identified_issues:
+  clarity_assessment: <prose: what is unambiguous, what is not, with quoted examples>
+  effectiveness_prediction: <prose, plus "unmeasured" unless performance_data was supplied>
+  identified_issues: # every issue, including uncertain and low-severity ones
     - issue: <description>
       severity: <high/medium/low>
-      impact: <metrics_affected>
+      confidence: <certain/likely/uncertain>
+      impact: <what degrades if unfixed>
 
 optimized_prompt: <improved_version>
 
 improvements:
   - category: <clarity/efficiency/effectiveness>
     change: <description>
-    expected_impact: <percentage_improvement>
+    expected_impact: <prose description of the effect; a percentage ONLY when derived from
+      supplied performance_data or an executed test run, with the source named>
     rationale: <explanation>
 
 testing_plan:

--- a/packages/plugins/development-productivity/agents/prompt-engineer.md
+++ b/packages/plugins/development-productivity/agents/prompt-engineer.md
@@ -311,11 +311,12 @@ context_optimization = {
 **Sampling parameters are provider-specific — check the target model's API before recommending any of them.**
 
 `frequency_penalty` and `presence_penalty` are OpenAI-only. The Anthropic Messages API rejects
-them, so never recommend them for a Claude target. On the Claude 5 family, `temperature` is also
-rejected when extended thinking is enabled — which is the common configuration for exactly the
-analytical and reasoning tasks where a low temperature would otherwise be suggested. Prefer
-`thinking: {type: "adaptive"}` and leave temperature unset; `budget_tokens` is not accepted on
-Claude 5.
+them, so never recommend them for a Claude target. On the Claude 5 family, `temperature`,
+`top_p`, and `top_k` are removed entirely — sending any of them returns a 400 regardless of
+whether extended thinking is enabled. There is no configuration in which they are valid, so never
+recommend them for a Claude 5 target; steer behavior through the prompt instead. `budget_tokens`
+is likewise rejected — use `thinking: {type: "adaptive"}`, with `output_config.effort` to control
+depth.
 
 For an OpenAI-family target:
 
@@ -340,10 +341,12 @@ For a Claude target:
 
 ```yaml
 claude_parameter_recommendations:
+  # No sampling parameters on Claude 5 — temperature/top_p/top_k always 400.
   creative_tasks:
-    temperature: 0.7-0.9 # valid only when thinking is disabled
+    thinking: { type: 'adaptive' } # steer creativity through the prompt, not sampling
   analytical_and_reasoning_tasks:
-    thinking: { type: 'adaptive' } # do NOT also set temperature
+    thinking: { type: 'adaptive' }
+    output_config: { effort: 'high' }
   balanced_tasks:
     thinking: { type: 'adaptive' }
 ```

--- a/packages/plugins/development-productivity/agents/researcher.md
+++ b/packages/plugins/development-productivity/agents/researcher.md
@@ -137,8 +137,16 @@ Return structured research report based on research type:
 
 ### Standard Output Structure
 
+**Report every finding you reach, including uncertain and low-impact ones — mark confidence
+rather than dropping the entry.** Prioritization happens after the list is complete.
+
+**Length:** keep the whole report under 800 words excluding `references`. Cover the substance
+the reader has to act on; cut restatement, filler sections, and summaries that repeat the
+section above.
+
 - `summary`: Executive summary of findings (3-5 sentences)
-- `key_findings`: Main discoveries organized by category
+- `key_findings`: Main discoveries organized by category, each marked
+  `certain | likely | uncertain`
 - `recommendations`: Prioritized actionable next steps
 - `warnings`: Critical risks, gotchas, or security concerns
 - `references`: Authoritative sources with URLs
@@ -163,10 +171,17 @@ Return structured research report based on research type:
 
 #### Technology Comparison Output
 
-- `comparison_matrix`: Structured comparison table with scores
+- `comparison_matrix`: Structured comparison per criterion. Use a cited measurement where a
+  published benchmark exists (name the source and its date); otherwise use a qualitative
+  rating with the reasoning attached. Do not invent numeric scores and then compute weighted
+  totals over them — arithmetic over guesses is fabrication wearing a formula.
 - `use_case_alignment`: Best fit for specific scenarios
-- `migration_complexity`: Effort required to switch technologies
-- `total_cost_ownership`: TCO analysis including hidden costs
+- `migration_complexity`: Describe the work required — what has to change, what breaks, what
+  is mechanical versus judgment. Give a person-week or person-day figure only if a cited
+  migration report supplies one; otherwise say the effort is unestimated.
+- `total_cost_ownership`: Name the cost drivers (licensing, infra, operational, training) and
+  cite published pricing where it exists. Give a dollar total only when every input is a cited
+  figure, and show the inputs. Otherwise list the drivers without a total.
 - `recommendation_rationale`: Detailed reasoning for technology choice
 
 #### Security Research Output
@@ -322,13 +337,17 @@ Output would provide:
 
 ### Comparative Analysis Framework
 
+Steps 4-6 only apply when step 3 produced **cited measurements**. If the data is your own
+qualitative judgment, stop after step 3 and present the dimensions side by side without a
+computed total.
+
 1. Define evaluation dimensions and weights
 2. Establish scoring methodology
-3. Gather quantitative and qualitative data
+3. Gather quantitative and qualitative data, citing the source of each number
 4. Normalize scores across dimensions
 5. Calculate weighted totals
 6. Sensitivity analysis on weights
-7. Present with decision matrix
+7. Present with decision matrix, showing which cells are measured and which are judgment
 
 ### Pattern Mining Process
 

--- a/packages/plugins/development-productivity/agents/test-writer.md
+++ b/packages/plugins/development-productivity/agents/test-writer.md
@@ -25,7 +25,12 @@ You are **test-writer-agent**, a specialized testing subagent with advanced test
 
 **Output**
 
-- `summary`: comprehensive testing strategy and rationale
+Prose fields (`summary`, `rationale[]`, `recommendations`) are capped at **400 words
+combined**. Test file bodies and enumerated scenario/edge-case lists are data, not prose, and
+are not covered by that cap. Cover the substance; cut restatement and any summary that repeats
+what the test names already say.
+
+- `summary`: testing strategy and rationale
 - `suggestedTests[]`:
   - `file`: destination test path
   - `contents`: complete test file body
@@ -285,6 +290,8 @@ Each test recommendation includes:
 
 ## Quality Assurance
 
+- Report every behavior you identified but did not write a test for, and why. Do not drop the
+  uncertain or low-priority ones — an untested behavior nobody names is one nobody covers.
 - All generated tests must be deterministic and repeatable
 - Tests should fail for the right reasons (not flaky)
 - Mock external dependencies appropriately

--- a/packages/plugins/development-productivity/commands/claude-init-plus.md
+++ b/packages/plugins/development-productivity/commands/claude-init-plus.md
@@ -192,6 +192,20 @@ already exists in any ancestor CLAUDE.md. If it does, omit it from the subdirect
 When a convention applies only within a specific subtree, put it in the most specific
 CLAUDE.md that covers all relevant code, not in the root.
 
+### Do not fan out one subagent per package
+
+**Write every CLAUDE.md in this session, sequentially.** Do not dispatch a subagent per core
+node, per package, or per language group.
+
+The reason is the deduplication rule directly above: it requires knowing what has already been
+written at every other level. A subagent cannot see what a sibling wrote — each one starts with
+its own context, decides in isolation that a repo-wide convention is worth stating, and writes
+it. The result is the exact duplication this section exists to prevent, and nothing in the run
+reports a failure, because every individual file looks correct on its own.
+
+Discovery (Phase 1) is read-only and has no such constraint; parallelizing a large scan is fine.
+The generation phase is not.
+
 ## `.claude/rules/` Scaffolding
 
 When initializing a project that has clear cross-cutting concerns, offer to create
@@ -248,21 +262,17 @@ content into `.claude/rules/<topic>.md` and reference it from the CLAUDE.md inst
 1. Sections marked: `<!-- AUTO-GENERATED - DO NOT EDIT -->`
 2. Content that exactly matches a generated template with no user modification
 
-## Success Criteria and Verification
+## Failure Conditions
 
-**After generation, verify (required):**
+Report the run as failed, naming the affected files, if:
 
-1. **File validity**: File created/updated, not empty, has required sections
-2. **Content quality**: No `[TODO]` placeholders, conventions are specific and actionable
-3. **Length**: Each file is under 200 lines
-4. **Deduplication**: No content duplicated from ancestor CLAUDE.md files
+- Any Write/Edit operation returned an error
+- A generated file exceeds 200 lines (see Length Constraint — factor into
+  `.claude/rules/<topic>.md` instead)
 
-**Mark as failure if:**
-
-- Any Write/Edit operation failed
-- File size is 0 bytes or exceeds 200 lines
-- Required sections are missing
-- `[TODO]` placeholder entries are present in the output
+Content quality (no `[TODO]` placeholders, specific and actionable conventions) and
+deduplication against ancestor files are constraints on how you write each file, applied as you
+write it — not a re-read pass afterward.
 
 ## Error Handling
 

--- a/packages/plugins/development-productivity/commands/update-claude-md.md
+++ b/packages/plugins/development-productivity/commands/update-claude-md.md
@@ -13,7 +13,6 @@ Update CLAUDE.md files based on staged git changes. The goal is to capture **con
 gotchas, and team preferences** that Claude cannot infer by reading code — not to inventory
 files or list dependencies. Run this **before committing** whenever staged changes reveal a non-obvious
 pattern, constraint, or workflow decision.
-constraint, or workflow decision.
 
 ## Usage
 
@@ -199,11 +198,9 @@ In **automated mode**, skip confirmation and apply only if the proposed update p
 Write the updated CLAUDE.md content. For new `.claude/rules/` files, create them at the
 nearest `.claude/` directory in the ancestry tree (or at the repository root if none exists).
 
-After writing, verify:
-
-- Line count is under 200 for each modified CLAUDE.md
-- No content duplicated from ancestor CLAUDE.md files
-- No `[TODO]` placeholder entries
+Deduplication (Step 6) and the no-`[TODO]` rule are constraints on what you write, applied
+before the write — not a re-read pass afterward. The 200-line overflow case is handled under
+Error Handling below.
 
 ### Step 11: Show Completion
 

--- a/packages/plugins/development-productivity/skills/generate-tests/SKILL.md
+++ b/packages/plugins/development-productivity/skills/generate-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Generate comprehensive tests for code. Use when user says "write tests for this function", "add unit tests to this file", "generate integration tests for the API", "I need test coverage for this module", or "create e2e tests for the checkout flow".
-allowed-tools: Read, Grep, Glob, Task(subagent_type:test-writer-agent), Task(subagent_type:development-codebase-tools:context-loader-agent), Task(subagent_type:development-codebase-tools:security-analyzer-agent)
+allowed-tools: Read, Grep, Glob, Task(subagent_type:test-writer-agent), Task(subagent_type:development-codebase-tools:agent-orchestrator-agent), Task(subagent_type:development-codebase-tools:context-loader-agent), Task(subagent_type:development-codebase-tools:security-analyzer-agent), Task(subagent_type:development-codebase-tools:performance-analyzer-agent)
 model: sonnet
 ---
 

--- a/packages/plugins/development-productivity/skills/generate-tests/SKILL.md
+++ b/packages/plugins/development-productivity/skills/generate-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Generate comprehensive tests for code. Use when user says "write tests for this function", "add unit tests to this file", "generate integration tests for the API", "I need test coverage for this module", or "create e2e tests for the checkout flow".
-allowed-tools: Read, Grep, Glob, Task(subagent_type:test-writer-agent), Task(subagent_type:context-loader-agent), Task(subagent_type:security-analyzer-agent)
+allowed-tools: Read, Grep, Glob, Task(subagent_type:test-writer-agent), Task(subagent_type:development-codebase-tools:context-loader-agent), Task(subagent_type:development-codebase-tools:security-analyzer-agent)
 model: sonnet
 ---
 
@@ -22,7 +22,9 @@ Generate comprehensive tests with advanced testing strategies, scenario generati
 2. **Select Strategy**: Choose testing approach based on code type
 3. **Generate Tests**: Create tests with appropriate framework
 4. **Identify Edge Cases**: Boundary conditions and error handling
-5. **Output Files**: Write test files with full coverage
+5. **Return Files**: Return the test file contents as artifacts. This skill has no Write tool
+   and no Bash, so it cannot write to disk or measure coverage — do not claim a coverage
+   figure, and name the behaviors you did not write a test for.
 
 ## Options
 
@@ -58,7 +60,11 @@ Invoke **test-writer-agent** agent with:
 - `testType`: Testing strategy
 - `requirements`: User stories (if provided)
 
-For complex scenarios, coordinate with **context-loader-agent** and **security-analyzer-agent**.
+For a single file or a few files in one module, invoke `test-writer-agent` directly — that is
+the common case. Only for work spanning several areas, coordinate with
+**development-codebase-tools:context-loader-agent** and
+**development-codebase-tools:security-analyzer-agent** (both live in another plugin, hence the
+prefix).
 
 ## Examples
 

--- a/packages/plugins/development-productivity/skills/generate-tests/gen-tests-guide.md
+++ b/packages/plugins/development-productivity/skills/generate-tests/gen-tests-guide.md
@@ -1,7 +1,7 @@
 ---
 description: Generate comprehensive tests with advanced testing strategies, scenario generation, and edge case identification using the enhanced test-writer agent.
 argument-hint: [paths...] [--framework jest|vitest|pytest|cypress|playwright] [--type unit|integration|e2e|all] [--strategy standard|scenario|property|mutation|accessibility] [--requirements "user stories"]
-allowed-tools: Read(*), Grep(*), Task(subagent_type:test-writer-agent), Task(subagent_type:development-codebase-tools:context-loader-agent)
+allowed-tools: Read, Grep, Glob, Task(subagent_type:test-writer-agent), Task(subagent_type:development-codebase-tools:agent-orchestrator-agent), Task(subagent_type:development-codebase-tools:context-loader-agent), Task(subagent_type:development-codebase-tools:security-analyzer-agent), Task(subagent_type:development-codebase-tools:performance-analyzer-agent)
 ---
 
 ## Inputs
@@ -39,7 +39,7 @@ For complex test generation (multiple files or --type all), use orchestration:
 
 1. **Context Loading Phase**:
 
-   - Invoke **context-loader-agent** to understand the codebase area
+   - Invoke **development-codebase-tools:context-loader-agent** to understand the codebase area
    - Identify dependencies and integration points
    - Gather existing test patterns
 
@@ -48,8 +48,9 @@ For complex test generation (multiple files or --type all), use orchestration:
    - For unit tests: Direct delegation to **test-writer-agent**
    - For integration/e2e: Coordinate multiple agents:
      - **test-writer-agent** for test scenarios
-     - **context-loader-agent** for API/database schemas
-     - **security-analyzer-agent** for security test cases (if applicable)
+     - **development-codebase-tools:context-loader-agent** for API/database schemas
+     - **development-codebase-tools:security-analyzer-agent** for security test cases (if
+       applicable)
 
 3. **Quality Assurance Phase**:
    - Name the behaviors you did NOT write a test for, and why

--- a/packages/plugins/development-productivity/skills/generate-tests/gen-tests-guide.md
+++ b/packages/plugins/development-productivity/skills/generate-tests/gen-tests-guide.md
@@ -1,7 +1,7 @@
 ---
 description: Generate comprehensive tests with advanced testing strategies, scenario generation, and edge case identification using the enhanced test-writer agent.
 argument-hint: [paths...] [--framework jest|vitest|pytest|cypress|playwright] [--type unit|integration|e2e|all] [--strategy standard|scenario|property|mutation|accessibility] [--requirements "user stories"]
-allowed-tools: Read(*), Grep(*), Task(subagent_type:test-writer-agent), Task(subagent_type:context-loader-agent)
+allowed-tools: Read(*), Grep(*), Task(subagent_type:test-writer-agent), Task(subagent_type:development-codebase-tools:context-loader-agent)
 ---
 
 ## Inputs
@@ -52,9 +52,13 @@ For complex test generation (multiple files or --type all), use orchestration:
      - **security-analyzer-agent** for security test cases (if applicable)
 
 3. **Quality Assurance Phase**:
-   - Validate test coverage completeness
+   - Name the behaviors you did NOT write a test for, and why
    - Check for test anti-patterns
    - Ensure proper mocking strategies
+
+**When to skip the orchestration above:** a single file, or a handful of files in one module,
+is faster and more accurate done directly. The agent list below is a menu of what is available,
+not a set of steps to work through — invoke only the agents the specific task needs.
 
 ## Delegation
 
@@ -71,22 +75,25 @@ Invoke **test-writer-agent** with:
 
 ### Complex Case (multiple files or integration/e2e)
 
-**If agent-orchestrator-agent is available** (from development-codebase-tools plugin):
+The orchestrator and the loader/analyzer agents live in the **development-codebase-tools**
+plugin, so dispatch them with the cross-plugin form
+`Task(subagent_type: development-codebase-tools:<agent-name>)`. `test-writer-agent` is in this
+plugin and needs no prefix.
 
-Invoke it to coordinate:
+**If `development-codebase-tools:agent-orchestrator-agent` is available**, invoke it to coordinate:
 
-- **context-loader-agent**: Build comprehensive understanding
+- **development-codebase-tools:context-loader-agent**: Build comprehensive understanding
 - **test-writer-agent**: Generate test scenarios and implementations
-- **security-analyzer-agent**: Add security test cases (for APIs)
-- **performance-analyzer-agent**: Add performance benchmarks (for critical paths)
+- **development-codebase-tools:security-analyzer-agent**: Add security test cases (for APIs)
+- **development-codebase-tools:performance-analyzer-agent**: Add performance benchmarks (for critical paths)
 
-**Fallback (if agent-orchestrator-agent is not available)**:
+**Fallback (if the orchestrator is not available)**:
 
 Execute agents sequentially:
 
-1. First invoke **context-loader-agent** to gather context
+1. First invoke **development-codebase-tools:context-loader-agent** to gather context
 2. Then invoke **test-writer-agent** with the gathered context
-3. Optionally invoke **security-analyzer-agent** for API endpoints
+3. Optionally invoke **development-codebase-tools:security-analyzer-agent** for API endpoints
 4. Aggregate results manually
 
 ## Output Format
@@ -96,9 +103,15 @@ Execute agents sequentially:
   summary: string; // Overview of test generation strategy
   testStrategy: {
     approach: string; // Selected testing approach
-    coverage: number; // Estimated coverage percentage
-    edgeCasesIdentified: number;
-    scenariosGenerated: number;
+    // Coverage is only reported when a coverage tool actually ran and produced a
+    // number. This skill's allowed-tools include no Bash, so it cannot run one --
+    // in that case emit 'not_measured' and say which command the user should run.
+    // Never estimate a coverage percentage; a guessed number reads as a
+    // measurement and is not one.
+    coverage: number | 'not_measured';
+    coverageSource?: string; // Command whose output produced the number
+    edgeCasesIdentified: number; // Count of edge cases you actually enumerated below
+    scenariosGenerated: number; // Count of scenarios you actually generated below
   };
   suggestedTests: Array<{
     file: string; // Test file path

--- a/packages/plugins/development-productivity/skills/optimize-prompt/SKILL.md
+++ b/packages/plugins/development-productivity/skills/optimize-prompt/SKILL.md
@@ -48,8 +48,9 @@ Optimize prompts for better AI model performance using engineering techniques.
 - Prompt chaining strategies
 - Sampling parameter tuning — parameters are provider-specific. `frequency_penalty` and
   `presence_penalty` are OpenAI-only and are rejected by the Anthropic Messages API. On the
-  Claude 5 family, `temperature` is rejected when extended thinking is enabled, and
-  `budget_tokens` is not accepted (use `thinking: {type: "adaptive"}`).
+  Claude 5 family, `temperature`, `top_p`, and `top_k` are removed entirely — sending any of them
+  returns a 400 whether or not thinking is enabled, so never recommend them for a Claude 5 target.
+  `budget_tokens` is also rejected (use `thinking: {type: "adaptive"}`).
 - Token budget management
 
 ### 5. RAG Integration

--- a/packages/plugins/development-productivity/skills/optimize-prompt/SKILL.md
+++ b/packages/plugins/development-productivity/skills/optimize-prompt/SKILL.md
@@ -44,10 +44,12 @@ Optimize prompts for better AI model performance using engineering techniques.
 
 ### 4. Model-Specific Optimization
 
-- GPT-4 best practices
-- Claude optimization techniques
+- Techniques for the target model family, checked against its current API rather than recalled
 - Prompt chaining strategies
-- Temperature/parameter tuning
+- Sampling parameter tuning — parameters are provider-specific. `frequency_penalty` and
+  `presence_penalty` are OpenAI-only and are rejected by the Anthropic Messages API. On the
+  Claude 5 family, `temperature` is rejected when extended thinking is enabled, and
+  `budget_tokens` is not accepted (use `thinking: {type: "adaptive"}`).
 - Token budget management
 
 ### 5. RAG Integration


### PR DESCRIPTION
## Headline: the documentation-agent verification contradiction

`agents/documentation.md` and `agents/claude-docs-initializer.md` gave opposite instructions about who verifies generated documentation:

- `documentation.md` stated verification is an **internal phase, never a separate agent call**.
- `claude-docs-initializer.md` mandated invoking `documentation-agent` as a **second-pass verifier per 1-2 file batch**, and set `requires_verification: true` so callers kept invoking the fact-checker regardless of what the other file's prose said.

**Resolution: keep `documentation.md`'s inline posture, fix the initializer.**

- Removed the mandated `documentation-agent` second pass (Mission, Steps 2-3 of batch execution, and the `MANDATORY VERIFICATION` constraint).
- Removed the `requires_verification: true` flag from the batch-execution output schema.
- Replaced both with **per-file `unverified_claims`**: the agent flags each claim it could not confirm, inline, with the check it attempted.

### The related incomplete fix in `documentation.md`

An earlier pass rewrote that file's prose to say verification is inline but left the machinery implementing the old behavior. A prompt's behavior lives in its output schema as much as in its instructions, so all of it is now gone:

| Was | Now |
| --- | --- |
| `quality_score: number # 0-100` | removed |
| `quality_analysis: {completeness, accuracy, consistency}`, each `# 0-100` | `unverified_claims` + `known_gaps` |
| `accuracy_score` in the CLAUDE.md output block | `critical_claims_confirmed: boolean` + `unverified` list |
| `(verified_claims / total_claims) * 100` plus severity-point deductions | flag each unconfirmed claim; no score |
| the `accuracy < 70%` gate (both occurrences) | gate on any CRITICAL claim being wrong or unconfirmed |
| `Quality Scoring (0-100)` with 25%/25%/25%/25% weights | qualitative `Reporting Quality` |

Every one of those demanded a number the model has no measured input for. It fills the required field, fabricates a score, and the score then reads as evidence while being none.

## Changes by delta

### Delta 1 — Opus 5 self-verifies

- `claude-docs-initializer.md`: second-agent verification pass removed (above).
- `documentation.md`: dropped the `Completeness Assessment` and `Consistency Checks` subsections (8 bullets re-reading just-written prose). **Kept** `Accuracy Verification` — link validation and code-sync checks ground claims against the codebase, which is not the same as re-reading your own work. Retitled to say so.
- `commands/claude-init-plus.md`: replaced the trailing 4-item verify checklist, plus the block restating the same four items as failure conditions, with the two conditions actually checkable after the fact.
- `commands/update-claude-md.md`: dropped the Step 10 post-write re-read. Deduplication (Step 6) and the no-`[TODO]` rule are constraints on the write; the 200-line overflow case was already covered under Error Handling.

### Delta 2 — delegation

- `commands/claude-init-plus.md`: added an explicit instruction against one-subagent-per-package fan-out, naming the reason. The command's **Hierarchy Deduplication** rule requires knowing what was written at every other level; a subagent cannot see what a sibling wrote, so each one independently decides a repo-wide convention is worth stating and writes it. Nothing reports a failure, because every individual file still looks correct. Discovery is read-only and explicitly still parallelizable; generation is not.
- `skills/generate-tests/*`: added when-NOT-to-delegate guidance. The agent list is a menu of what is available, not a sequence to work through.

### Delta 3 — recall filters

- `documentation.md`: `HIGH (verify when time permits)` reads to Opus 5 as license to skip. Now `HIGH (verify; if you cannot, flag the claim inline)`, same for the `LOW` tier, and the matrix header says it sets work order rather than granting permission to skip a tier.
- `agents/agent-tester.md`, `agents/prompt-engineer.md`: neither had any coverage instruction in its findings section. Both now say to report every genuine finding, mark severity and confidence, and not drop the uncertain or low-severity ones. Added the same to `agents/researcher.md` and `agents/test-writer.md`.
- Stripped decorative `CRITICAL:`/`MANDATORY` emphasis where it was not load-bearing.

### Delta 4 — unbounded deliverables

- `claude-docs-initializer.md`: `coordinationContext` capped at 200 words — the highest-cost one here, since it feeds another agent's context.
- `agents/researcher.md` (800 words), `agents/agent-tester.md` (600 words, narrative sections only), `agents/test-writer.md` (400 words). Each bound explicitly excludes data (test bodies, logs, enumerated lists) so it does not cause dropped findings.
- **Kept** the "under 200 lines per CLAUDE.md" convention everywhere it appears — that IS the fix, not an instance of the problem.

### Invented numbers

| File | Was | Now |
| --- | --- | --- |
| `skills/generate-tests/gen-tests-guide.md` | required `coverage: number` in a skill whose `allowed-tools` has **no Bash** | `coverage \| 'not_measured'` plus `coverageSource`; reported only when a coverage tool actually ran |
| `skills/generate-tests/SKILL.md` | "Write test files with full coverage" — no Write tool, no Bash | returns artifacts; names untested behaviors |
| `agents/prompt-engineer.md` | `expected_impact: <percentage_improvement>`, `clarity_score`, `effectiveness_prediction` | prose unless derived from supplied `performance_data` or an executed run; the whole Effectiveness Measurement section is gated on measured input |
| `agents/researcher.md` | `total_cost_ownership`, `migration_complexity`, scored `comparison_matrix` | cited sources or an explicit "unestimated"; weighted totals only over cited measurements |
| `agents/agent-tester.md` | coverage percentages of an unenumerable whole; `overall_score: 0-100`; `dimension_scores` | counts against an enumerated list plus named gaps; per-dimension findings with a `not_tested` state |

### Stale facts

- `prompt-engineer.md:18`: `target_model` examples were `"gpt-4"`, `"claude-3"`, `"llama-2"`. `claude-3` was **never** a valid API model id. Replaced, with a note preferring the bare `opus`/`sonnet`/`haiku` aliases since they self-update.
- `prompt-engineer.md`: `frequency_penalty` and `presence_penalty` are OpenAI-only and 400 against the Anthropic Messages API. The parameter table is now split by provider. Also flagged that `temperature` is rejected alongside thinking on Claude 5 — precisely the analytical/reasoning case where the old table recommended a low temperature — pointing at `thinking: {type: "adaptive"}`, and noted `budget_tokens` is not accepted on Claude 5.
- `skills/optimize-prompt/SKILL.md:47`: "GPT-4 best practices" replaced with provider-neutral guidance plus those concrete constraints.

### Broken references

`context-loader-agent`, `security-analyzer-agent`, `performance-analyzer-agent`, and `agent-orchestrator-agent` all live in **development-codebase-tools**, but `generate-tests` referenced them bare — including inside `allowed-tools`, where a bare name does not resolve cross-plugin. All now use `development-codebase-tools:<agent-name>`. Verified every agent name in this plugin against frontmatter `name:` on disk; the rest resolve correctly.

### Out-of-scope defect fixed in passing

- `commands/update-claude-md.md:16` — a dangling sentence fragment (`constraint, or workflow decision.` duplicated from the line above) left by a bad edit.

## Findings in the brief that did not exist

Reported rather than worked around:

- **`skills/mermaid-diagram`, `skills/diagram-excalidraw`, `skills/daily-standup`** — none exist in this plugin. Its six skills are `audit-dependencies`, `generate-document`, `generate-tests`, `optimize-prompt`, `research-topic`, `update-claude-docs`. The verification-ceremony findings for those three could not be acted on here.
- **`skills/claude-init-plus`, `skills/update-claude-md`** — these are **commands** (`commands/*.md`), not skills. Fixed at their real paths.
- **`skills/update-claude-md/SKILL.md:16` dangling fragment** — no such file. The fragment is real but lives at `commands/update-claude-md.md:16`; fixed there.
- **`agents/documentation.md` "12 items"** — there was no 12-item trailing checklist. The closest match was three 4-bullet Quality Analysis subsections; two were self-review and were removed, one was grounding and was kept.
- **`researcher.md` "TCO in dollars and migration effort in person-weeks"** — the file never names those units; the fields are `total_cost_ownership: TCO analysis including hidden costs` and `migration_complexity: Effort required to switch technologies`. The defect is real (both invite unmeasured figures) but the brief's wording overstated what the file says.

## Version bump

`packages/plugins/development-productivity/.claude-plugin/plugin.json` 2.4.1 -> **2.5.0** (MINOR), and the matching row in the root `CLAUDE.md`. **The two agreed at 2.4.1 before this change** — no drift here, unlike the sibling plugin.

## Test plan

```
$ node scripts/validate-plugin.cjs packages/plugins/development-productivity
  ✓ plugin.json: development-productivity v2.5.0
  ✓ package.json: @uniswap/development-productivity
  ✓ project.json: development-productivity
  ✓ skills/: 6 item(s)
  ✓ agents/: 6 item(s)
  ✓ commands/: 2 item(s)
  ✓ hooks/: 2 item(s)
Validation PASSED

$ bunx markdownlint-cli2 --fix "packages/plugins/development-productivity/**/*.md"
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Linting: 200 file(s)
Summary: 0 error(s)

$ bunx nx format:write --uncommitted
(no output — nothing left to reformat)
```

The lefthook pre-commit gate ran on all three commits:

```
✔️ format  ✔️ lint  ✔️ lint-markdown  ✔️ test  ✔️ typecheck  ✔️ update-lockfile
```

Every agent name referenced in this plugin was checked against frontmatter `name:` on disk:

```
$ find packages/plugins -path '*/agents/*.md' -exec sh -c 'grep -m1 "^name:" "$1"' _ {} \;
```

The diff is entirely prompt text plus one version field — no executable behavior in this repo changes.
