### PR TITLE
fix(workflows): drop the contradicting pin-comment rule in the version worker

### DIFF
--- a/.github/workflows/_update-action-versions-worker.yml
+++ b/.github/workflows/_update-action-versions-worker.yml
@@ -289,7 +289,9 @@ jobs:
           gh api 'repos/{owner}/{repo}/releases?per_page=100' \
             | jq -r '[.[] | select(.draft == false and .prerelease == false)
                      | .tag_name | select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))]
-                     | sort_by(.[1:] | split(".") | map(tonumber)) | last'
+                     | sort_by(.[1:] | split(".") | map(tonumber)) | last // empty'
+          # No output means the action has no concrete vX.Y.Z release. Skip that
+          # action and report it under "Skipped"; never fall back to a moving tag.
 
           # Get the SHA for that tag
           gh api repos/{owner}/{repo}/git/ref/tags/{tag} --jq '.object.sha'
@@ -391,7 +393,9 @@ jobs:
           ## Guidelines
 
           - Always use full 40-character SHAs, never abbreviated
-          - Preserve existing comment format (some use `# v4`, others use `# v4.0.0`)
+          - Always write a concrete version in the comment (`# v4.2.0`). If an action is
+            currently pinned with a moving major tag (`# v4`), replace it with the concrete
+            version you resolved - do not preserve the moving form
           - Skip actions that don't have GitHub releases (some use only tags)
           - Skip private or archived repositories
           - Handle rate limiting gracefully (gh CLI has built-in retry)


### PR DESCRIPTION
Two review findings that landed on #559 three minutes after it merged, so they never got applied there.

## What changed

`_update-action-versions-worker.yml` is the prompt for the agent that bumps action pins across the repo. #559 taught it to write a concrete version in the pin comment (`# v4.2.0`) rather than a moving major tag (`# v4`), because zizmor's stale-ref audit fails the build on moving tags. That change missed two things in the same prompt:

- A Guidelines bullet 70 lines below still said *"Preserve existing comment format (some use `# v4`, others use `# v4.0.0`)"*, contradicting the new rule. This is live rather than theoretical: `publish-packages.yml` pins `crazy-max/ghaction-import-gpg` with `# v6` at two sites, so the next bump would have preserved the moving form and reintroduced the failure.
- The jq that selects the release ended in `last`, which prints the literal string `null` on an empty array. An action with no `vX.Y.Z` release would hand the agent `null` to carry into the tag lookup. It is now `last // empty`, with an instruction to skip that action and report it rather than fall back to a moving tag. The sync job already guarded this; the prompt copy did not.

## Why

Without this, the next scheduled run of the version worker can undo the pin-comment fix that #559 shipped.

## How it was verified

- `jq -r "last // empty"` on `[]` emits nothing (confirmed at the shell); plain `last` prints `null`.
- `grep -rn "ghaction-import-gpg@"` confirms the two live `# v6` pins the contradicting bullet would have preserved.
- Workflow parses under `yaml.safe_load`.

The `# v4` example at line 272 is deliberately left alone - it sits under "Important patterns to identify" and describes what to find in the repo, not what to write.