### PR TITLE
chore(workflows): bump claude-code-action to v1.0.210

### DIFF
--- a/.github/workflows/_claude-code-review.yml
+++ b/.github/workflows/_claude-code-review.yml
@@ -1219,7 +1219,7 @@ jobs:
       - name: Run Claude Code Review
         if: steps.cache-check.outputs.cache-hit != 'true' && steps.diff-size.outputs.is_too_large != 'true'
         id: claude
-        uses: anthropics/claude-code-action@c81e3bc69d1b18badbb63ba39581218f02421678 # v1.0.201
+        uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1.0.210
         with:
           # Authentication: provide either API key or OAuth token (validated in earlier step)
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -1712,7 +1712,7 @@ jobs:
       - name: Run Claude Auto-Fix
         id: claude-fix
         if: steps.auto-fix-check.outputs.should_fix == 'true' && steps.pr-branch.outputs.repo_full_name == github.repository
-        uses: anthropics/claude-code-action@c81e3bc69d1b18badbb63ba39581218f02421678 # v1.0.201
+        uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1.0.210
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/_claude-docs-check.yml
+++ b/.github/workflows/_claude-docs-check.yml
@@ -707,7 +707,7 @@ jobs:
       # Run Claude
       - name: Run Claude Docs Check
         id: claude
-        uses: anthropics/claude-code-action@c81e3bc69d1b18badbb63ba39581218f02421678 # v1.0.201
+        uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1.0.210
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -1032,7 +1032,7 @@ jobs:
       - name: Run Claude Auto-Fix
         id: claude-fix
         if: steps.auto-fix-check.outputs.should_fix == 'true' && steps.pr-branch.outputs.repo_full_name == github.repository
-        uses: anthropics/claude-code-action@c81e3bc69d1b18badbb63ba39581218f02421678 # v1.0.201
+        uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1.0.210
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/_claude-main.yml
+++ b/.github/workflows/_claude-main.yml
@@ -457,7 +457,7 @@ jobs:
       # Supports both API key and OAuth token authentication (validated in earlier step)
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@c81e3bc69d1b18badbb63ba39581218f02421678 # v1.0.201
+        uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1.0.210
         with:
           # Authentication: provide either API key or OAuth token (validated in earlier step)
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/_claude-task-worker.yml
+++ b/.github/workflows/_claude-task-worker.yml
@@ -577,7 +577,7 @@ jobs:
           GIT_AUTHOR_EMAIL: "github-actions[bot]@users.noreply.github.com"
           GIT_COMMITTER_NAME: "github-actions[bot]"
           GIT_COMMITTER_EMAIL: "github-actions[bot]@users.noreply.github.com"
-        uses: anthropics/claude-code-action@c81e3bc69d1b18badbb63ba39581218f02421678 # v1.0.201
+        uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1.0.210
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/_generate-pr-metadata.yml
+++ b/.github/workflows/_generate-pr-metadata.yml
@@ -486,7 +486,7 @@ jobs:
           steps.quality-gate-prep.outputs.has_user_content == 'true'
         id: quality-gate-eval
         continue-on-error: true
-        uses: anthropics/claude-code-action@c81e3bc69d1b18badbb63ba39581218f02421678 # v1.0.201
+        uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1.0.210
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -944,7 +944,7 @@ jobs:
       - name: Run Claude Code Generation
         if: steps.cache-check.outputs.cache-hit != 'true' && steps.quality-gate.outputs.should_skip != 'true'
         id: claude
-        uses: anthropics/claude-code-action@c81e3bc69d1b18badbb63ba39581218f02421678 # v1.0.201
+        uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1.0.210
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/_update-action-versions-worker.yml
+++ b/.github/workflows/_update-action-versions-worker.yml
@@ -443,7 +443,7 @@ jobs:
       # Supports both API key and OAuth token authentication (OAuth takes precedence)
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@c81e3bc69d1b18badbb63ba39581218f02421678 # v1.0.201
+        uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1.0.210
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

Maintenance pass on Claude Code Action workflows. Applies three classes of edit atomically:

- **claude-code-action:** `v1.0.210` (`a874e9e`) — see https://github.com/anthropics/claude-code-action/releases/tag/v1.0.210
- **ai-toolkit reusable workflows:** `c4820d6` (Uniswap/ai-toolkit `main` HEAD, the released branch)
- **Models:**
  - `haiku` → `claude-haiku-4-5-20251001`
  - `opus` → `claude-opus-5`
  - `sonnet` → `claude-sonnet-5`

### Per-file changes

#### `.github/workflows/_claude-code-review.yml`
- SHA bump `anthropics/claude-code-action`: `c81e3bc` → `a874e9e` (v1.0.210)
- SHA bump `anthropics/claude-code-action`: `c81e3bc` → `a874e9e` (v1.0.210)

#### `.github/workflows/_claude-docs-check.yml`
- SHA bump `anthropics/claude-code-action`: `c81e3bc` → `a874e9e` (v1.0.210)
- SHA bump `anthropics/claude-code-action`: `c81e3bc` → `a874e9e` (v1.0.210)

#### `.github/workflows/_claude-main.yml`
- SHA bump `anthropics/claude-code-action`: `c81e3bc` → `a874e9e` (v1.0.210)

#### `.github/workflows/_claude-task-worker.yml`
- SHA bump `anthropics/claude-code-action`: `c81e3bc` → `a874e9e` (v1.0.210)

#### `.github/workflows/_generate-pr-metadata.yml`
- SHA bump `anthropics/claude-code-action`: `c81e3bc` → `a874e9e` (v1.0.210)
- SHA bump `anthropics/claude-code-action`: `c81e3bc` → `a874e9e` (v1.0.210)

#### `.github/workflows/_update-action-versions-worker.yml`
- SHA bump `anthropics/claude-code-action`: `c81e3bc` → `a874e9e` (v1.0.210)



_Opened by the `sync-claude-code-action` maintenance job. The job runs weekly and bumps SHAs + applies known migrations; review the diff before merging._

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Weekly maintenance pass from the `sync-claude-code-action` job. The only edit needed this run was the pinned SHA for `anthropics/claude-code-action`: `c81e3bc` (v1.0.201) → `a874e9ecd7bb36efdad65429c6b35815f5a08f10` (v1.0.210).
Release notes: <https://github.com/anthropics/claude-code-action/releases/tag/v1.0.210>
## Changes
All 9 `uses: anthropics/claude-code-action@...` references in the reusable workflows are updated; no reference to the old SHA remains.
| File | Refs bumped | Steps |
| ---- | ----------- | ----- |
| `.github/workflows/_claude-code-review.yml` | 2 | Run Claude Code Review, Run Claude Auto-Fix |
| `.github/workflows/_claude-docs-check.yml` | 2 | Run Claude Docs Check, Run Claude Auto-Fix |
| `.github/workflows/_generate-pr-metadata.yml` | 2 | quality-gate-eval, Run Claude Code Generation |
| `.github/workflows/_claude-main.yml` | 1 | Run Claude Code |
| `.github/workflows/_claude-task-worker.yml` | 1 | Run Claude Code |
| `.github/workflows/_update-action-versions-worker.yml` | 1 | Run Claude Code |
Nothing else changed — the diff is 9 insertions and 9 deletions, all `uses:` lines and their trailing version comments. No workflow inputs, permissions, `with:` blocks, or prompts were touched.
## Notes
- The job's other two edit classes were no-ops this pass: model aliases (`haiku`/`opus`/`sonnet`) were already on their pinned Claude 5-family IDs, and the reusable-workflow references in this repo resolve via `@main` rather than a pinned ai-toolkit SHA. The earlier commit message and description mentioning `ait=c4820d6` and model renames do not correspond to anything in this diff.
- These are reusable workflows consumed by other repositories (`Uniswap/universe`, `Uniswap/backend`) at `@main`, so merging to `main` rolls v1.0.210 out to every consumer. Verify the action's v1.0.201 → v1.0.210 changelog for input or behavior changes before merge.

</details>
<!-- claude-pr-description-end -->