### PR TITLE
feat: add uniswap-wiki plugin to the marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,6 +49,15 @@
       "name": "claude-setup",
       "source": "./packages/plugins/claude-setup",
       "description": "Interactive setup wizard for configuring any repository with Claude Code best practices"
+    },
+    {
+      "name": "uniswap-wiki",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/Uniswap/wiki.git",
+        "path": "plugin"
+      },
+      "description": "Search and read the internal Uniswap knowledge wiki from Claude, with cited sources — plus file ingest requests for gaps. Requires a GitHub credential with access to Uniswap/wiki (gh auth login or GITHUB_TOKEN)."
     }
   ]
 }


### PR DESCRIPTION
Adds the `uniswap-wiki` plugin — an MCP server + skill giving Claude searchable, cited access to the internal knowledge wiki (Uniswap/wiki#529).

This is the marketplace's first **external `git-subdir` source**: the plugin lives in the `plugin/` directory of `Uniswap/wiki` rather than being vendored here, so the wiki repo's own CI keeps the server bundle and plugin version current, and this marketplace picks up releases automatically (explicit `version` in the plugin manifest is bumped only when the plugin itself changes, so daily wiki ingests do NOT churn plugin updates).

Validated end-to-end with a scratch marketplace before this PR: install materializes only the ~1MB `plugin/` subdirectory (not the 14MB wiki repo), skills + `.mcp.json` + bundled server all resolve, and the server starts. Users need a GitHub credential with wiki access (`gh auth login` or `GITHUB_TOKEN`) — the plugin fetches all data with the user's own token, so access control rides GitHub org membership / Okta.

Install after merge: `/plugin install uniswap-wiki`

🤖 Generated with [Claude Code](https://claude.com/claude-code)