### PR TITLE
fix(ci): delete the packages token from disk after review-cli installs

### DIFF
--- a/.github/actions/install_review_cli/action.yml
+++ b/.github/actions/install_review_cli/action.yml
@@ -73,9 +73,24 @@ runs:
         [install.scopes]
         "@uniswap" = { url = "https://npm.pkg.github.com", token = "$GH_PACKAGES_TOKEN" }
         EOF
+        # The bunfig holds the packages token in cleartext and is only needed
+        # until the package resolves. Remove it on every exit path -- a failed
+        # `bun add` must not leave it under $RUNNER_TEMP either.
+        trap 'rm -f "$install_dir/bunfig.toml" "$RUNNER_TEMP/bun-add.err"' EXIT
         cd "$install_dir"
         bun init -y > /dev/null
-        bun add "@uniswap/review-cli@${REVIEW_CLI_VERSION}"
+        # --config is passed explicitly rather than relying on the scratch CWD
+        # alone: bun ignores the BUN_CONFIG_FILE environment variable, so the
+        # flag plus the scratch directory are what keep any other bunfig.toml
+        # out of scope. Mirrors the canonical review.yml template in
+        # Uniswap/internal-tools.
+        if ! bun add --config="$install_dir/bunfig.toml" "@uniswap/review-cli@${REVIEW_CLI_VERSION}" 2> "$RUNNER_TEMP/bun-add.err"; then
+          cat "$RUNNER_TEMP/bun-add.err" >&2
+          if grep -qE '(^|[^0-9])403([^0-9]|$)' "$RUNNER_TEMP/bun-add.err"; then
+            echo "::error::403 from GitHub Packages. $GITHUB_REPOSITORY has no read access to @uniswap/review-cli. Fix: Uniswap/internal-tools -> Packages -> review-cli -> Package settings -> Manage Actions access -> add this repository. This is a per-repo grant; no workflow change can confer it."
+          fi
+          exit 1
+        fi
 
         # Consumers gate on `bin-path != ''` to avoid resolving
         # "$REVIEW_CLI_BIN/review-cli" to "/review-cli" and dying on exit 127.


### PR DESCRIPTION
## What changed

`.github/actions/install_review_cli/action.yml` now removes the `bunfig.toml` it writes, passes `--config` to `bun add` explicitly, and prints a diagnostic when GitHub Packages returns 403.

## Why

That bunfig holds the GitHub Packages token in cleartext under `$RUNNER_TEMP` and nothing deleted it, so the token stayed readable on the runner for the rest of the job. The canonical `review.yml` template in [Uniswap/internal-tools](https://github.com/Uniswap/internal-tools/blob/main/packages/review-cli/templates/workflows/review.yml) already removes it on every exit path; this action had not been brought in line. [ECO-890](https://linear.app/uniswap/issue/ECO-890/migrate-ai-toolkits-own-pr-description-job-and-delete-the-two-reusable) names this file as needing "the same cleanup the fleet workflows now do".

`--config` is passed explicitly because bun ignores `BUN_CONFIG_FILE`; the flag plus the scratch directory are together what keep any other `bunfig.toml` out of scope. The 403 branch names the per-repo package-access grant, which no workflow change can confer.

## How it was verified

Ran the extracted script against a stubbed `bun` on both paths. Success path: exit 0, `bin-path` written, bunfig gone. 403 path: exit 1, diagnostic emitted once, bunfig and the stderr capture both gone. `shellcheck -s bash` clean; `zizmor --persona=auditor` reports no findings. Repo pre-commit gates (format, lint, test, typecheck) pass.

## Scope note

ECO-890's main steps — migrating `generate-pr-title-description.yml` and deleting the two reusable workflows — are gated on every migration PR merging, and those are still open. This PR carries only the action cleanup, which does not depend on that gate. The ticket stays in Todo.

Autonomously generated by the Linear Task Worker.